### PR TITLE
Disable KDE drkonqi coredump handling

### DIFF
--- a/debian-rk3576-ospack.yaml
+++ b/debian-rk3576-ospack.yaml
@@ -228,6 +228,20 @@ actions:
     chroot: true
     command: update-alternatives --set regulatory.db /lib/firmware/regulatory.db-upstream
 
+  - action: run
+    description: Disable KDE drkonqi coredump handling
+    chroot: true
+    command: |
+      systemctl --global mask \
+        drkonqi-coredump-launcher.socket \
+        drkonqi-coredump-cleanup.service \
+        drkonqi-coredump-cleanup.timer \
+        drkonqi-coredump-pickup.service \
+        drkonqi-sentry-postman.path \
+        drkonqi-sentry-postman.service \
+        drkonqi-sentry-postman.timer
+      systemctl mask drkonqi-coredump-processor@.service
+
   - action: overlay
     description: Copy test suite into the target
     source: {{ $testsdir }}


### PR DESCRIPTION
The drkonqi-coredump-launcher.socket has UpheldBy=sockets.target which causes systemd to retry it for users where ConditionUser=!@system fails (sddm, flipctl), flooding journal with thousands of messages per minute. Mask the full set of drkonqi coredump units to disable the feature entirely; coredumps are still captured by systemd-coredump.