### PR TITLE
Slim the build: prune apt cruft, drop plasma-discover, zstd ospack

### DIFF
--- a/build-rootfs-img.sh
+++ b/build-rootfs-img.sh
@@ -20,7 +20,7 @@ fi
 
 mkdir -p "$IMG_OUT"
 
-if [ ! -f "$IMG_OUT"/debian-ospack.tar.gz -o "$UPDATE_OSPACK" ]; then
+if [ ! -f "$IMG_OUT"/debian-ospack.tar.zst -o "$UPDATE_OSPACK" ]; then
 	./build-ospack.sh
 fi
 

--- a/debian-rk3576-img.yaml
+++ b/debian-rk3576-img.yaml
@@ -14,8 +14,8 @@ architecture: arm64
 sectorsize: {{ $sectorsize }}
 actions:
   - action: unpack
-    description: Load a tarball of the root filesystem
-    file: debian-ospack.tar.gz
+    description: Load the ospack archive
+    file: debian-ospack.tar.zst
 
   # debos formats btrfs (default flags, random FSUUID), mounts the top level at
   # $IMAGEMNTDIR, and records the standard root fstab line + root=UUID.

--- a/debian-rk3576-img.yaml
+++ b/debian-rk3576-img.yaml
@@ -133,6 +133,15 @@ actions:
     chroot: true
     command: find /var/cache/linux-kernel -name linux-image-\*.deb -a ! -name \*-dbg_\* -print0 | xargs -0 apt install -y
 
+  - action: run
+    description: Prune orphaned packages and apt cache
+    chroot: true
+    command: |
+      set -eu
+      apt-get autoremove --purge -y
+      apt-get clean
+      rm -rf /var/lib/apt/lists/*
+
   # The kernel-install plugin only wrote @Minimal's entry (the build root). Fan the installed
   # kernel(s) out to every profile: one entry + a reflinked /boot/<token>/ per profile per version
   # (token = <NN>-flipperos-<subvol>, NN from the flipper-profiles order). The shared logic lives in
@@ -243,6 +252,14 @@ actions:
       - sddm
       - sddm-theme-breeze
       - systemsettings
+  - action: run
+    description: Prune orphaned packages and apt cache
+    chroot: true
+    command: |
+      set -eu
+      apt-get autoremove --purge -y
+      apt-get clean
+      rm -rf /var/lib/apt/lists/*
   - action: overlay
     description: KDE profile config (sddm autologin, plasma, wallpaper)
     source: overlays/profile-kde
@@ -285,6 +302,14 @@ actions:
       - cage
       - kodi
       - kodi-eventclients-kodi-send
+  - action: run
+    description: Prune orphaned packages and apt cache
+    chroot: true
+    command: |
+      set -eu
+      apt-get autoremove --purge -y
+      apt-get clean
+      rm -rf /var/lib/apt/lists/*
   - action: overlay
     description: TV media box profile config (kodi, enabled under multi-user)
     source: overlays/profile-tv-media-box

--- a/debian-rk3576-img.yaml
+++ b/debian-rk3576-img.yaml
@@ -245,7 +245,6 @@ actions:
       - konsole
       - kscreen
       - mpv
-      - plasma-discover
       - plasma-nm
       - plasma-systemmonitor
       - powerdevil

--- a/debian-rk3576-ospack.yaml
+++ b/debian-rk3576-ospack.yaml
@@ -263,5 +263,6 @@ actions:
     command: chown -R user:user /home/user
 
   - action: pack
-    description: Save a tarball of the root filesystem
-    file: debian-ospack.tar.gz
+    description: Save the ospack archive
+    file: debian-ospack.tar.zst
+    compression: zstd


### PR DESCRIPTION
Three upstream-independent build tweaks on top of the merged BLS work in `dev`. (The image-compression and debos-partition changes were split into separate branches — see the bottom.)

## Prune orphaned packages and clean apt cache
`apt-get autoremove --purge` + `apt-get clean` + `rm -rf /var/lib/apt/lists/*` after the `@Minimal` base, `@Desktop`, and `@TV-Media-Box` package installs. Drops orphaned deps (e.g. `libllvm19`, `libz3-4`), the cached `.deb`s, and the package index lists from the shipped image.

## Drop plasma-discover from @Desktop
The GUI software store isn't needed on the appliance.

## Use zstd for the ospack archive
The `debos pack`/`unpack` intermediate is now `debian-ospack.tar.zst` (`compression: zstd`; `unpack` auto-detects). Faster pack + unpack at a better ratio; the ospack archive is a pure build intermediate that never ships.

## Requires a buildbot config change
The ospack archive `.gz` → `.zst` rename means any buildbot artifact step that globs `debian-ospack.tar.gz` must be updated to `.zst`, or it fails. That lives in the buildbot master config, not in this repo.

## Split into separate branches (blocked on upstream bumps)
- `image-zstd-rockusb` — final-image compression `pigz` → `zstd` (`build-images.sh`, Dockerfile). Needs rockusb to flash `.zst` images.
- `debos-image-partition` — newer debos image-partition features (`debian-rk3576-img.yaml`). Needs the debos bump.