### PR TITLE
Assign touchpad input device to seat1 for Cog

### DIFF
--- a/overlays/configs/udev/rules.d/72-seat-cog.rules
+++ b/overlays/configs/udev/rules.d/72-seat-cog.rules
@@ -1,2 +1,7 @@
 SUBSYSTEM=="drm", ENV{ID_FOR_SEAT}=="drm-platform-2acf0000_spi-cs-0", ENV{ID_SEAT}="seat1"
+
+# /dev/input/event0: Flipper One Buttons
 SUBSYSTEM=="input", ATTRS{phys}=="flipper-one-input/input0", ENV{ID_SEAT}="seat1"
+
+# /dev/input/event1: Flipper One Touchpad
+SUBSYSTEM=="input", ATTRS{phys}=="flipper-one-input/input1", ENV{ID_SEAT}="seat1"


### PR DESCRIPTION
The touchpad (input1) was being grabbed by seat0, leaving Cog on seat1 with no pointer input. Tag it as seat1 alongside the buttons (input0) so libinput inside the Cog session picks it up.