### PR TITLE
Show booted profile name in MOTD

### DIFF
--- a/overlays/configs/update-motd.d/00-flipperone
+++ b/overlays/configs/update-motd.d/00-flipperone
@@ -15,6 +15,11 @@ build_git=${BUILD_GIT:-unknown}
 
 total_mem=$(awk '/MemTotal/ {printf "%.1f GB", $2/1024/1024}' /proc/meminfo)
 
+# Get currently booted profile = the btrfs subvolume mounted as root (@Desktop, @Router, @TV-Media-Box, @Minimal).
+profile=$(findmnt -nro FSROOT / 2>/dev/null)
+profile=${profile#/}
+[ -n "$profile" ] && [ "$profile" != "/" ] || profile=unknown
+
 # Generate MOTD
 cat <<EOF
 
@@ -25,6 +30,7 @@ cat <<EOF
    CPU Serial:   $serial
    Memory:       $total_mem
    Build ID:     $build_id
+   Profile:      $profile
 
 Memory Status:
 $(free -hv)

--- a/overlays/usr/local/bin/set-hostname-and-banner.sh
+++ b/overlays/usr/local/bin/set-hostname-and-banner.sh
@@ -30,6 +30,11 @@ build_git=${BUILD_GIT:-unknown}
 
 total_mem=$(awk '/MemTotal/ {printf "%.1f GB", $2/1024/1024}' /proc/meminfo)
 
+# Get currently booted profile = the btrfs subvolume mounted as root (@Desktop, @Router, @TV-Media-Box, @Minimal).
+profile=$(findmnt -nro FSROOT / 2>/dev/null)
+profile=${profile#/}
+[ -n "$profile" ] && [ "$profile" != "/" ] || profile=unknown
+
 # Generate SSH welcome banner
 cat <<EOF >/etc/ssh/welcome_banner
 =================== Welcome to FlipperOne ===================
@@ -38,6 +43,7 @@ Board:        $board
 CPU Serial:   $serial
 Memory:       $total_mem
 Build ID:     $build_id
+Profile:      $profile
 Default credentials: user / user
 =============================================================
 EOF


### PR DESCRIPTION
Derive the active profile from the btrfs subvolume mounted as root (`@Desktop`, `@Router`, `@TV-Media-Box`, `@Minimal`) and show it as a `Profile:` line in the MOTD, so it's obvious which profile a session booted into.

Uses `findmnt -nro FSROOT /`; falls back to `unknown` on a non-subvolume root.