### PR TITLE
Per-profile BLS boot entries for profile system

### DIFF
--- a/debian-rk3576-img.yaml
+++ b/debian-rk3576-img.yaml
@@ -1,10 +1,12 @@
 {{ $sectorsize := or .sectorsize 512 }}
 {{ $imagesize  := or .imagesize  "4GiB" }}
 {{ $kerneldir  := or .kerneldir  "prebuilt/linux" }}
-{{ $cmdline    := or .cmdline    "audit=0 console=tty1 console=ttyS0,1500000n8" }}
+# cmdline: shared facts + policy only. The BLS generator adds the per-entry rootflags=subvol=
+# and the serial consoles (console=ttyS0/ttyS4/fbcon or ttyFIQ0, per kernel config).
+{{ $cmdline    := or .cmdline    "audit=0 console=tty1" }}
 {{ $fslabel    := or .fslabel    "flipperos" }}
-{{- /* fs-wide btrfs mount options. ssd is FORCED (loopback/eMMC isn't reliably
-       detected as non-rotational). */ -}}
+# btrfsopts: fs-wide mount options. ssd is FORCED (loopback/eMMC isn't reliably
+# detected as non-rotational).
 {{ $btrfsopts  := or .btrfsopts  "compress=zstd,noatime,ssd,discard=async" }}
 {{ $rootdev    := "findmnt -fn --nofsroot -o SOURCE --target $IMAGEMNTDIR" }}
 
@@ -72,17 +74,17 @@ actions:
       mount -t btrfs -o "{{ $btrfsopts }},subvol=@var-log"   "$ROOTPART" "$IMAGEMNTDIR/var/log"
       mount -t btrfs -o "{{ $btrfsopts }},subvol=@var-cache" "$ROOTPART" "$IMAGEMNTDIR/var/cache"
 
-  # debos writes the standard root line into /etc/fstab and root=UUID into the cmdline;
-  # the root subvolume is selected by the appended rootflags. @Desktop is the default root
-  # (the desktop); the other profiles' BLS entries append rootflags=subvol=@<profile>
-  # and the last rootflags= on the line wins. (Deploy still happens into @Minimal.)
+  # debos writes the standard root line into /etc/fstab and root=UUID into the cmdline.
+  # The root subvolume is NOT baked here: /etc/kernel/cmdline carries only shared facts +
+  # policy (root=UUID, audit, console=tty1). The BLS generator supplies rootflags=subvol=
+  # per entry (from flipper-profiles at build, from findmnt at runtime). Deploy into @Minimal.
   - action: filesystem-deploy
-    append-kernel-cmdline: rootflags=subvol=@Desktop {{ $cmdline }}
+    append-kernel-cmdline: {{ $cmdline }}
 
   # Add fstab entries for the non-root subvolumes (debos only generated the root
   # line). The FSUUID is read back at build time. These (/boot, /home, /var/log,
-  # /var/cache) are shared by every profile root. @snapshots is intentionally omitted
-  # -- it holds runtime snapshots, managed on demand, never auto-mounted.
+  # /var/cache) are shared by every profile root. @snapshots is intentionally omitted:
+  # it holds runtime snapshots, managed on demand, never auto-mounted.
   - action: run
     description: Append subvolume entries to /etc/fstab
     chroot: false
@@ -114,10 +116,50 @@ actions:
     origin: artifacts
     destination: /var/cache/linux-kernel
 
+  # Bake @Minimal's entry-token before the kernel install, so the kernel-install plugin stages the
+  # kernel into /boot/<token>/ instead of the 'debian' fallback. @Minimal is the build root, so its
+  # token is the one the plugin reads. NN is derived from @Minimal's position in flipper-profiles.
+  - action: run
+    description: Pin @Minimal's kernel entry-token before the kernel install
+    chroot: true
+    command: |
+      set -eu
+      . /usr/lib/flipper-bls.sh
+      mkdir -p /etc/kernel
+      make_token "$(profile_base_nn @Minimal)" @Minimal > /etc/kernel/entry-token
+
   - action: run
     description: Install Linux kernel packages inside the target
     chroot: true
     command: find /var/cache/linux-kernel -name linux-image-\*.deb -a ! -name \*-dbg_\* -print0 | xargs -0 apt install -y
+
+  # The kernel-install plugin only wrote @Minimal's entry (the build root). Fan the installed
+  # kernel(s) out to every profile: one entry + a reflinked /boot/<token>/ per profile per version
+  # (token = <NN>-flipperos-<subvol>, NN from the flipper-profiles order). The shared logic lives in
+  # /usr/lib/flipper-bls.sh; this build step is the only fan-out (the plugin handles one root).
+  - action: run
+    description: Generate the per-profile BLS entries for the installed kernel(s)
+    chroot: true
+    command: |
+      set -eu
+      . /usr/lib/flipper-bls.sh
+      CONF_ROOT=/etc/kernel; PROFILES=/etc/kernel/flipper-profiles; ENTRIES=/boot/loader/entries
+      MACHINE_ID=""; DEVICETREE=""; DEVICETREE_ENTRY=""; BOOT_MNT="/"
+      mkdir -p "$ENTRIES"; SORT_KEY="$(os_sort_key)"
+      for _k in /boot/vmlinuz-*; do
+        [ -e "$_k" ] || continue
+        KERNEL_VERSION="${_k#/boot/vmlinuz-}"; KCONFIG="/boot/config-$KERNEL_VERSION"
+        set_dtb_dirs; discover_devicetreedir; compute_base_opts
+        _i=0
+        while IFS='|' read -r tok suf extra gate dtbos legend; do
+          tok="$(echo "$tok" | tr -d '[:space:]')"; case "$tok" in ''|\#*) continue ;; esac
+          extra="$(trim "$extra")"; _sv="$(subvol_of "$extra")"
+          ENTRY_TOKEN="$(make_token "$(printf '%03d' "$((900 - _i * 100))")" "$_sv")"
+          remove_entries "$_sv" "$KERNEL_VERSION"; stage_kernel_reflink
+          emit_entry "$(trim "$suf")" "$extra" "$(trim "$gate")" "$(trim "$dtbos")"
+          _i=$((_i + 1))
+        done <"$PROFILES"
+      done
 
   # Default session for every profile: the no-DE multi-user target, where the cog-seat1
   # kiosk runs (and @TV's kodi, enabled under multi-user). Only @Desktop overrides this to
@@ -139,7 +181,7 @@ actions:
   # @home and @var-* are separate top-level subvols shared by all profiles.
   #
   # KDE and TV-Media-Box install their packages (apt) + config (overlay); only @Desktop changes
-  # its default target (to graphical, for sddm) -- TV/Router/Minimal stay on multi-user.
+  # its default target (to graphical, for sddm); TV/Router/Minimal stay on multi-user.
   # Router applies only its config overlay (NM AP/WAN + ip-forwarding); no packages needed.
   # ===========================================================================
 
@@ -148,6 +190,8 @@ actions:
     chroot: false
     command: |
       set -eu
+      # @Minimal's entry-token was baked before the kernel install, so @Minimal_stock (snapshotted
+      # here) and the re-created @Minimal both inherit it; no need to rewrite it.
       sync
       ROOTPART="$({{ $rootdev }})"                 # @Minimal is still mounted at $IMAGEMNTDIR
       # Mount the btrfs top level at a fixed path and KEEP it mounted for the whole profile
@@ -163,8 +207,8 @@ actions:
         | awk '{ print length, $0 }' | sort -rn | cut -d" " -f2- \
         | while read -r mp; do umount "$mp"; done
       # Re-create @Minimal as a writable child of the golden base (parent = @Minimal_stock)
