### PR TITLE
Fix drkonqi-coredump-launcher journal flood

### DIFF
--- a/overlays/configs/systemd/user/drkonqi-coredump-launcher.socket.d/override.conf
+++ b/overlays/configs/systemd/user/drkonqi-coredump-launcher.socket.d/override.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionUser=


### PR DESCRIPTION
The socket's ConditionUser=!@system fails for system user managers (sddm, flipctl), and UpheldBy=sockets.target retries the skip endlessly, flooding the journal. Clear ConditionUser via a global drop-in so the socket starts instead of being skipped. Coredumps are still captured by systemd-coredump.