### PR TITLE
Fix Docker build by pinning zeekstd_cli to v0.4.4-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,8 @@ RUN go install -v github.com/go-debos/debos/cmd/debos@latest
 
 RUN install -m 755 ~/go/bin/debos /usr/local/bin
 
-RUN cargo install --git https://github.com/rorosen/zeekstd.git zeekstd_cli
+# v0.4.5-cli+ needs Rust 1.91 (Path::with_added_extension); see https://github.com/rorosen/zeekstd/tags
+RUN cargo install --git https://github.com/rorosen/zeekstd.git --tag v0.4.4-cli zeekstd_cli
 
 RUN install -m 755 ~/.cargo/bin/zeekstd /usr/local/bin/
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ For assembling complete disk images:
 
 ```bash
 sudo apt install systemd-resolved pipx pigz cargo parted fdisk
-cargo install --git https://github.com/rorosen/zeekstd.git zeekstd_cli
+cargo install --git https://github.com/rorosen/zeekstd.git --tag v0.4.4-cli zeekstd_cli
 sudo install -m 755 ~/.cargo/bin/zeekstd /usr/local/bin/
 sudo pipx install --global git+https://github.com/flipperdevices/bmaptool.git@flipper-devel
 


### PR DESCRIPTION
- Pin `zeekstd_cli` install to git tag [`v0.4.4-cli`](https://github.com/rorosen/zeekstd/tags) in `Dockerfile` and manual setup in `README.md`.
- Fixes Docker image build failure at the `cargo install zeekstd_cli` step.

Findings

`cargo install --git https://github.com/rorosen/zeekstd.git zeekstd_cli` (no tag) builds from the repo default branch, which currently resolves to **zeekstd_cli v0.4.5** (`37c74abd`).

v0.4.5 uses `Path::with_added_extension()` (Rust issue [#127292](https://github.com/rust-lang/rust/issues/127292)), stabilized in **Rust 1.91+**. Debian Trixie's packaged `rustc` is older, so compilation fails with:

```text
error[E0658]: use of unstable library feature `path_add_extension`