-      # so it matches the other profiles -- which are snapshots of their _stock -- instead
-      # of being the build origin with no parent.
+      # so it matches the other profiles (each a snapshot of its _stock) instead of being
+      # the build origin with no parent.
       btrfs subvolume delete "$TOP/@Minimal"
       btrfs subvolume snapshot "$TOP/@Minimal_stock" "$TOP/@Minimal"
 
@@ -208,6 +252,13 @@ actions:
     chroot: true
     command: systemctl set-default graphical.target
   - action: run
+    description: Pin @Desktop's kernel entry-token (NN from flipper-profiles)
+    chroot: true
+    command: |
+      set -eu
+      . /usr/lib/flipper-bls.sh
+      make_token "$(profile_base_nn @Desktop)" @Desktop > /etc/kernel/entry-token
+  - action: run
     description: Lock @Desktop_stock RO and spawn writable @Desktop
     chroot: false
     command: |
@@ -239,6 +290,13 @@ actions:
     source: overlays/profile-tv-media-box
     destination: /
   - action: run
+    description: Pin @TV-Media-Box's kernel entry-token (NN from flipper-profiles)
+    chroot: true
+    command: |
+      set -eu
+      . /usr/lib/flipper-bls.sh
+      make_token "$(profile_base_nn @TV-Media-Box)" @TV-Media-Box > /etc/kernel/entry-token
+  - action: run
     description: Lock @TV-Media-Box_stock RO and spawn writable @TV-Media-Box
     chroot: false
     command: |
@@ -269,6 +327,13 @@ actions:
     description: Fix NetworkManager connection permissions on @Router
     chroot: true
     command: chmod 600 /etc/NetworkManager/system-connections/*.nmconnection
+  - action: run
+    description: Pin @Router's kernel entry-token (NN from flipper-profiles)
+    chroot: true
+    command: |
+      set -eu
+      . /usr/lib/flipper-bls.sh
+      make_token "$(profile_base_nn @Router)" @Router > /etc/kernel/entry-token
   - action: run
     description: Lock @Router_stock RO and spawn writable @Router
     chroot: false

--- a/debian-rk3576-ospack.yaml
+++ b/debian-rk3576-ospack.yaml
@@ -199,6 +199,11 @@ actions:
     destination: /usr/local
 
   - action: overlay
+    description: Overlay our usr/lib helpers
+    source: overlays/usr/lib
+    destination: /usr/lib
+
+  - action: overlay
     description: Overlay our usr/share files
     source: overlays/usr/share
     destination: /usr/share

--- a/overlays/configs/kernel/flipper-profiles
+++ b/overlays/configs/kernel/flipper-profiles
@@ -1,18 +1,19 @@
 # Flipper One boot profiles -> one BLS entry per profile per kernel.
 #
-# Each profile is derived from the base ("[DESKTOP]") entry that
-# 90-loaderentry.install generates: it reuses the same linux/initrd/devicetreedir
-# and only adds a title suffix, extra kernel cmdline, and/or DTB overlays.
+# Every bootable session, including the default desktop, is a line below; there is no
+# separate base entry. Each lives in its own btrfs root subvolume (@Desktop, @Minimal,
+# @TV-Media-Box, @Router) selected by its OWN `rootflags=subvol=@<name>` (the cmdline no
+# longer carries one). The session (KDE/kodi/router) is baked into each root's
+# default.target; no systemd.unit= needed.
 #
-# Each bootable session lives in its own btrfs root subvolume (@Desktop, @Minimal,
-# @TV-Media-Box, @Router). A profile selects its root by appending
-# `rootflags=subvol=@<name>` to the cmdline -- this overrides the base
-# `rootflags=subvol=@Desktop` because the LAST rootflags= on the line wins. So [DESKTOP]
-# boots @Desktop (the desktop) and the entries below switch to the other roots. The session
-# (KDE/kodi/router) is baked into each root's default.target; no systemd.unit= needed.
+# This list is read two ways:
+#   - build: img.yaml sources flipper-bls.sh and emits one entry per line (the fan-out).
+#   - runtime (apt install): 90-loaderentry.install emits ONLY the booted root's entry, matching
+#     this list by rootflags=subvol= for the title/overlays.
 #
 # Columns (pipe-separated; '#' starts a comment line):
-#   1 token        short id, used in the entry filename + sort ordering
+#   1 token        short id used in the entry filename. The generator also prepends a
+#                  position-derived "NN-" prefix so this list's order becomes the menu order.
 #   2 suffix       appended to the menu title, e.g. "[ROUTER]"
 #   3 cmdline      extra kernel command-line fragment: root selection
 #                  (rootflags=subvol=@<name>) and/or tweaks (may be empty)
@@ -26,12 +27,20 @@
 #                  them (else the entry is still produced without overlays).
 #   6 legend       short description shown in the menu header (may be empty)
 #
-# Order here = order in the generated menu (after the [DESKTOP] = @Desktop entry).
+# Order here = order of the menu BANDS, top to bottom. Each line's position sets a base slot
+# (line #1 -> 900, #2 -> 800, ... step 100) that starts the entry-token (<NN>-flipperos-<subvol>),
+# which leads the .conf filename. U-Boot's bls bootmeth sorts by filename and lists them
+# descending, so line #1 (@Desktop) is the top band and the default. Within a band the factory
+# entry and any in-profile install share the profile's base slot (newest kernel first); a clone
+# gets base+clone-depth (a direct clone 901, a clone of a clone 902, ... origin profile + depth via
+# the btrfs snapshot parent chain), so clones sit just above. Reorder these lines to reorder the
+# menu. (See flipper-bls.sh's emit_entry header for the full scheme.)
 
-minimal|[MINIMAL]     |rootflags=subvol=@Minimal       |               |          |No desktop (cog kiosk only)
+desktop|[DESKTOP]     |rootflags=subvol=@Desktop       |               |          |Default desktop (KDE/sddm)
 tvbox  |[TV MEDIA BOX]|rootflags=subvol=@TV-Media-Box  |               |hdmi-cec  |Kodi media-box session
 router |[ROUTER]      |rootflags=subvol=@Router        |               |          |Wi-Fi router mode
+minimal|[MINIMAL]     |rootflags=subvol=@Minimal       |               |          |No desktop (cog kiosk only)
 #hdmi4k|[HDMI-4K]     |dyndbg="file drivers/gpu/drm/rockchip/dw-dp.c +p"|ROCKCHIP_DW_DP|!rk3576-evb1-v10-typec-base rk3576-evb1-v10-typec-hdmi-dp|HDMI 4k (on @Desktop)
-dp4k  |[DP-4K]       |dyndbg="file drivers/gpu/drm/rockchip/dw-dp.c +p"|ROCKCHIP_DW_DP|!rk3576-evb1-v10-typec-base rk3576-evb1-v10-typec-dp-hdmi|DisplayPort 4k (on @Desktop)
-#fan  |[FAN]         |                                |               |!rk3576-evb1-v10-fan-pwm|PWM fan control
+#dp4k  |[DP-4K]       |dyndbg="file drivers/gpu/drm/rockchip/dw-dp.c +p"|ROCKCHIP_DW_DP|!rk3576-evb1-v10-typec-base rk3576-evb1-v10-typec-dp-hdmi|DisplayPort 4k (on @Desktop)
+#fan   |[FAN]         |                                |               |!rk3576-evb1-v10-fan-pwm|PWM fan control
 #ncm   |[USB NCM]     |systemd.wants=usb-ncm-gadget.service|USB_CONFIGFS_NCM USB_F_NCM|usb-ncm|USB NCM Ethernet gadget

--- a/overlays/configs/kernel/install.d/90-loaderentry.install
+++ b/overlays/configs/kernel/install.d/90-loaderentry.install
@@ -9,9 +9,16 @@
 # Keys written: standard BLS (title, version, machine-id, sort-key, options, linux,
 # devicetree, devicetree-overlay, initrd) plus 'devicetreedir' - a U-Boot extension
 # (DTB directory for cross-board fdtdir auto-selection; a U-Boot alias of 'fdtdir').
+#
+# The shared entry-writing helpers live in /usr/lib/flipper-bls.sh (also sourced by the
+# btrfs snapshot tooling: create_profile / rename_profile).
 
 set -e
+. /usr/lib/flipper-bls.sh
 
+# ===========================================================================
+# kernel-install plugin body.
+# ===========================================================================
 COMMAND="${1:?}"
 KERNEL_VERSION="${2:?}"
 ENTRY_DIR_ABS="${3:?}"
@@ -25,113 +32,40 @@ ENTRY_TOKEN="${KERNEL_INSTALL_ENTRY_TOKEN:?}"
 MACHINE_ID="${KERNEL_INSTALL_MACHINE_ID:-}"
 CONF_ROOT="${KERNEL_INSTALL_CONF_ROOT:-/etc/kernel}"
 ENTRIES="$BOOT_ROOT/loader/entries"
-ENTRY_STEM="$ENTRIES/$ENTRY_TOKEN-$KERNEL_VERSION"
 PROFILES="${FLIPPER_PROFILES:-/etc/kernel/flipper-profiles}"
 KCONFIG="$BOOT_ROOT/config-$KERNEL_VERSION"
-VENDOR=rockchip
-TITLE_MAX="${FLIPPER_TITLE_MAX:-26}"
+set_dtb_dirs
+[ -n "${BOOT_MNT:-}" ] || BOOT_MNT="/"
 
-# Where the kernel package installs DTBs/overlays: primary dir + the modules fallback.
-DTB_DIR="/usr/lib/linux-image-$KERNEL_VERSION"
-DTB_DIRS="$DTB_DIR /usr/lib/modules/$KERNEL_VERSION/dtb"
-
-# U-Boot reads the btrfs TOP LEVEL (subvolid 5), so in-entry devicetreedir/overlay paths must
-# be prefixed with the root subvolume the entry boots -- /@<subvol>/usr/lib/... -- where that
-# root's DTBs live (the kernel package installs them in every root's /usr/lib). The prefix is
-# derived per entry from its own rootflags=subvol= (each profile boots a different root). The
-# staged kernel/initrd live under /boot (the boot subvolume) and are never prefixed.
-# Set FDT_SUBVOL_PREFIX to override the derivation (e.g. "" if the root is not a subvolume).
-fdt_prefix() {  # $1 = options string -> "/<rootflags-subvol>" (or $FDT_SUBVOL_PREFIX if set)
-    if [ "${FDT_SUBVOL_PREFIX+x}" = x ]; then printf '%s' "$FDT_SUBVOL_PREFIX"; return 0; fi
-    _sv=$(printf '%s' "$1" | tr ' ' '\n' | sed -n 's/^rootflags=subvol=//p' | tail -n1)
-    [ -n "$_sv" ] && printf '/%s' "$_sv"
-    return 0
-}
-
-log() { [ "${KERNEL_INSTALL_VERBOSE:-0}" -gt 0 ] && echo "flipper-bls: $*" >&2; return 0; }
-die() { echo "flipper-bls: $*" >&2; exit 1; }
-trim() { printf '%s' "$1" | sed 's/^ *//; s/ *$//'; }
-# copy a file into the entry dir as root:root 0644
-stage_file() { install -m 0644 -o root -g root "$1" "$2" || die "could not copy '$1'"; }
-
-# remove: drop the base entry and all profile variants for this kernel
+# remove: drop every entry for THIS version that boots the CURRENT root subvol, whatever its
+# entry-token (factory 'debian-*' and per-root 'flipperos-*' alike). Keyed on each entry's own
+# content (version + rootflags=subvol=), so it never touches another profile's entries and
+# survives any purge/cleanup path. kernel-install itself removes this root's staged dir.
 if [ "$COMMAND" = "remove" ]; then
