### PR TITLE
TV media box target

### DIFF
--- a/debian-rk3576-ospack.yaml
+++ b/debian-rk3576-ospack.yaml
@@ -270,8 +270,8 @@ actions:
     origin: cog-seat
 
   - action: download
-    description: Download SDDM from Debian Sid rebuilt against Trixie libraries
-    url: https://dl-linux-images.flipp.dev/flipperone-deb/pool/main/s/sddm/sddm_0.21.0%2Bgit20251101.dfa5315-1_arm64.deb
+    description: Download SDDM from Debian Sid rebuilt against Trixie libraries (with seat patch)
+    url: https://dl-linux-images.flipp.dev/flipperone-deb/pool/main/s/sddm/sddm_0.21.0+git20251101.dfa5315-1+flipper1_arm64.deb
     name: sddm-sid
 
   - action: install-deb

--- a/debian-rk3576-ospack.yaml
+++ b/debian-rk3576-ospack.yaml
@@ -72,6 +72,7 @@ actions:
       - kde-standard
       - kmscube
       - kodi
+      - kodi-eventclients-kodi-send
       - konsole
       - kscreen
       - less

--- a/debian-rk3576-ospack.yaml
+++ b/debian-rk3576-ospack.yaml
@@ -69,6 +69,7 @@ actions:
       - kde-spectacle
       - kde-standard
       - kmscube
+      - kodi
       - konsole
       - kscreen
       - less
@@ -156,7 +157,10 @@ actions:
              echo "user:user" | chpasswd &&
              gpasswd -a user audio &&
              gpasswd -a user bluetooth &&
-             gpasswd -a user sudo
+             gpasswd -a user sudo &&
+             gpasswd -a user input &&
+             gpasswd -a user video &&
+             gpasswd -a user render
 
   - action: run
     description: Add dedicated "flipctl" user

--- a/debian-rk3576-ospack.yaml
+++ b/debian-rk3576-ospack.yaml
@@ -109,6 +109,7 @@ actions:
       - plasma-systemmonitor
       - powercap-utils
       - powerdevil
+      - python3-evdev
       - python3-pandas
       - python3-plotly
       - rfkill

--- a/debian-rk3576-ospack.yaml
+++ b/debian-rk3576-ospack.yaml
@@ -34,8 +34,10 @@ actions:
       - bsdextrautils
       - bsdmainutils
       - build-essential
+      - cage
       - ca-certificates
       - cec-utils
+      - chromium
       - cog
       - curl
       - device-tree-compiler
@@ -282,6 +284,16 @@ actions:
   - action: install-deb
     description: Install the updated Mediatek firmware into the target
     origin: firmware-sid
+
+  - action: overlay
+    description: Overlay Kodi Chromium kiosk launcher
+    source: overlays/home/user/
+    destination: /home/user/
+    
+  - action: run
+    description: Fix ownership of overlaid home files
+    chroot: true
+    command: chown -R user:user /home/user
 
   - action: pack
     description: Save a tarball of the root filesystem

--- a/overlays/configs/NetworkManager/conf.d/20-connectivity.conf
+++ b/overlays/configs/NetworkManager/conf.d/20-connectivity.conf
@@ -1,0 +1,6 @@
+[connectivity]
+uri=http://network-test.debian.org/nm
+interval=300
+response=NetworkManager is online
+timeout=3
+capabilities=all

--- a/overlays/configs/NetworkManager/dispatcher.d/90-captive-portal
+++ b/overlays/configs/NetworkManager/dispatcher.d/90-captive-portal
@@ -1,0 +1,11 @@
+#!/bin/sh
+[ "$2" = connectivity-change ] && [ "$CONNECTIVITY_STATE" = PORTAL ] || exit 0
+uid=$(loginctl list-sessions --no-legend | awk '/seat0/{print $2; exit}')
+exec sudo -u "#$uid" env \
+  XDG_RUNTIME_DIR="/run/user/$uid" \
+  WAYLAND_DISPLAY=wayland-0 \
+  chromium --ozone-platform=wayland \
+  --password-store=basic \
+  --user-data-dir=/home/user/.config/chromium-standalone \
+  --force-dark-mode \
+  --start-maximized http://network-test.debian.org/nm

--- a/overlays/configs/systemd/system/kodi.service
+++ b/overlays/configs/systemd/system/kodi.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Kodi standalone (GBM)
+After=remote-fs.target systemd-user-sessions.service sound.target
+Conflicts=getty@tty1.service
+
+[Service]
+User=user
+Group=user
+PAMName=login
+TTYPath=/dev/tty1
+StandardInput=tty
+StandardOutput=journal
+ExecStart=/usr/bin/kodi-standalone
+Restart=on-abort
+
+[Install]
+WantedBy=tv-media-box.target

