### PR TITLE
Harden cog and kodi display device handling

### DIFF
--- a/overlays/configs/systemd/system/cog-seat1.service
+++ b/overlays/configs/systemd/system/cog-seat1.service
@@ -35,14 +35,16 @@ ProtectHome=read-only
 ReadWritePaths=/var/lib/flipctl
 ReadWritePaths=/run/user/999
 
-# Device cgroup allowlist
 DevicePolicy=closed
-DeviceAllow=/dev/dri/card0 rw
+DeviceAllow=/dev/dri/by-path/platform-2acf0000.spi-cs-0-card rw
 DeviceAllow=/dev/dri/renderD128 rw
-DeviceAllow=/dev/dri/card1 rw
 DeviceAllow=/dev/input/event0 rw
 DeviceAllow=/dev/input/event1 rw
-InaccessiblePaths=/dev/dri/card2
+
+TemporaryFileSystem=/dev/dri
+BindPaths=/dev/dri/by-path/platform-2acf0000.spi-cs-0-card:/dev/dri/card0
+BindPaths=/dev/dri/by-path/platform-27800000.gpu-card:/dev/dri/card1
+BindPaths=/dev/dri/by-path/platform-27800000.gpu-render:/dev/dri/renderD128
 
 ExecStartPre=/bin/sh -lc 'test -e /dev/dri/card0 && test -e /dev/input/event0'
 ExecStart=/usr/bin/cog -P drm -O renderer=gles http://localhost:8899

--- a/overlays/home/user/.kodi/kodi-display-gate
+++ b/overlays/home/user/.kodi/kodi-display-gate
@@ -1,8 +1,10 @@
 #!/bin/sh
-# Block until at least one card2 connector is connected, then exit 0.
+# Block until a DP/HDMI connector (the main display) reports connected, then exit 0.
+# Match the connector on ANY card -- DRM card numbers renumber across kernel builds
+# (the main display is not always card2), so never hardcode cardN.
 while :; do
-    for c in DP-1 HDMI-A-1; do
-        [ "$(cat /sys/class/drm/card2-$c/status 2>/dev/null)" = connected ] && exit 0
+    for f in /sys/class/drm/card*-DP-1/status /sys/class/drm/card*-HDMI-A-1/status; do
+        [ "$(cat "$f" 2>/dev/null)" = connected ] && exit 0
     done
     sleep 1
 done


### PR DESCRIPTION
Split out from the btrfs stack per review: the cog-seat1.service and kodi-display-gate changes are not tied to btrfs, so they go straight onto dev.

- Address the SPI panel by its stable by-path name and bind it to a fixed /dev/dri/card0 inside cog's namespace, so DRM card renumbering across kernel builds no longer breaks seat1.
- Make the kodi display-gate match the main connector on any card rather than a hardcoded cardN.

The handoff removals and shutdown.conf from the original commit move into the profile-migration commit (#96).