### PR TITLE
Updated the README with clearer build and flashing instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,22 @@
 
 The scripts in this repository produce disk images for Rockchip RK3576 based boards, ready to be flashed to an SD card or uploaded to internal storage via a USB connection and Maskrom mode.
 
-They are meant to be run on a Debian 13 (trixie) or later systems. It's probably possible to use different distributions too, but you'll need to find the right prerequisites yourself. Your mileage may vary.
+They are meant to be run on Debian 13 (trixie) or later. It's probably possible to use different distributions too, but you'll need to find the right prerequisites yourself. Your mileage may vary.
 
 Note that while you can compile all of this software by hand by running the scripts in this repository, you don't necessarily have to. Most commits include a small green checkmark in the GitHub interface next to the commit message (or a red cross if we are less lucky), which link to a page in our [Buildbot web interface](https://linux-images.flipp.dev/) with full build logs and links to [pre-built images for all relevant boards](https://dl-linux-images.flipp.dev/full-img/), which our automated build system produces whenever something updates either in this repository or in one of its dependencies.
+> Pre-built images for all supported boards are available at [dl-linux-images.flipp.dev](https://dl-linux-images.flipp.dev/full-img/) and are updated automatically on every commit. Building from source is only necessary if you want to modify the system.
+
+## Related repositories
+
+This repo contains build scripts only. The full system is assembled from several components:
+
+| Repository | Description |
+|---|---|
+| **flipperone-linux-build-scripts** | Build scripts that assemble complete disk images for RK3576-based boards |
+| [flipper-linux-kernel](https://github.com/flipperdevices/flipper-linux-kernel) | Linux kernel patches and configuration for Flipper One RK3576-based boards |
+| [flipperone-mcu-firmware](https://github.com/flipperdevices/flipperone-mcu-firmware) | Firmware for the low-power RP2350 MCU |
+
+The build scripts pull the kernel and other components automatically — you don't need to clone other repos manually unless you want to modify them.
 
 
 ## Quick start with Dev Container (VS Code)
@@ -23,34 +36,49 @@ Note that while you can compile all of this software by hand by running the scri
 
 ## Quick start with Docker
 
-**TODO**: Move to Docker Hub
+The Docker image contains the dependencies required to build Flipper One Linux images locally. Build artifacts are written to the `out/` directory on the host.
 
 ```bash
-# Clone repo 
-git clone https://github.com/flipperdevices/rk3576-linux-build 
-cd rk3576-linux-build
+# Clone repo
+git clone https://github.com/flipperdevices/flipperone-linux-build-scripts
+cd flipperone-linux-build-scripts
 
-# Build docker image and start container
-docker build -t rk3576-linux-build .
-docker run --privileged --rm -v $(pwd)/out:/artifacts \
-	rk3576-linux-build
+# Build Docker image
+docker build -t flipperone-linux-build-scripts .
 
-# Flash image to Radxa 4D MicroSD card via USB
-
-# 1. Switch Radxa 4D into Maskrom mode and verify it
-# rockusb should work inside Docker container becuase of privileged mode
-rockusb list
-
-# 2. Upload bootloader to Radxa 4D
-rockusb download-boot out/u-boot/rock-4d/rk3576_spl_loader_*.bin
-
-# 3. Flash image to MicroSD card
-rockusb write-bmap out/images/debian-rock-4d-20250824-0021.img.gz
-
-# 4. Reboot the board
-rockusb reset-device
+# Build OS images
+mkdir -p out
+docker run --privileged --rm -v "$(pwd)/out:/artifacts" \
+    flipperone-linux-build-scripts
 ```
 
+After the build finishes, generated images can be found in `out/images/`.
+
+### Flashing to Radxa 4D eMMC via USB
+
+Switch Radxa 4D into Maskrom mode and verify that it is visible:
+
+```bash
+rockusb list
+```
+
+Upload the bootloader:
+
+```bash
+rockusb download-boot out/u-boot/rock-4d/rk3576_spl_loader_*.bin
+```
+
+Flash the image to eMMC:
+
+```bash
+rockusb write-bmap out/images/debian-rock-4d-*.img.gz
+```
+
+Reboot the board:
+
+```bash
+rockusb reset-device
+```
 
 ## Prepare build system manually
 
@@ -202,7 +230,7 @@ If you have a built-in SD card slot, you may use that, and the card will likely 
 If you are using a USB card reader, the card will likely show up as `/dev/sdX` (where `X` is a lowercase letter). In this latter case you need to be triple careful, because any SATA or SCSI storage devices will also share the same naming scheme, and if you have important data on any other `/dev/sdX` device (such as your main system disk being called something like `/dev/sda`) you might end up inadvertently overwriting it if you pick the wrong one in the below commands, losing all your data. Please be careful.
 
 ```bash
-sudo bmaptool copy out/debian-<your_board>.img.gz /dev/sdX
+sudo bmaptool copy out/images/debian-<your_board>.img.gz /dev/sdX
 ```
 
 ### Flashing to eMMC using a USB cable and Maskrom
@@ -211,8 +239,8 @@ Rockchip devices include a special built-in mode called Maskrom, which allows fl
 
 This mode is activated by holding down a MASKROM button when the power supply gets connected.
 
-- Instructions for Radxa Rock 4D: https://docs.radxa.com/en/rock4/rock4d/hardware-use/maskrom?maskrom-display=Linux%2FMacOS. Connect a USB A to A cable (or Type C to USB A, depending on you host computer’s available USB ports) to the top USB 3.0 blue port, hold the MASKROM button and apply power to the board as usual via its Type C DC IN. Note that eMMC modules cannot be used together with the onboard SPI flash, as they share pins internally
-- Instructions for ArmSoM Sige5: https://docs.armsom.org/getting-start/flash-img#241-device-connection. Connect a USB A to Type C cable (or Type C to Type C, depending on your host computer’s available USB ports) to the Type C OTG port (marked TYPEC on the board), hold the MASKROM button and apply power to the board as usual via its Type C DC IN
+- Instructions for [Radxa Rock 4D](https://docs.radxa.com/en/rock4/rock4d/hardware-use/maskrom?maskrom-display=Linux%2FMacOS): Connect a USB A to A cable (or Type C to USB A, depending on your host computer's available USB ports) to the top USB 3.0 blue port, hold the MASKROM button and apply power to the board as usual via its Type C DC IN. Note that eMMC modules cannot be used together with the onboard SPI flash, as they share pins internally
+- Instructions for [ArmSoM Sige5](https://docs.armsom.org/getting-start/flash-img#241-device-connection): Connect a USB A to Type C cable (or Type C to Type C, depending on your host computer's available USB ports) to the Type C OTG port (marked TYPEC on the board), hold the MASKROM button and apply power to the board as usual via its Type C DC IN
 
 You should then see something like this in `lsusb` command output:
 
@@ -226,5 +254,5 @@ Your device is now ready for programming over the Rockusb protocol.
 # Boot the board in USB upload mode
 sudo rockusb download-boot prebuilt/u-boot/<your_board>/rk3576_spl_loader_*.bin
 
-sudo rockusb write-bmap out/debian-<your_board>.img.gz
+sudo rockusb write-bmap out/images/debian-<your_board>.img.gz
 ```


### PR DESCRIPTION
Changes:
- fix the Debian version wording in the introduction
- add a short note about pre-built images and when building from source is necessary
- add a Related repositories section to clarify which components are assembled by this repo
- update the kernel repository description
- replace the old `rk3576-linux-build` repository name with `flipperone-linux-build-scripts`
- remove the outdated Docker Hub TODO
- use the current repository name as the Docker image tag
- add `mkdir -p out` before mounting the artifacts directory
- quote the Docker volume path
- separate Docker build steps from flashing steps
- replace the fixed dated image filename with a wildcard pattern
- update generated image paths to use `out/images/`