-    rm -f "$ENTRY_STEM.conf" "$ENTRY_STEM-"*.conf
-    _id="" && [ -r /etc/os-release ] && _id="$(. /etc/os-release; printf '%s' "${IMAGE_ID:-$ID}")" || :
-    if [ -n "$_id" ] && [ "$_id" != "$ENTRY_TOKEN" ]; then
-        _alt="$ENTRIES/$_id-$KERNEL_VERSION"
-        rm -f "$_alt.conf" "$_alt-"*.conf
-    fi
+    remove_entries "$(current_subvol)" "$KERNEL_VERSION"
+    # kernel-install removed this version's staged dir; reap the now-empty per-token parent
+    # ($BOOT_ROOT/$ENTRY_TOKEN) too. rmdir (not rm -rf) only succeeds if truly empty, so it
+    # never touches a token dir that still has another version staged.
+    rmdir "$BOOT_ROOT/$ENTRY_TOKEN" 2>/dev/null || :
     exit 0
 fi
 [ "$COMMAND" = "add" ] || exit 0
 
-# In-entry paths are relative to the partition U-Boot actually reads. On Flipper One
-# that is always the root partition — /boot is a directory/subvolume on it, never a
-# separate boot partition U-Boot mounts — so paths must keep the /boot prefix, i.e.
-# BOOT_MNT=/. (Override BOOT_MNT in the environment if /boot ever becomes its own
-# partition, which would make boot_rel strip the mountpoint again.)
-[ -n "$BOOT_MNT" ] || BOOT_MNT="/"
-
-# absolute path under BOOT_ROOT -> path as it must appear inside a BLS entry (relative
-# to the boot partition; identical to the absolute path when /boot is on the rootfs).
-boot_rel() { if [ "$BOOT_MNT" = "/" ]; then printf '%s\n' "$1"; else printf '%s\n' "${1#"$BOOT_MNT"}"; fi; }
-
 ENTRY_DIR="$(boot_rel "$ENTRY_DIR_ABS")"
 [ -d "$ENTRY_DIR_ABS" ] || die "entry directory '$ENTRY_DIR_ABS' does not exist"
-
-# The loader entries dir may not exist yet on a fresh boot partition.
 mkdir -p "$ENTRIES" || die "could not create '$ENTRIES'"
 
-has_config() { [ -f "$KCONFIG" ] && grep -q "^CONFIG_$1=[ym]" "$KCONFIG"; }
+# Base cmdline shared by every entry (profiles append their rootflags=subvol=).
+compute_base_opts
 
