### PR TITLE
Move test suite folder and keep .git 

### DIFF
--- a/build-ospack.sh
+++ b/build-ospack.sh
@@ -31,7 +31,7 @@ mkdir -p "$IMG_OUT"
 rm -rf "${TESTS_OUT}"
 mkdir -p "${TESTS_OUT}"
 
-cp -r "${TESTS_DIR}"/* "${TESTS_OUT}/"
+cp -a "${TESTS_DIR}/." "${TESTS_OUT}/"
 
 if [ -c /dev/kvm -a -w /dev/kvm ]; then
         # Have virtualization support, can use fakemachine (default, fast, safe)

--- a/debian-rk3576-ospack.yaml
+++ b/debian-rk3576-ospack.yaml
@@ -224,7 +224,12 @@ actions:
   - action: overlay
     description: Copy test suite into the target
     source: {{ $testsdir }}
-    destination: /rk3576-linux-tests
+    destination: /flipperone-testing
+
+  - action: run
+    description: Make test suite writable for all users
+    chroot: true
+    command: chmod -R o+w /flipperone-testing
 
   - action: pack
     description: Save a tarball of the root filesystem

--- a/overlays/configs/systemd/system/fake-flipctl-node-server.service
+++ b/overlays/configs/systemd/system/fake-flipctl-node-server.service
@@ -1,1 +1,0 @@
-/rk3576-linux-tests/fake-flipctl/systemd/fake-flipctl-node-server.service

--- a/overlays/configs/systemd/system/fake-flipctl-node-server.service
+++ b/overlays/configs/systemd/system/fake-flipctl-node-server.service
@@ -1,0 +1,1 @@
+/flipperone-testing/fake-flipctl/systemd/fake-flipctl-node-server.service

--- a/overlays/configs/systemd/system/multi-user.target.wants/fake-flipctl-node-server.service
+++ b/overlays/configs/systemd/system/multi-user.target.wants/fake-flipctl-node-server.service
@@ -1,1 +1,1 @@
-/rk3576-linux-tests/fake-flipctl/systemd/fake-flipctl-node-server.service
+/flipperone-testing/fake-flipctl/systemd/fake-flipctl-node-server.service


### PR DESCRIPTION
Making the `fake-flipctl` update feature just by using `git fetch` from interface

- Change cp to `cp -a dir/.` to include hidden files (.git)
- Rename destination from /rk3576-linux-tests to /flipperone-testing
- Add chmod -R o+w so non-root users can write to the test directory