### PR TITLE
Chromium captive launch fix

### DIFF
--- a/overlays/configs/NetworkManager/dispatcher.d/90-captive-portal
+++ b/overlays/configs/NetworkManager/dispatcher.d/90-captive-portal
@@ -4,12 +4,18 @@ session=$(loginctl show-seat seat0 -p ActiveSession --value)
 [ -n "$session" ] || exit 0
 [ "$(loginctl show-session "$session" -p Class --value)" = user ]   || exit 0
 
-uid=$(id -u user)
-exec sudo -u user env \
+uid=$(loginctl show-session "$session" -p User --value)
+name=$(loginctl show-session "$session" -p Name --value)
+[ -n "$uid" ] && [ -n "$name" ] || exit 0
+home=$(getent passwd "$name" | cut -d: -f6)
+[ -n "$home" ] || exit 0
+[ -S "/run/user/$uid/wayland-0" ] || exit 0
+
+exec sudo -u "$name" env \
   XDG_RUNTIME_DIR="/run/user/$uid" \
   WAYLAND_DISPLAY=wayland-0 \
   chromium --ozone-platform=wayland \
   --password-store=basic \
-  --user-data-dir=/home/user/.config/chromium-standalone \
+  --user-data-dir="$home/.config/chromium-standalone" \
   --force-dark-mode \
   --start-maximized http://network-test.debian.org/nm

--- a/overlays/configs/NetworkManager/dispatcher.d/90-captive-portal
+++ b/overlays/configs/NetworkManager/dispatcher.d/90-captive-portal
@@ -1,7 +1,11 @@
 #!/bin/sh
 [ "$2" = connectivity-change ] && [ "$CONNECTIVITY_STATE" = PORTAL ] || exit 0
-uid=$(loginctl list-sessions --no-legend | awk '/seat0/{print $2; exit}')
-exec sudo -u "#$uid" env \
+session=$(loginctl show-seat seat0 -p ActiveSession --value)
+[ -n "$session" ] || exit 0
+[ "$(loginctl show-session "$session" -p Class --value)" = user ]   || exit 0
+
+uid=$(id -u user)
+exec sudo -u user env \
   XDG_RUNTIME_DIR="/run/user/$uid" \
   WAYLAND_DISPLAY=wayland-0 \
   chromium --ozone-platform=wayland \


### PR DESCRIPTION
Derive the target account from the active seat0 session instead of
hardcoding the 'user' account: use the session's User (uid) and Name
properties, and resolve the home directory via getent for the Chromium
profile path. Bail out unless a live Wayland socket
(/run/user/$uid/wayland-0) exists, so the portal only launches when
there's an actual graphical display to draw on (skips greeter and TTY
sessions).