--- a/overlays/configs/systemd/system/kodi.service
+++ b/overlays/configs/systemd/system/kodi.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Kodi standalone (GBM)
+Description=Kodi standalone (Wayland via Cage)
 After=remote-fs.target systemd-user-sessions.service sound.target
 Conflicts=getty@tty1.service
 
@@ -10,7 +10,7 @@ PAMName=login
 TTYPath=/dev/tty1
 StandardInput=tty
 StandardOutput=journal
-ExecStart=/usr/bin/kodi-standalone
+ExecStart=/usr/bin/cage -- /usr/bin/kodi-standalone
 Restart=on-abort
 
 [Install]

--- a/overlays/configs/systemd/system/kodi.service
+++ b/overlays/configs/systemd/system/kodi.service
@@ -10,6 +10,8 @@ PAMName=login
 TTYPath=/dev/tty1
 StandardInput=tty
 StandardOutput=journal
+TimeoutStartSec=infinity
+ExecStartPre=/home/user/.kodi/kodi-display-gate
 ExecStart=/usr/bin/cage -- /usr/bin/kodi-standalone
 Restart=on-abort
 

--- a/overlays/configs/systemd/system/kodi.service.d/handoff.conf
+++ b/overlays/configs/systemd/system/kodi.service.d/handoff.conf
@@ -1,0 +1,6 @@
+[Unit]
+Conflicts=sddm.service
+After=sddm.service
+[Service]
+ExecStop=-/usr/bin/kodi-send --action=Quit
+TimeoutStopSec=5s

--- a/overlays/configs/systemd/system/sddm.service.d/handoff.conf
+++ b/overlays/configs/systemd/system/sddm.service.d/handoff.conf
@@ -1,0 +1,3 @@
+[Unit]
+Conflicts=kodi.service
+After=kodi.service

--- a/overlays/configs/systemd/system/sddm.service.d/seat.conf
+++ b/overlays/configs/systemd/system/sddm.service.d/seat.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=SDDM_SEATS=seat0

--- a/overlays/configs/systemd/system/tv-media-box.target
+++ b/overlays/configs/systemd/system/tv-media-box.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=TV Media Box
+Requires=multi-user.target
+After=multi-user.target
+AllowIsolate=yes

--- a/overlays/configs/systemd/system/tv-media-box.target.wants/kodi.service
+++ b/overlays/configs/systemd/system/tv-media-box.target.wants/kodi.service
@@ -1,0 +1,1 @@
+/etc/systemd/system/kodi.service

--- a/overlays/home/user/.kodi/kodi-display-gate
+++ b/overlays/home/user/.kodi/kodi-display-gate
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Block until at least one card2 connector is connected, then exit 0.
+while :; do
+    for c in DP-1 HDMI-A-1; do
+        [ "$(cat /sys/class/drm/card2-$c/status 2>/dev/null)" = connected ] && exit 0
+    done
+    sleep 1
+done

--- a/overlays/home/user/.kodi/userdata/favourites.xml
+++ b/overlays/home/user/.kodi/userdata/favourites.xml
@@ -1,0 +1,3 @@
+<favourites>
+    <favourite name="Chromium" thumb="/usr/share/icons/hicolor/256x256/apps/chromium.png">System.Exec(/home/user/.kodi/userdata/launch-chromium.sh)</favourite>
+</favourites>

--- a/overlays/home/user/.kodi/userdata/launch-chromium.sh
+++ b/overlays/home/user/.kodi/userdata/launch-chromium.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+exec /usr/bin/chromium \
+    --ozone-platform=wayland \
+    --force-dark-mode \
+    --user-data-dir=/home/user/.config/chromium-standalone \
+    --start-maximized \
+    "https://google.com" \
+    "http://speedtest.net"

--- a/overlays/usr/share/u-boot-menu/enabled.d/03-tv-media-box
+++ b/overlays/usr/share/u-boot-menu/enabled.d/03-tv-media-box
@@ -1,0 +1,2 @@
+default
+tv-media-box

--- a/overlays/usr/share/u-boot-menu/features.d/tv-media-box
+++ b/overlays/usr/share/u-boot-menu/features.d/tv-media-box
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Reset name to base (removes [DEFAULT] suffix added by default feature)
+set_base_profile_name "${base_profile_name}"
+append_name "[TV MEDIA BOX]"
+add_bootargs systemd.unit=tv-media-box.target
+add_board_dtbo -d "hdmi-cec" -n "CEC"


### PR DESCRIPTION
TV media box target and:

- chromium
- chromium launch button for kodi
- scripts to launch chromium on captive portal detect
- python3-evdev for input forwarding (flipper buttons)
- handoff for fast switching tv-media-box <-> KDE
- HDMI and DP connectivity gating so kodi won't start without screen
