### PR TITLE
Split Docker toolchain stage and make entrypoint overridable

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.gitignore
+.dockerignore
+out
+prebuilt
+src

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
-FROM debian:trixie
+FROM debian:trixie AS toolchain
 
-# Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
-ENV IMG_OUT=/artifacts/images
-ENV UBOOT_OUT=/artifacts/u-boot
-ENV LINUX_OUT=/artifacts/linux
 
 # Add arm64 architecture for cross-compilation
 RUN dpkg --add-architecture arm64 && apt-get update
@@ -64,9 +60,16 @@ RUN pipx install --global git+https://github.com/flipperdevices/bmaptool.git@fli
 # Clean up apt cache to reduce image size
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* ~/.cargo ~/go
 
-# Clone the flipperone-linux-build-scripts repository
-WORKDIR /flipperone-linux-build-scripts
-RUN git clone --depth=1 https://github.com/flipperdevices/flipperone-linux-build-scripts .
+FROM toolchain AS build
 
-# Entry point
-ENTRYPOINT ./build-uboot.sh && ./build-kernel-mainline.sh && ./build-kernel-bsp.sh && ./build-images.sh
+ENV IMG_OUT=/artifacts/images
+ENV UBOOT_OUT=/artifacts/u-boot
+ENV LINUX_OUT=/artifacts/linux
+
+WORKDIR /flipperone-linux-build-scripts
+COPY . .
+
+RUN bash -n docker-entrypoint.sh \
+    && install -m 755 docker-entrypoint.sh /usr/local/bin/flipperone-entrypoint
+
+ENTRYPOINT ["/usr/local/bin/flipperone-entrypoint"]

--- a/README.md
+++ b/README.md
@@ -85,6 +85,28 @@ docker run --privileged --rm -v "$(pwd)/out:/artifacts" \
     flipperone-linux-build-scripts
 ```
 
+Running the image without a command builds U-Boot, both kernels, and the final images. To open a shell or run an
+individual build script, append the command normally:
+
+```bash
+docker run --privileged --rm -it -v "$(pwd)/out:/artifacts" \
+    flipperone-linux-build-scripts bash
+
+docker run --privileged --rm -v "$(pwd)/out:/artifacts" \
+    flipperone-linux-build-scripts ./build-kernel-mainline.sh
+```
+
+The Dockerfile separates the slow-changing compiler and packaging toolchain into a named `toolchain` stage. Build and
+tag that stage independently when it should be shared or cached separately from the build scripts:
+
+```bash
+docker build --target toolchain -t flipperone-toolchain:trixie .
+docker build -t flipperone-linux-build-scripts .
+```
+
+CI can push the toolchain target to a registry and provide it as a build cache with `--cache-from`; the final stage
+only copies this repository, so ordinary source changes do not reinstall packages or rebuild the Go and Rust tools.
+
 Replace `docker` with `podman` if that's what you have. `--privileged` is required because debos and mmdebstrap use loop devices and mount namespaces.
 
 ### Quick start with VS Code Dev Container

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+if [ "$#" -gt 0 ]; then
+	exec "$@"
+fi
+
+./build-uboot.sh
+./build-kernel-mainline.sh
+./build-kernel-bsp.sh
+exec ./build-images.sh


### PR DESCRIPTION
## Summary

- split the slow-changing toolchain into a reusable Docker stage
- copy the current checkout into the final image
- replace the shell-form entrypoint with an exec-form wrapper
- allow commands such as `bash` or individual build scripts
- document the new container workflow

Closes #77
Closes #78

## Testing

- `git diff --cached --check`
- `docker build --check .`
- `docker build --target toolchain -t flipperone-toolchain:test .`
- `docker build --progress=plain -t flipperone-linux-build-scripts:test .`
- verified that the final build reused the cached toolchain layers
- `docker run --rm flipperone-linux-build-scripts:test bash -lc "echo override-ok; test -f ./build-uboot.sh"`
- verified the command override printed `override-ok` and exited with status `0`