-# ===========================================================================
-# Stage the artifacts shared by every entry (kernel, initrd(s), devicetree[dir]).
-# ===========================================================================
-
-# Base kernel command line (profiles append to this).
-if [ -f "$CONF_ROOT/cmdline" ]; then
-    BASE_OPTS="$(grep -Gv '^\s*#' "$CONF_ROOT/cmdline" | tr -s '[:space:]' ' ')"
-elif [ -f /usr/lib/kernel/cmdline ]; then
-    BASE_OPTS="$(grep -Gv '^\s*#' /usr/lib/kernel/cmdline | tr -s '[:space:]' ' ')"
-else
-    BASE_OPTS=""
-fi
-BASE_OPTS="$(trim "$BASE_OPTS")"
-
-# If the boot entries are named after the machine ID, pin systemd.machine_id= on the
-# kernel command line so the machine ID stays stable inside the initrd (where it isn't
-# directly accessible yet) and across factory reset on a volatile root.
-# (No-op unless entry-token == machine-id, e.g. machine-id-based entry naming.)
-if [ -n "$MACHINE_ID" ] && [ "$ENTRY_TOKEN" = "$MACHINE_ID" ] && ! echo "$BASE_OPTS" | grep -q "systemd.machine_id="; then
-    BASE_OPTS="$BASE_OPTS systemd.machine_id=$MACHINE_ID"
-fi
-
-# Console selection replicating the old features.d/default logic:
-# FIQ kernel  -> console=ttyFIQ0,1500000n8
-# mainline    -> console=ttyS0,1500000n8 console=ttyS4,1500000n8 fbcon=map:1
-if has_config FIQ_DEBUGGER_CONSOLE; then
-    BASE_OPTS="$(echo " $BASE_OPTS " | sed 's/ console=ttyS0,1500000n8 / /g')"
-    BASE_OPTS="$(trim "$BASE_OPTS") console=ttyFIQ0,1500000n8"
-else
-    BASE_OPTS="$(echo " $BASE_OPTS " | sed 's/ console=ttyS0,1500000n8 / /g')"
-    BASE_OPTS="$(trim "$BASE_OPTS") console=ttyS0,1500000n8"
-    BASE_OPTS="$(echo " $BASE_OPTS " | sed 's/ console=ttyS4,1500000n8 / /g')"
-    BASE_OPTS="$(trim "$BASE_OPTS") console=ttyS4,1500000n8"
-    BASE_OPTS="$(echo " $BASE_OPTS " | sed 's/ console=ttyFIQ0,1500000n8 / /g')"
-    BASE_OPTS="$(trim "$BASE_OPTS") fbcon=map:1"
-fi
-
-# Standard BLS sort-key (os-release IMAGE_ID, else ID): a spec-compliant reader uses
-# it to order entries
-SORT_KEY=""
-[ -r /etc/os-release ] && SORT_KEY="$(. /etc/os-release; printf '%s' "${IMAGE_ID:-$ID}")" || :
+# Standard BLS sort-key (os-release IMAGE_ID, else ID).
+SORT_KEY="$(os_sort_key)"
 
 # Kernel image.
 stage_file "$KERNEL_IMAGE" "$ENTRY_DIR_ABS/linux"
 KERNEL_ENTRY="$ENTRY_DIR/linux"
 
-# devicetree (single, optional) — copied into the entry dir.
+# devicetree (single, optional): copied into the entry dir.
 DEVICETREE=""; DEVICETREE_ENTRY=""
 [ -f "$CONF_ROOT/devicetree" ] && read -r DEVICETREE <"$CONF_ROOT/devicetree" || :
 if [ -n "$DEVICETREE" ]; then
@@ -144,33 +78,10 @@ if [ -n "$DEVICETREE" ]; then
     [ -n "$DEVICETREE_ENTRY" ] || die "device tree blob '$DEVICETREE' not found"
 fi
 
-# devicetreedir (U-Boot fdtdir extension) — referenced in place, opt-in via a
-# /etc/kernel/devicetreedir file containing a true boolean. Only when no single
-# devicetree was configured.
-DEVICETREEDIR_SRC=""; DEVICETREEDIR_REL=""
-if [ -z "$DEVICETREE" ] && [ -f "$CONF_ROOT/devicetreedir" ]; then
-    _v=""; read -r _v <"$CONF_ROOT/devicetreedir" || :
-    case "$_v" in
-        1|[Yy]|[Yy][Ee][Ss]|[Tt]|[Tt][Rr][Uu][Ee]|[Oo][Nn])
-            for p in $DTB_DIRS; do
-                [ -d "$p" ] || continue
-                for d in "$p"/*.dtb "$p"/*/*.dtb "$p"/*/*/*.dtb; do
-                    [ -f "$d" ] && { DEVICETREEDIR_SRC="$p"; break; }
-                done
-                [ -n "$DEVICETREEDIR_SRC" ] && break
-            done
-            [ -n "$DEVICETREEDIR_SRC" ] || die "no device-tree directory for $KERNEL_VERSION"
-            DEVICETREEDIR_REL="$(boot_rel "$DEVICETREEDIR_SRC")"   # /usr/lib/...; prefixed per entry
-            ;;
-    esac
-fi
-# Overlay directory: DT overlays sit flat next to the .dtb files (upstream layout),
-# i.e. in the same vendor dir the DTBs live in. Path == entry path while /boot is on
-# the rootfs.
-OVERLAY_DIR="${DEVICETREEDIR_SRC:-$DTB_DIR}/$VENDOR"
+# devicetreedir (U-Boot fdtdir extension) + overlay dir.
+discover_devicetreedir
 
-# initrd(s): from the kernel-install staging area, positional args, or the
-# distro's well-known names. Collect the in-entry paths once for reuse.
+# initrd(s): from the kernel-install staging area, positional args, or well-known names.
 shift "$INITRD_SHIFT"
 INITRD_ENTRIES=""
 add_initrd() { INITRD_ENTRIES="$INITRD_ENTRIES${INITRD_ENTRIES:+ }$1"; }
@@ -185,104 +96,29 @@ for i in "$KERNEL_INSTALL_STAGING_AREA"/microcode* "$@" "$KERNEL_INSTALL_STAGING
     stage_file "$i" "$ENTRY_DIR_ABS/$_bn"
     add_initrd "$ENTRY_DIR/$_bn"
 done
-# Fallbacks when no initrd was staged into kernel-install (e.g. initramfs-tools).
 [ -z "$INITRD_ENTRIES" ] && [ -f "$ENTRY_DIR_ABS/initrd" ] && add_initrd "$ENTRY_DIR/initrd"
 [ -z "$INITRD_ENTRIES" ] && [ -f "$BOOT_ROOT/initramfs-$KERNEL_VERSION.img" ] && add_initrd "$(boot_rel "$BOOT_ROOT/initramfs-$KERNEL_VERSION.img")"
 [ -z "$INITRD_ENTRIES" ] && [ -f "$BOOT_ROOT/initrd.img-$KERNEL_VERSION" ] && add_initrd "$(boot_rel "$BOOT_ROOT/initrd.img-$KERNEL_VERSION")"
 
-# ===========================================================================
-# Entry writer + overlay discovery.
-# ===========================================================================
+# Write this root's entry. apt/dpkg only ever touch the booted root, so emit ONLY its entry. The
+# entry-token (from kernel-install, baked per root as <NN>-flipperos-<subvol>) already carries the
+# menu band and IS the /boot/<token>/ staging dir, so there is no slot math here: match the booted
+# root to a profile line for its title/overlays, else treat it as a clone (title = name, own root).
+CUR_SUBVOL="$(current_subvol)"
+[ -n "$CUR_SUBVOL" ] || die "cannot determine current root subvol (findmnt)"
 
