### PR TITLE
feat: add gstreamer h264 userspace packages

### DIFF
--- a/debian-rk3576-ospack.yaml
+++ b/debian-rk3576-ospack.yaml
@@ -41,6 +41,8 @@ actions:
       - dmidecode
       - dnsmasq-base
       - drm-info
+      - gstreamer1.0-plugins-bad
+      - gstreamer1.0-tools
       - e2fsprogs
       - edid-decode
       - evtest


### PR DESCRIPTION
## Summary
- add `gstreamer1.0-tools` to the RK3576 ospack so the image includes `gst-launch-1.0` and `gst-inspect-1.0`
- add `gstreamer1.0-plugins-bad` to the RK3576 ospack so the image includes the V4L2 stateless decoder plugin set used for H.264 validation

## Scope
This PR is now limited to package inclusion in the RK3576 image.

Not included here:
- on-device helper scripts
- mpv integration
- ffmpeg/V4L2-request player work
- runtime claims about RK3576 hardware decode

## Notes
- I removed the helper script from this repo after review; that test helper can live in `flipperone-testing` instead.
- I checked the package relationships before keeping these entries:
  - `gstreamer1.0-tools` is not pulled in by the current image package set.
  - `gstreamer1.0-plugins-bad` is suggested by the current WebKit stack, but not installed as a hard dependency, so it still needs to be listed explicitly.

## Verification
- PR diff is now limited to `debian-rk3576-ospack.yaml`
- `git diff --check` passes
- checked Debian package metadata for the current dependency path:
  - `gstreamer1.0-tools` has no existing parent package in this image that installs it automatically
  - `gstreamer1.0-plugins-bad` is not a hard dependency of the current Cog/WebKit path

Refs #13
