### PR TITLE
Report build ID in MOTD and login banner

### DIFF
--- a/overlays/configs/update-motd.d/00-flipperone
+++ b/overlays/configs/update-motd.d/00-flipperone
@@ -10,9 +10,8 @@ serial=$(tr -d '\0' < /sys/firmware/devicetree/base/serial-number 2>/dev/null ||
 . /etc/os-release
 
 # Get build info
-build_id=${BUILD_ID:-0}
+build_id=${BUILD_ID:-unknown}
 build_git=${BUILD_GIT:-unknown}
-build_date=$(date -d "@$build_id" "+%Y-%m-%d %H:%M:%S %Z" 2>/dev/null || echo "$build_id")
 
 total_mem=$(awk '/MemTotal/ {printf "%.1f GB", $2/1024/1024}' /proc/meminfo)
 
@@ -25,7 +24,7 @@ cat <<EOF
    Board:        $board
    CPU Serial:   $serial
    Memory:       $total_mem
-   Build Date:   $build_date
+   Build ID:     $build_id
 
 Memory Status:
 $(free -hv)

--- a/overlays/usr/local/bin/set-hostname-and-banner.sh
+++ b/overlays/usr/local/bin/set-hostname-and-banner.sh
@@ -25,9 +25,8 @@ new_hostname="${device}-${serial_prefix}-${BUILD_ID}"
 hostnamectl set-hostname "${new_hostname}"
 
 # Get build info
-build_id=${BUILD_ID:-0}
+build_id=${BUILD_ID:-unknown}
 build_git=${BUILD_GIT:-unknown}
-build_date=$(date -d "@$build_id" "+%Y-%m-%d %H:%M:%S %Z" 2>/dev/null || echo "$build_id")
 
 total_mem=$(awk '/MemTotal/ {printf "%.1f GB", $2/1024/1024}' /proc/meminfo)
 
@@ -38,7 +37,7 @@ Git:          $build_git
 Board:        $board
 CPU Serial:   $serial
 Memory:       $total_mem
-Build Date:   $build_date
+Build ID:     $build_id
 Default credentials: user / user
 =============================================================
 EOF


### PR DESCRIPTION
Split out from the btrfs build-stamping work per review: this is a display fixup, not tied to btrfs.

Show the raw BUILD_ID instead of decoding it as a timestamp-based "Build Date", and default it to "unknown" when unset.