-# write_entry FILE TITLE OPTIONS FDTOVERLAYS
-write_entry() {
-    _f="$1"; _title="$2"; _opts="$3"; _fdtov="$4"
-    # devicetreedir is prefixed with THIS entry's root subvol (U-Boot reads subvolid 5)
-    _dtdir=""; [ -n "$DEVICETREEDIR_REL" ] && _dtdir="$(fdt_prefix "$_opts")$DEVICETREEDIR_REL"
-    {
-        echo "# Boot Loader Specification type#1 entry (Flipper One)"
-        echo "title      $_title"
-        echo "version    $KERNEL_VERSION"
-        [ -n "$MACHINE_ID" ] && [ "$ENTRY_TOKEN" = "$MACHINE_ID" ] && echo "machine-id $MACHINE_ID"
-        [ -n "$SORT_KEY" ] && echo "sort-key   $SORT_KEY"
-        [ -n "$_opts" ]  && echo "options    $_opts"
-        echo "linux      $KERNEL_ENTRY"
-        [ -n "$DEVICETREE_ENTRY" ] && echo "devicetree    $DEVICETREE_ENTRY"
-        [ -n "$_dtdir" ]           && echo "devicetreedir $_dtdir"
-        [ -n "$_fdtov" ]           && echo "devicetree-overlay $_fdtov"
-        for _i in $INITRD_ENTRIES; do echo "initrd     $_i"; done
-    } >"$_f"
-    return 0   # don't let a trailing empty conditional's status abort `set -e`
-}
-
-# Echo the space-separated paths of the named DT overlays (flat, next to the DTBs).
-# Returns non-zero with no output if any one is missing.
-overlay_paths() {  # $1 = subvol prefix (e.g. /@Desktop); remaining args = overlay names
-    _pfx="$1"; shift
-    _paths=""
-    for _n in "$@"; do
-        [ -f "$OVERLAY_DIR/$_n.dtbo" ] || return 1   # check the real on-disk path
-        _paths="$_paths${_paths:+ }$_pfx$OVERLAY_DIR/$_n.dtbo"
-    done
-    printf '%s' "$_paths"
-}
-
-# ===========================================================================
-# Write the entries.
-# ===========================================================================
-
-# Menu titles must fit the device's small screen. A title is "<version> <profile>";
-# cap the TOTAL length at TITLE_MAX chars by trimming the (long) version while keeping
-# the profile suffix intact. Entry filenames and the 'version' field keep the full
-# kernel version, which kernel-install needs to stay consistent with /lib/modules.
-make_title() {
-    _suf="$1"
-    _avail=$(( TITLE_MAX - ${#_suf} - 1 ))
-    if [ "$_avail" -ge 1 ]; then
-        printf '%s %s' "$(printf '%s' "$KERNEL_VERSION" | cut -c"1-$_avail")" "$_suf"
-    else
-        printf '%s' "$_suf" | cut -c"1-$TITLE_MAX"
-    fi
-}
-
-# Base entry == the [DESKTOP] profile.
-write_entry "$ENTRY_STEM.conf" "$(make_title '[DESKTOP]')" "$BASE_OPTS" ""
-
-[ -f "$PROFILES" ] || { log "$PROFILES not found, only the [DESKTOP] entry written"; exit 0; }
-
-while IFS='|' read -r tok suf extra gate dtbos legend; do
-    tok="$(echo "$tok" | tr -d '[:space:]')"
-    case "$tok" in ''|\#*) continue ;; esac
-
-    suf="$(trim "$suf")"
-    extra="$(trim "$extra")"
-    gate="$(trim "$gate")"
-    dtbos="$(trim "$dtbos")"
-
-    # gate may list several config symbols; all must be present.
-    gated_out=0; _failed_g=""
-    for g in $gate; do has_config "$g" || { gated_out=1; _failed_g="$g"; break; }; done
-    if [ "$gated_out" = 1 ]; then log "skip $tok (CONFIG_$_failed_g not set for $KERNEL_VERSION)"; continue; fi
-
-    opts="$BASE_OPTS"
-    [ -n "$extra" ] && opts="$opts $extra"
-
-    if [ -z "$dtbos" ]; then
-        write_entry "$ENTRY_STEM-$tok.conf" "$(make_title "$suf")" "$opts" ""
-        continue
-    fi
-
-    # A leading '!' on the overlay list = required (skip if overlays absent, like the
-    # old add_board_dtbo -z); otherwise optional (entry is still written, sans overlay).
-    required=0
-    case "$dtbos" in '!'*) required=1; dtbos="$(trim "${dtbos#\!}")" ;; esac
-
-    paths="$(overlay_paths "$(fdt_prefix "$opts")" $dtbos)" || paths=""
-    if [ -z "$paths" ] && [ "$required" = 1 ]; then
-        log "skip $tok (overlays not found for $KERNEL_VERSION)"
-        continue
-    fi
-    write_entry "$ENTRY_STEM-$tok.conf" "$(make_title "$suf")" "$opts" "$paths"
-done <"$PROFILES"
+matched=0
+if [ -f "$PROFILES" ]; then
+    while IFS='|' read -r tok suf extra gate dtbos legend; do
+        tok="$(echo "$tok" | tr -d '[:space:]')"
+        case "$tok" in ''|\#*) continue ;; esac
+        extra="$(trim "$extra")"
+        if [ "$(subvol_of "$extra")" = "$CUR_SUBVOL" ]; then
+            emit_entry "$(trim "$suf")" "$extra" "$(trim "$gate")" "$(trim "$dtbos")"
+            matched=1; break
+        fi
+    done <"$PROFILES"
+fi
+[ "$matched" = 1 ] || emit_entry "$(printf '%s' "$CUR_SUBVOL" | tr -d '@')" "rootflags=subvol=$CUR_SUBVOL" "" ""
 
 exit 0

--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -1,0 +1,332 @@
+#!/bin/sh
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# flipper-bls.sh - shared library for Flipper One BLS boot-entry generation.
+#
+# SOURCED, never executed. Defines the helpers used by the kernel-install plugin
+# (90-loaderentry.install) and the btrfs snapshot tooling (create_profile/rename_profile).
+# Functions read globals lazily (at call time), so callers set what they need first.
+# The kernel/initrd staging and devicetree(dir) handling are derived from systemd's
+# 90-loaderentry.install (LGPL-2.1-or-later).
+
+VENDOR=rockchip
+TITLE_MAX="${FLIPPER_TITLE_MAX:-26}"
+
+log() { [ "${KERNEL_INSTALL_VERBOSE:-0}" -gt 0 ] && echo "flipper-bls: $*" >&2; return 0; }
+die() { echo "flipper-bls: $*" >&2; exit 1; }
+trim() { printf '%s' "$1" | sed 's/^ *//; s/ *$//'; }
+# copy a file into the entry dir as root:root 0644
+stage_file() { install -m 0644 -o root -g root "$1" "$2" || die "could not copy '$1'"; }
+
+# absolute path under BOOT_ROOT -> path as it must appear inside a BLS entry (relative to the
+# boot partition; identical to the absolute path while /boot is on the rootfs). On Flipper One
+# BOOT_MNT=/ (/boot is a subvol on the root partition, never a separate boot partition).
+boot_rel() { if [ "${BOOT_MNT:-/}" = "/" ]; then printf '%s\n' "$1"; else printf '%s\n' "${1#"${BOOT_MNT}"}"; fi; }
+
+has_config() { [ -f "$KCONFIG" ] && grep -q "^CONFIG_$1=[ym]" "$KCONFIG"; }
+
+# Last rootflags=subvol= value in a cmdline/options string (empty if none).
+subvol_of() { printf '%s' "$1" | tr ' ' '\n' | sed -n 's/^rootflags=subvol=//p' | tail -n1; }
+
+# BLS sort-key from os-release (IMAGE_ID, else ID); empty if no os-release.
+os_sort_key() { [ -r /etc/os-release ] && ( . /etc/os-release; printf '%s' "${IMAGE_ID:-$ID}" ) || :; }
+
+# Set DTB_DIR + DTB_DIRS (primary dir + modules fallback) for the current $KERNEL_VERSION.
+set_dtb_dirs() { DTB_DIR="/usr/lib/linux-image-$KERNEL_VERSION"; DTB_DIRS="$DTB_DIR /usr/lib/modules/$KERNEL_VERSION/dtb"; }
+
+# Kernel entry-token for a root: <NN>-flipperos-<subvol sans @>, carrying the menu band + root id.
+# Empty NN -> plain flipperos-<name> (sorts above the numbered bands, like an unmappable root).
+make_token() {  # $1 = NN (may be empty)  $2 = subvol
+    _n="$(printf '%s' "$2" | tr -d '@')"
+    [ -n "$1" ] && printf '%s-flipperos-%s' "$1" "$_n" || printf 'flipperos-%s' "$_n"
+}
+
+# Reflink the shared /boot kernel + initrd for $KERNEL_VERSION into this $ENTRY_TOKEN's staging
+# dir (/boot/$ENTRY_TOKEN/$KERNEL_VERSION); btrfs shares the extents, so per-root dirs are ~free.
+# Sets KERNEL_ENTRY + INITRD_ENTRIES. For paths the kernel-install plugin does not stage itself
+# (the build fan-out and the clone tooling).
+stage_kernel_reflink() {
+    _sd="/boot/$ENTRY_TOKEN/$KERNEL_VERSION"
+    mkdir -p "$_sd" || die "cannot create $_sd"
+    cp -a --reflink=auto "/boot/vmlinuz-$KERNEL_VERSION" "$_sd/linux" || die "no /boot/vmlinuz-$KERNEL_VERSION"
+    KERNEL_ENTRY="$(boot_rel "$_sd/linux")"
+    INITRD_ENTRIES=""
+    if [ -e "/boot/initrd.img-$KERNEL_VERSION" ]; then
+        cp -a --reflink=auto "/boot/initrd.img-$KERNEL_VERSION" "$_sd/initrd.img-$KERNEL_VERSION"
+        INITRD_ENTRIES="$(boot_rel "$_sd/initrd.img-$KERNEL_VERSION")"
+    fi
+}
+
+# U-Boot reads the btrfs TOP LEVEL (subvolid 5), so in-entry devicetreedir/overlay paths need the
+# entry's own root subvol prefixed (/@<subvol>/usr/lib/...), taken from its rootflags=subvol=.
+# Set FDT_SUBVOL_PREFIX to override (e.g. "" if the root isn't a subvol).
+fdt_prefix() {  # $1 = options string -> "/<rootflags-subvol>" (or $FDT_SUBVOL_PREFIX if set)
+    if [ "${FDT_SUBVOL_PREFIX+x}" = x ]; then printf '%s' "$FDT_SUBVOL_PREFIX"; return 0; fi
+    _sv=$(subvol_of "$1")
+    [ -n "$_sv" ] && printf '/%s' "$_sv"
+    return 0
+}
+
+# btrfs subvol of the currently-booted root (e.g. @Desktop); empty if not a subvol.
+current_subvol() { findmnt -nro FSROOT / 2>/dev/null | sed 's,^/,,'; }
+
+# Remove loader entries whose options select SUBVOL and whose version == VERSION. Content-based
+# (token/filename-agnostic), so it leaves every other root's entries untouched. Uses $ENTRIES.
+remove_entries() {  # $1 = subvol  $2 = version
+    [ -n "$1" ] && [ -n "$2" ] || return 0
+    for _c in "${ENTRIES:-/boot/loader/entries}"/*.conf; do
+        [ -f "$_c" ] || continue
+        [ "$(awk '$1=="version"{print $2; exit}' "$_c")" = "$2" ] || continue
+        _es="$(awk '$1=="options"{for(i=2;i<=NF;i++) if($i ~ /^rootflags=subvol=/) s=$i}
+                    END{sub(/^rootflags=subvol=/,"",s); print s}' "$_c")"
+        [ "$_es" = "$1" ] && rm -f "$_c"
+    done
+    return 0   # a non-matching last entry must not fail the loop under set -e
+}
+
+# Tear down a whole root: remove EVERY entry that selects SUBVOL (all versions) and each one's
+# /boot/<token>/ staging tree. The staging dir is derived from the entry's own 'linux' line, so it
+# works no matter how the token was computed. For delete_profile/rename_profile (whole-profile ops).
+# Uses $ENTRIES. Prints what it removes to stderr.
+remove_root_entries() {  # $1 = subvol
+    [ -n "$1" ] || return 0
+    for _c in "${ENTRIES:-/boot/loader/entries}"/*.conf; do
+        [ -f "$_c" ] || continue
+        _es="$(awk '$1=="options"{for(i=2;i<=NF;i++) if($i ~ /^rootflags=subvol=/) s=$i}
+                    END{sub(/^rootflags=subvol=/,"",s); print s}' "$_c")"
+        [ "$_es" = "$1" ] || continue
+        _lx="$(awk '$1=="linux"{print $2; exit}' "$_c")"
+        rm -f "$_c"; echo "removed boot entry $_c" >&2
+        case "$_lx" in /boot/*/*/linux)
+            _td="${_lx%/*/linux}"; [ "$_td" != /boot ] && rm -rf "$_td" ;;
+        esac
+    done
+    return 0
+}
+
+# Base menu slot (900,800,700,... by flipper-profiles position) for the profile $1 belongs to.
+# $1 is a btrfs-PARENT name. It anchors on an ACTUAL profile: the exact name (@Desktop) or its
+# golden base / snapshot (@Desktop_stock, @Desktop_<stamp>: profile name followed by '_'). A
+# hyphen-suffixed clone (@Desktop-2) must NOT match here, so origin_base_depth can walk THROUGH
+# it to count clone depth. Empty if none. Steps of 100 leave room for ~99 variants per band.
+profile_base_nn() {
+    _want="$1"; _pf="${PROFILES:-/etc/kernel/flipper-profiles}"; [ -f "$_pf" ] || return 0
+    _j=0
+    while IFS='|' read -r _t _s _e _g _d _l; do
+        _t="$(echo "$_t" | tr -d '[:space:]')"; case "$_t" in ''|\#*) continue ;; esac
+        _sv="$(subvol_of "$_e" | tr -d '[:space:]')"
+        [ -n "$_sv" ] && case "$_want" in "$_sv"|"$_sv"_*) printf '%03d' "$((900 - _j * 100))"; return 0 ;; esac
+        _j=$((_j + 1))
+    done <"$_pf"
+    return 0
+}
+
+# Origin-profile base slot AND clone depth for a derived root. Clone/snapshot names are arbitrary
+# and can chain (a snapshot of a snapshot), so instead of matching the name we WALK the btrfs
+# parent_uuid chain up from the subvol at $1, counting hops, until an ancestor is a listed profile
+# or its golden base (profile_base_nn). Prints "BASE DEPTH" (e.g. "900 2" = desktop, grandparent);
+# depth is the hop count (1 = direct clone, 2 = clone of a clone, ...). Empty if none maps or no
+# btrfs. One `subvolume list` covers the whole fs (ancestors need not be mounted).
+origin_base_depth() {  # $1 = mounted path (default /)
+    command -v btrfs >/dev/null 2>&1 || return 0
+    _mp="${1:-/}"
+    _cur="$(btrfs subvolume show "$_mp" 2>/dev/null | sed -n 's/.*[Pp]arent UUID:[[:space:]]*//p' | head -n1)"
+    [ -n "$_cur" ] && [ "$_cur" != "-" ] || return 0
+    # fs-wide table: one row "uuid parent_uuid name" per subvolume
+    _tbl="$(btrfs subvolume list -qu "$_mp" 2>/dev/null | awk '{ u="-"; p="-"; for(i=1;i<NF;i++){ if($i=="uuid")u=$(i+1); else if($i=="parent_uuid")p=$(i+1) } print u, p, $NF }')"
+    _seen=" "; _depth=0
+    while [ -n "$_cur" ] && [ "$_cur" != "-" ]; do
+        case "$_seen" in *" $_cur "*) break ;; esac        # cycle guard
+        _seen="$_seen$_cur "
+        _row="$(printf '%s\n' "$_tbl" | awk -v u="$_cur" '$1==u{print $2, $3; exit}')"
+        [ -n "$_row" ] || break
+        _depth=$((_depth + 1))
+        _pn="${_row#* }"; _pn="${_pn##*/}"                 # this ancestor's name (basename)
+        _bn="$(profile_base_nn "$_pn")"
+        [ -n "$_bn" ] && { printf '%s %s' "$_bn" "$_depth"; return 0; }
+        _cur="${_row%% *}"                                 # follow parent_uuid to the grandparent
+    done
+    return 0
+}
+
+# Clone menu slot for a derived root: origin base + clone-depth (direct clone -> base+1,
+# clone of a clone -> base+2, ...), so clones sit just above the profile (whose factory and
+# in-profile-install entries share the base slot). $1 = mounted path; $2 = optional origin hint
+# (the name it was restored FROM). Prefers the parent-chain walk (true depth); if that yields
+# nothing (e.g. parent_uuid left dangling by a move/receive) it falls back to the hint as a direct
+# clone (depth 1 -> base+1). Prints a 3-digit NN, or empty if unresolved.
+clone_slot() {  # $1 = mounted path (default /); $2 = origin hint (optional)
+    _cs_bd="$(origin_base_depth "${1:-/}")"
+    if [ -n "$_cs_bd" ]; then
+        printf '%03d' "$(( ${_cs_bd%% *} + ${_cs_bd#* } ))"; return 0
+    fi
+    if [ -n "${2:-}" ]; then
+        _cs_b="$(profile_base_nn "${2##*/}")"
+        [ -n "$_cs_b" ] && printf '%03d' "$(( _cs_b + 1 ))"
+    fi
+    return 0
+}
+
+# Menu titles must fit the small screen: cap total at TITLE_MAX by trimming the (long) version
+# while keeping the suffix intact. (Filenames + the 'version' field keep the full version.)
+make_title() {
+    _suf="$1"
+    _avail=$(( TITLE_MAX - ${#_suf} - 1 ))
+    if [ "$_avail" -ge 1 ]; then
+        printf '%s %s' "$(printf '%s' "$KERNEL_VERSION" | cut -c"1-$_avail")" "$_suf"
+    else
+        printf '%s' "$_suf" | cut -c"1-$TITLE_MAX"
+    fi
+}
+
+# write_entry FILE TITLE OPTIONS FDTOVERLAYS
+write_entry() {
+    _f="$1"; _title="$2"; _opts="$3"; _fdtov="$4"
+    # devicetreedir is prefixed with THIS entry's root subvol (U-Boot reads subvolid 5)
+    _dtdir=""; [ -n "$DEVICETREEDIR_REL" ] && _dtdir="$(fdt_prefix "$_opts")$DEVICETREEDIR_REL"
+    {
+        echo "# Boot Loader Specification type#1 entry (Flipper One)"
+        echo "title      $_title"
+        echo "version    $KERNEL_VERSION"
+        [ -n "$MACHINE_ID" ] && [ "$ENTRY_TOKEN" = "$MACHINE_ID" ] && echo "machine-id $MACHINE_ID"
+        [ -n "$SORT_KEY" ] && echo "sort-key   $SORT_KEY"
+        [ -n "$_opts" ]  && echo "options    $_opts"
+        echo "linux      $KERNEL_ENTRY"
+        [ -n "$DEVICETREE_ENTRY" ] && echo "devicetree    $DEVICETREE_ENTRY"
+        [ -n "$_dtdir" ]           && echo "devicetreedir $_dtdir"
+        [ -n "$_fdtov" ]           && echo "devicetree-overlay $_fdtov"
+        for _ird in $INITRD_ENTRIES; do echo "initrd     $_ird"; done
+    } >"$_f"
+    return 0   # don't let a trailing empty conditional's status abort `set -e`
+}
+
+# Echo the space-separated paths of the named DT overlays (flat, next to the DTBs).
+# Returns non-zero with no output if any one is missing.
+overlay_paths() {  # $1 = subvol prefix (e.g. /@Desktop); remaining args = overlay names
+    _pfx="$1"; shift
+    _paths=""
+    for _n in "$@"; do
+        [ -f "$OVERLAY_DIR/$_n.dtbo" ] || return 1   # check the real on-disk path
+        _paths="$_paths${_paths:+ }$_pfx$OVERLAY_DIR/$_n.dtbo"
+    done
+    printf '%s' "$_paths"
+}
+
+# Set BASE_OPTS from CONF_ROOT/cmdline (root=UUID + policy) + this kernel's console layout.
+# FIQ kernel -> console=ttyFIQ0 ; mainline -> console=ttyS0 + ttyS4 + fbcon=map:1.
+compute_base_opts() {
+    if [ -f "$CONF_ROOT/cmdline" ]; then
+        BASE_OPTS="$(grep -Gv '^\s*#' "$CONF_ROOT/cmdline" | tr -s '[:space:]' ' ')"
+    elif [ -f /usr/lib/kernel/cmdline ]; then
+        BASE_OPTS="$(grep -Gv '^\s*#' /usr/lib/kernel/cmdline | tr -s '[:space:]' ' ')"
+    else
+        BASE_OPTS=""
+    fi
+    BASE_OPTS="$(trim "$BASE_OPTS")"
+    # Pin systemd.machine_id= only when entries are named after the machine-id (no-op otherwise).
+    if [ -n "$MACHINE_ID" ] && [ "$ENTRY_TOKEN" = "$MACHINE_ID" ] && ! echo "$BASE_OPTS" | grep -q "systemd.machine_id="; then
+        BASE_OPTS="$BASE_OPTS systemd.machine_id=$MACHINE_ID"
+    fi
+    if has_config FIQ_DEBUGGER_CONSOLE; then
+        BASE_OPTS="$(echo " $BASE_OPTS " | sed 's/ console=ttyS0,1500000n8 / /g')"
+        BASE_OPTS="$(trim "$BASE_OPTS") console=ttyFIQ0,1500000n8"
+    else
+        BASE_OPTS="$(echo " $BASE_OPTS " | sed 's/ console=ttyS0,1500000n8 / /g')"
+        BASE_OPTS="$(trim "$BASE_OPTS") console=ttyS0,1500000n8"
+        BASE_OPTS="$(echo " $BASE_OPTS " | sed 's/ console=ttyS4,1500000n8 / /g')"
+        BASE_OPTS="$(trim "$BASE_OPTS") console=ttyS4,1500000n8"
+        BASE_OPTS="$(echo " $BASE_OPTS " | sed 's/ console=ttyFIQ0,1500000n8 / /g')"
+        BASE_OPTS="$(trim "$BASE_OPTS") fbcon=map:1"
+    fi
+}
+
+# Set DEVICETREEDIR_REL + OVERLAY_DIR for $KERNEL_VERSION (needs DTB_DIR/DTB_DIRS set). Opt-in via a
+# /etc/kernel/devicetreedir boolean, only when no single 'devicetree' is configured. Always the
+# kernel's own installed DTB dir (first existing of DTB_DIRS), never inspected or borrowed; if it
+# ships none, no devicetreedir is written and U-Boot falls back to its control FDT.
+discover_devicetreedir() {
+    DEVICETREEDIR_SRC=""; DEVICETREEDIR_REL=""
+    if [ -z "${DEVICETREE:-}" ] && [ -f "$CONF_ROOT/devicetreedir" ]; then
+        _v=""; read -r _v <"$CONF_ROOT/devicetreedir" || :
+        case "$_v" in
+            1|[Yy]|[Yy][Ee][Ss]|[Tt]|[Tt][Rr][Uu][Ee]|[Oo][Nn])
+                for p in $DTB_DIRS; do
+                    [ -d "$p" ] && { DEVICETREEDIR_SRC="$p"; break; }
+                done
+                if [ -n "$DEVICETREEDIR_SRC" ]; then
+                    DEVICETREEDIR_REL="$(boot_rel "$DEVICETREEDIR_SRC")"   # /usr/lib/...; prefixed per entry
+                else
+                    log "$KERNEL_VERSION ships no DTB dir; omitting devicetreedir (U-Boot control FDT)"
+                fi
+                ;;
+        esac
+    fi
+    # DT overlays sit flat next to the .dtb files (upstream layout), in the same vendor dir.
+    OVERLAY_DIR="${DEVICETREEDIR_SRC:-$DTB_DIR}/$VENDOR"
+}
+
+# emit_entry SUF EXTRA GATE DTBOS -> write one BLS entry for the current $ENTRY_TOKEN.
+# The filename is $ENTRY_TOKEN-$KERNEL_VERSION.conf. The token is <NN>-flipperos-<subvol>, so it
+# LEADS with the 3-digit menu band and U-Boot's bls (filename sort, descending) orders entries by
+# band then version. EXTRA carries this entry's rootflags=subvol=; BASE_OPTS has none, so there is
+# exactly one per entry. Honours gate (skip if a CONFIG_ symbol is missing) + overlays.
+emit_entry() {
+    _suf="$1"; _extra="$2"; _gate="$3"; _dtbos="$4"
+
+    # gate may list several config symbols; all must be present in this kernel.
+    for _g in $_gate; do
+        has_config "$_g" || { log "skip $ENTRY_TOKEN (CONFIG_$_g not set for $KERNEL_VERSION)"; return 0; }
+    done
+
+    _opts="$BASE_OPTS"
+    [ -n "$_extra" ] && _opts="$_opts $_extra"
+    _fn="$ENTRIES/$ENTRY_TOKEN-$KERNEL_VERSION.conf"
+
+    if [ -z "$_dtbos" ]; then
+        write_entry "$_fn" "$(make_title "$_suf")" "$_opts" ""
+        return 0
+    fi
+
+    # A leading '!' on the overlay list = required (skip the entry if the overlays are
+    # absent); otherwise optional (the entry is still written, sans overlay).
+    _required=0
+    case "$_dtbos" in '!'*) _required=1; _dtbos="$(trim "${_dtbos#\!}")" ;; esac
+
+    _paths="$(overlay_paths "$(fdt_prefix "$_opts")" $_dtbos)" || _paths=""
+    if [ -z "$_paths" ] && [ "$_required" = 1 ]; then
+        log "skip $ENTRY_TOKEN (overlays not found for $KERNEL_VERSION)"
+        return 0
+    fi
+    write_entry "$_fn" "$(make_title "$_suf")" "$_opts" "$_paths"
+}
+
+# flipper_write_entry <subvol> <mounted-path> [<origin-hint>]: write a BLS entry for an EXISTING
+# writable top-level subvol (a restored snapshot/clone). Token = <NN>-flipperos-<name>, NN from
+# clone_slot (origin base + depth; the origin hint is the dangling-parent fallback). Reflinks
+# the shared /boot kernel into the root's own /boot/<token>/ dir. Sourced by create_profile /
+# rename_profile. Returns non-zero (no exit) on a recoverable problem.
+flipper_write_entry() {
+    _name="$1"; _snap="$2"; _origin="${3:-}"
+    { [ -n "$_name" ] && [ -d "$_snap" ]; } || { echo "flipper-bls: usage: flipper_write_entry <name> <mounted-path>" >&2; return 1; }
+    ENTRIES="${ENTRIES:-/boot/loader/entries}"
+    CONF_ROOT="${KERNEL_INSTALL_CONF_ROOT:-/etc/kernel}"
+    MACHINE_ID=""; DEVICETREE=""; DEVICETREE_ENTRY=""
+    # version from the target's OWN tree, so modules + dtbs are self-consistent
+    KERNEL_VERSION="$(ls -1d "$_snap"/usr/lib/linux-image-* 2>/dev/null | sed 's,.*/linux-image-,,' | sort -V | tail -n1)"
+    [ -n "$KERNEL_VERSION" ] || { echo "flipper-bls: no /usr/lib/linux-image-* inside $_name" >&2; return 1; }
+    [ -e "/boot/vmlinuz-$KERNEL_VERSION" ] || { echo "flipper-bls: kernel not in /boot: vmlinuz-$KERNEL_VERSION" >&2; return 1; }
+    KCONFIG="/boot/config-$KERNEL_VERSION"
+    set_dtb_dirs
+    SORT_KEY="$(os_sort_key)"
+    ENTRY_TOKEN="$(make_token "$(clone_slot "$_snap" "$_origin")" "$_name")"
+    mkdir -p "$ENTRIES" || { echo "flipper-bls: cannot create $ENTRIES" >&2; return 1; }
+    compute_base_opts
+    stage_kernel_reflink
+    # devicetreedir is the target root's OWN kernel dir (KERNEL_VERSION came from it, so it exists).
+    DEVICETREEDIR_REL="/usr/lib/linux-image-$KERNEL_VERSION"
+    OVERLAY_DIR="$DTB_DIR/$VENDOR"
+    # pin the root's own entry-token so a later runtime apt install in it lands in the same band
+    mkdir -p "$_snap/etc/kernel" && printf '%s\n' "$ENTRY_TOKEN" > "$_snap/etc/kernel/entry-token"
+    emit_entry "$(printf '%s' "$_name" | tr -d '@')" "rootflags=subvol=$_name" "" ""
+    echo "flipper-bls: wrote entry for $_name (kernel $KERNEL_VERSION, token $ENTRY_TOKEN)"
+}


### PR DESCRIPTION
Per-profile BLS boot entries for the per-subvolume profile system.

Each profile (@Desktop/@TV-Media-Box/@Router/@Minimal) is a btrfs root. Every bootable
entry lives under a per-root kernel entry-token of the form `<NN>-flipperos-<subvol>`, so
the token is at once the `/boot/<token>/<version>/` staging dir and the
`<token>-<version>.conf` filename. U-Boot's bls sorts by filename, so NN is the menu band
(900/800/700/600, step 100) and versions sort within it. Clones sit just above their
profile at base+clone-depth (a direct clone 901, a clone of a clone 902, ...), derived
from the btrfs snapshot parent chain. This makes the token, the staged files, and the
menu position all agree (spec-conventional `<entry-token>-<version>.conf`).

- flipper-profiles: one line per profile; line order is the menu band order.
- flipper-bls.sh: shared library, sourced by the plugin, the build fan-out, and the
  btrfs snapshot tooling: make_token, stage_kernel_reflink (reflink the shared /boot
  kernel per root), emit_entry, remove_entries, clone_slot (band from the btrfs parent
  chain), discover_devicetreedir, flipper_write_entry.
- discover_devicetreedir points devicetreedir at each kernel's own installed DTB dir
  (never inspected or borrowed); a kernel shipping no DTB dir gets no devicetreedir and
  boots on U-Boot's control FDT, so a stock apt kernel install never fails.
- 90-loaderentry.install: runtime kernel-install plugin, booted root only; the band is
  in the pre-baked token, so it does no computation.
- debian-rk3576-img.yaml: drop rootflags=subvol= and console=ttyS0 from the cmdline;
  bake @Minimal's token before the kernel install; fan the installed kernel(s) out to
  every profile (reflinked `/boot/<token>/` + one entry each).

Runtime apt installs and clones (create_profile/rename_profile, in the separate
btrfs-tools repo) reuse the same library, so each lands in its own `/boot/<token>/` band.
