### PR TITLE
Add mDNS discovery with device serial number

### DIFF
--- a/debian-rk3576-ospack.yaml
+++ b/debian-rk3576-ospack.yaml
@@ -19,6 +19,7 @@ actions:
     include:
       - acl
       - adduser
+      - avahi-daemon
       - alsa-ucm-conf
       - alsa-utils
       - apt-transport-https

--- a/overlays/configs/systemd/system/avahi-daemon.service.d/after-hostname.conf
+++ b/overlays/configs/systemd/system/avahi-daemon.service.d/after-hostname.conf
@@ -1,0 +1,2 @@
+[Unit]
+After=set-hostname-and-banner.service

--- a/overlays/configs/update-motd.d/00-flipperone
+++ b/overlays/configs/update-motd.d/00-flipperone
@@ -4,6 +4,9 @@
 board=$(cat /sys/firmware/devicetree/base/compatible | tr '\0' '\n' | awk -F, '$2 != "rk3576" { print $2; exit }')
 board=${board:-rk3576}
 
+# CPU serial from device tree, falls back to systemd machine-id for non-DT boards
+serial=$(tr -d '\0' < /sys/firmware/devicetree/base/serial-number 2>/dev/null || cat /etc/machine-id)
+
 . /etc/os-release
 
 # Get build info
@@ -20,6 +23,7 @@ cat <<EOF
 
    Git:          $build_git
    Board:        $board
+   CPU Serial:   $serial
    Memory:       $total_mem
    Build Date:   $build_date
 

--- a/overlays/usr/local/bin/set-hostname-and-banner.sh
+++ b/overlays/usr/local/bin/set-hostname-and-banner.sh
@@ -34,4 +34,19 @@ Default credentials: user / user
 =============================================================
 EOF
 
+# Generate Avahi mDNS service for LAN discovery via _flipper._tcp
+mkdir -p /etc/avahi/services
+cat <<EOF >/etc/avahi/services/flipper.service
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">%h</name>
+  <service>
+    <type>_flipper._tcp</type>
+    <port>22</port>
+    <txt-record>serial=${serial}</txt-record>
+  </service>
+</service-group>
+EOF
+
 systemd-machine-id-setup

--- a/overlays/usr/local/bin/set-hostname-and-banner.sh
+++ b/overlays/usr/local/bin/set-hostname-and-banner.sh
@@ -5,6 +5,9 @@ set -e
 board=$(cat /sys/firmware/devicetree/base/compatible | tr '\0' '\n' | awk -F, '$2 != "rk3576" { print $2; exit }')
 board=${board:-rk3576}
 
+# CPU serial from device tree, falls back to systemd machine-id for non-DT boards
+serial=$(tr -d '\0' < /sys/firmware/devicetree/base/serial-number 2>/dev/null || cat /etc/machine-id)
+
 codename=$(. /etc/os-release; echo "${ID}${VERSION_ID}-${BUILD_ID}")
 new_hostname="${board}-${codename}"
 
@@ -24,6 +27,7 @@ cat <<EOF >/etc/ssh/welcome_banner
 =================== Welcome to FlipperOne ===================
 Git:          $build_git
 Board:        $board
+CPU Serial:   $serial
 Memory:       $total_mem
 Build Date:   $build_date
 Default credentials: user / user


### PR DESCRIPTION
We have many flippers connected to LAN, it's hard to find right one.
With mDNS we can see all devices easily.

# How to find all Flipper One's in LAN

## macOS

```bash 
# Initial scan
# Note: dns-sd doesn't exit on its own — it keeps listening. Press Ctrl+C to stop.
dns-sd -B _flipper._tcp .

# Get ip address
dns-sd -G v4 <hostname>.local
```

## Linux 

`dns-sd -B _flipper._tcp .`
