### PR TITLE
overlays/sbin: btrfs profile and snapshot tools

### DIFF
--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -4,7 +4,7 @@
 # flipper-bls.sh - shared library for Flipper One BLS boot-entry generation.
 #
 # SOURCED, never executed. Defines the helpers used by the kernel-install plugin
-# (90-loaderentry.install) and the btrfs snapshot tooling (create_profile/rename_profile).
+# (90-loaderentry.install) and the btrfs snapshot tooling (create-profile/rename-profile).
 # Functions read globals lazily (at call time), so callers set what they need first.
 # The kernel/initrd staging and devicetree(dir) handling are derived from systemd's
 # 90-loaderentry.install (LGPL-2.1-or-later).
@@ -86,7 +86,7 @@ remove_entries() {  # $1 = subvol  $2 = version
 
 # Tear down a whole root: remove EVERY entry that selects SUBVOL (all versions) and each one's
 # /boot/<token>/ staging tree. The staging dir is derived from the entry's own 'linux' line, so it
-# works no matter how the token was computed. For delete_profile/rename_profile (whole-profile ops).
+# works no matter how the token was computed. For delete-profile/rename-profile (whole-profile ops).
 # Uses $ENTRIES. Prints what it removes to stderr.
 remove_root_entries() {  # $1 = subvol
     [ -n "$1" ] || return 0
@@ -303,8 +303,8 @@ emit_entry() {
 # flipper_write_entry <subvol> <mounted-path> [<origin-hint>]: write a BLS entry for an EXISTING
 # writable top-level subvol (a restored snapshot/clone). Token = <NN>-flipperos-<name>, NN from
 # clone_slot (origin base + depth; the origin hint is the dangling-parent fallback). Reflinks
-# the shared /boot kernel into the root's own /boot/<token>/ dir. Sourced by create_profile /
-# rename_profile. Returns non-zero (no exit) on a recoverable problem.
+# the shared /boot kernel into the root's own /boot/<token>/ dir. Sourced by create-profile /
+# rename-profile. Returns non-zero (no exit) on a recoverable problem.
 flipper_write_entry() {
     _name="$1"; _snap="$2"; _origin="${3:-}"
     { [ -n "$_name" ] && [ -d "$_snap" ]; } || { echo "flipper-bls: usage: flipper_write_entry <name> <mounted-path>" >&2; return 1; }

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# flipper-btrfs.sh - shared helpers for the Flipper One btrfs profile/snapshot tooling.
+#
+# SOURCED, never executed. Defines the preamble (root/btrfs checks), the top-level
+# (subvolid=5) mount, and the small helpers duplicated across create-profile,
+# create-snapshot, delete-profile, delete-snapshot, list-profiles, list-snapshots,
+# btrfs-maintenance, receive-snapshot, rename-profile, send-snapshot and btrfs-show-space.
+# Functions read globals lazily, so callers set what they need first.
+
+die() { echo "Error: $*" >&2; exit 1; }
+
+need_root()  { [ "$(id -u)" -eq 0 ] || die "Must run as root (use sudo)"; }
+need_btrfs() { command -v btrfs >/dev/null 2>&1 || die "Btrfs-progs not installed"; }
+need_cmd()   { command -v "$1" >/dev/null 2>&1 || die "Command not installed: $1${2:+ ($2)}"; }
+
+# Ask on stderr, read stdin; abort unless yes. $1 may span lines.
+confirm() {
+    printf '%s [y/N] ' "$1" >&2
+    read -r _a || die "Aborted"
+    case "$_a" in y|Y|yes|YES) return 0 ;; *) die "Aborted" ;; esac
+}
+
+# Reserved subvolumes the tools must never write/delete/rename.
+is_reserved_subvol() {
+    case "$1" in
+        @|@home|@root|@snapshots|@var-log|@var-cache|boot) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Mount the btrfs top level (subvolid=5) at a temp dir and arrange teardown on EXIT.
+# Sets ROOTDEV and TOP. Extra temp files to remove: assign them to TOP_TMPFILES first.
+mount_top() {
+    ROOTDEV=$(findmnt -no SOURCE / | sed 's/\[.*//')
+    [ -n "$ROOTDEV" ] || die "Cannot determine root device"
+    TOP=$(mktemp -d)
+    trap 'top_cleanup' EXIT
+    _err=$(mount -o subvolid=5 "$ROOTDEV" "$TOP" 2>&1) || die "Mount failed: $_err"
+}
+top_cleanup() {
+    [ -n "${TOP:-}" ] && { umount "$TOP" 2>/dev/null || true; rmdir "$TOP" 2>/dev/null || true; }
+    [ -n "${TOP_TMPFILES:-}" ] && rm -f $TOP_TMPFILES
+    return 0
+}
+
+# One field from `btrfs subvolume show` output. $1 = output text, $2 = key label.
+get() { printf '%s\n' "$1" | awk -v k="$2" -F':[[:space:]]+' 'index($0,k){print $2; exit}'; }
+
+subvol_id() { get "$(btrfs subvolume show "$1" 2>/dev/null)" "Subvolume ID"; }
+booted_id() { subvol_id /; }
+
+# True if the subvolume at $1 is read-only.
+is_ro() {
+    case "$(btrfs subvolume show "$1" 2>/dev/null | awk -F':[[:space:]]+' '/Flags/{print $2}')" in
+        *readonly*) return 0 ;; *) return 1 ;;
+    esac
+}
+
+human() { numfmt --to=iec-i --suffix=B --format='%.1f' "${1:-0}" 2>/dev/null || printf '%s' "${1:-0}"; }
+
+# uuid -> "id <tab> path" for every subvolume, so parents resolve by UUID. $1 = top, $2 = out file.
+build_uuid_map() {
+    btrfs subvolume list -qu "$1" 2>/dev/null | awk '
+    {
+        id=""; u=""; p=""
+        for (i = 1; i <= NF; i++) {
+            if      ($i == "ID")   id = $(i+1)
+            else if ($i == "uuid") u  = $(i+1)
+            else if ($i == "path") { p = $(i+1); for (j = i+2; j <= NF; j++) p = p" "$j; break }
+        }
+        if (u != "" && u != "-") print u"\t"id"\t"p
+    }' > "$2"
+}
+
+# Resolve a parent UUID to "name (id)" via a map from build_uuid_map. $1 = map file, $2 = uuid.
+parent_of() {
+    case "$2" in ''|'-') printf '%s' "-"; return ;; esac
+    awk -F'\t' -v u="$2" '
+        $1==u { n=$3; sub(/.*\//,"",n); printf "%s (%s)", n, $2; f=1 }
+        END   { if (!f) printf "-" }' "$1"
+}
+
+# Print a TSV file with every column padded to its max width; last field left unpadded.
+align_table() {
+    awk -F'\t' '
+    { line[NR]=$0; nf=split($0,a,"\t"); for (i=1;i<=nf;i++) if (length(a[i])>w[i]) w[i]=length(a[i]) }
+    END {
+        for (r=1; r<=NR; r++) {
+            n=split(line[r], a, "\t"); out=""
+            for (i=1; i<=n; i++) out = (i<n) ? out sprintf("%-*s  ", w[i], a[i]) : out a[i]
+            print out
+        }
+    }' "$1"
+}

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -30,6 +30,21 @@ is_reserved_subvol() {
     esac
 }
 
+# Serialize our writers: an exclusive advisory lock (flock) held on FD 9 for the script's
+# lifetime, released on any exit (including crash/kill). The holder records "PID (tool)" in the
+# file so a blocked waiter can say who it is waiting on. Read-only tools do not take it, and it
+# does NOT guard against concurrent native `btrfs` commands, which honor no lock.
+LOCK_FILE=/run/flipper-btrfs.lock
+set_lock() {
+    exec 9<>"$LOCK_FILE" || die "Cannot open lock $LOCK_FILE"   # <> = don't truncate the holder line
+    if ! flock -w 0 9 2>/dev/null; then
+        _h=$(cat "$LOCK_FILE" 2>/dev/null); [ -n "$_h" ] || _h="PID unknown"
+        echo "Another flipper-btrfs operation is in progress ($_h); waiting for it to finish..." >&2
+        flock 9 || die "Cannot acquire lock $LOCK_FILE"
+    fi
+    printf 'PID %s (%s)\n' "$$" "${0##*/}" >"$LOCK_FILE" || true
+}
+
 # Mount the btrfs top level (subvolid=5) at a temp dir and arrange teardown on EXIT.
 # Sets ROOTDEV and TOP. Extra temp files to remove: assign them to TOP_TMPFILES first.
 mount_top() {

--- a/overlays/usr/local/sbin/btrfs-maintenance
+++ b/overlays/usr/local/sbin/btrfs-maintenance
@@ -1,0 +1,40 @@
+#!/bin/sh
+# btrfs-maintenance <check|fix|dedup|balance|all>
+#   check   - read-only scrub (verify checksums, no writes)
+#   fix     - scrub with repair (only where a good copy exists: DUP metadata yes,
+#             single-profile data cannot self-heal)
+#   dedup   - offline dedup via duperemove across ALL subvolumes (separate package)
+#   balance - light filtered balance to reclaim partly-empty chunks
+#   all     - check + dedup + balance
+# Offline 'btrfs check --repair' needs an UNMOUNTED fs (boot elsewhere).
+#
+# Example:
+#   btrfs-maintenance all   # scrub + dedup + balance across all profile/snapshot subvols
+set -eu
+. /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+need_root
+need_btrfs
+MNT=/
+
+usage() { sed -n '2,9p' "$0"; exit 1; }
+
+# Dedup across every profile/snapshot: duperemove must run on the btrfs TOP LEVEL (subvolid=5),
+# where all subvolumes appear as subdirectories. Run on / and it only sees the booted root.
+# Read-only subvols (@snapshots/*, *_stock) are skipped by duperemove (can't dedup a RO target).
+do_dedup() {
+    need_cmd duperemove
+    mount_top
+    duperemove -dhr "$TOP" || die "Duperemove failed (rc=$?)"
+}
+
+[ $# -ge 1 ] || usage
+case "$1" in
+    check)   btrfs scrub start -B -r "$MNT" ;;
+    fix)     btrfs scrub start -B "$MNT" ;;
+    dedup)   do_dedup ;;
+    balance) btrfs balance start -dusage=50 -musage=50 "$MNT" ;;
+    all)     btrfs scrub start -B -r "$MNT"
+             do_dedup
+             btrfs balance start -dusage=50 -musage=50 "$MNT" ;;
+    *)       usage ;;
+esac

--- a/overlays/usr/local/sbin/btrfs-maintenance
+++ b/overlays/usr/local/sbin/btrfs-maintenance
@@ -30,10 +30,11 @@ do_dedup() {
 [ $# -ge 1 ] || usage
 case "$1" in
     check)   btrfs scrub start -B -r "$MNT" ;;
-    fix)     btrfs scrub start -B "$MNT" ;;
-    dedup)   do_dedup ;;
-    balance) btrfs balance start -dusage=50 -musage=50 "$MNT" ;;
-    all)     btrfs scrub start -B -r "$MNT"
+    fix)     set_lock; btrfs scrub start -B "$MNT" ;;
+    dedup)   set_lock; do_dedup ;;
+    balance) set_lock; btrfs balance start -dusage=50 -musage=50 "$MNT" ;;
+    all)     set_lock
+             btrfs scrub start -B -r "$MNT"
              do_dedup
              btrfs balance start -dusage=50 -musage=50 "$MNT" ;;
     *)       usage ;;

--- a/overlays/usr/local/sbin/btrfs-show-space
+++ b/overlays/usr/local/sbin/btrfs-show-space
@@ -1,0 +1,99 @@
+#!/bin/sh
+# btrfs-show-space [-q|--quick] - btrfs usage + per-root-subvolume space.
+# (-q/--quick skips the compsize REFERENCED column, one less extent-walk per subvol.)
+# Lists profile roots and _stock bases, every snapshot under @snapshots, and any other
+# top-level @* (e.g. @.old_*). Shared @home/@var-* are not listed.
+#   UNIQUE     - data only this subvolume holds; freed if you delete IT ALONE,
+#                others kept (btrfs fi du, exact, uncompressed)
+#   REFERENCED - real on-disk size of all data it references, compressed
+#                (compsize, exact). Counts extents SHARED with other roots, so it
+#                is NOT additive across rows.
+#   TOTAL      - apparent/uncompressed size (btrfs fi du, exact)
+# The currently booted subvolume is marked  <- booted. Columns auto-size to fit.
+#
+# Example:
+#   btrfs-show-space --quick   # usage + per-subvol space (skips the slow REFERENCED column)
+set -eu
+. /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+need_root
+need_btrfs
+
+quick=0
+case "${1:-}" in -q|--quick) quick=1; shift ;; esac
+have_cs=0
+if [ "$quick" = 0 ] && command -v compsize >/dev/null 2>&1; then have_cs=1; fi
+
+echo "== filesystem =="
+btrfs filesystem usage -T /
+echo
+
+rows=$(mktemp)
+list=$(mktemp)
+TOP_TMPFILES="$rows $list"
+mount_top
+cur_id=$(booted_id)
+
+row() {  # $1=display name  $2=fs path  -> append a TSV row
+    line=$(btrfs filesystem du -s --raw "$2" 2>/dev/null | awk 'NR==2{print $1, $2}')
+    tot=$(printf '%s' "$line" | awk '{print $1}'); case "$tot" in ''|*[!0-9]*) tot=0 ;; esac
+    exc=$(printf '%s' "$line" | awk '{print $2}'); case "$exc" in ''|*[!0-9]*) exc=0 ;; esac
+    if [ "$have_cs" = 1 ]; then
+        ref=$(compsize -b "$2" 2>/dev/null | awk '/^TOTAL/{print $3; exit}')
+        case "$ref" in ''|*[!0-9]*) ref=0 ;; esac
+        ref_h=$(human "$ref")
+    else
+        ref_h="-"
+    fi
+    id=$(subvol_id "$2")
+    mark=""; [ -n "$cur_id" ] && [ "$id" = "$cur_id" ] && mark="<- booted"
+    printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$(human "$exc")" "$ref_h" "$(human "$tot")" "$mark" >> "$rows"
+}
+
+# collect subvols (cheap), then measure with progress: each row walks extents (slow on flash)
+for s in "$TOP"/@snapshots/*; do
+    [ -e "$s" ] || continue
+    printf '%s\t%s\n' "@snapshots/${s##*/}" "$s" >> "$list"
+done
+for d in "$TOP"/@*; do
+    [ -e "$d" ] || continue
+    n=${d##*/}
+    is_reserved_subvol "$n" && continue
+    btrfs subvolume show "$d" >/dev/null 2>&1 || continue
+    printf '%s\t%s\n' "$n" "$d" >> "$list"
+done
+total=$(wc -l < "$list" 2>/dev/null | tr -d ' '); [ -n "$total" ] || total=0
+
+printf 'NAME\tUNIQUE\tREFERENCED\tTOTAL\t\n' > "$rows"
+if [ "$total" -gt 0 ]; then
+    if [ "$have_cs" = 1 ]; then note="du + compsize"; else note="du only"; fi
+    printf 'Measuring %s subvolume(s) (%s), please wait...\n' "$total" "$note" >&2
+fi
+i=0; tab=$(printf '\t')
+while IFS="$tab" read -r nm pth; do
+    i=$((i + 1))
+    [ -t 2 ] && printf '\r  [%d/%d] %s\033[K' "$i" "$total" "$nm" >&2 || true
+    row "$nm" "$pth"
+done < "$list"
+{ [ -t 2 ] && [ "$total" -gt 0 ] && printf '\r\033[K' >&2; } || true
+
+echo "== root subvolumes & snapshots =="
+# align: NAME auto-width; numeric columns right-justified; marker appended
+awk -F'\t' '
+{ r[NR]=$0; if (length($1) > w) w = length($1) }
+END {
+    for (i = 1; i <= NR; i++) {
+        split(r[i], f, "\t")
+        printf "%-*s  %11s %11s %11s", w, f[1], f[2], f[3], f[4]
+        if (f[5] != "") printf "  %s", f[5]
+        printf "\n"
+    }
+}' "$rows"
+
+echo
+echo "UNIQUE     = freed if you delete that subvolume alone (uncompressed)."
+echo "REFERENCED = real on-disk size, compressed; counts shared extents, so NOT additive."
+if [ "$have_cs" = 0 ]; then
+    if [ "$quick" = 1 ]; then echo "REFERENCED '-': skipped for speed (--quick); run without it for compressed sizes."
+    else echo "REFERENCED shows '-': install 'compsize' (apt install compsize)."; fi
+fi
+echo "TOTAL      = apparent (uncompressed)."

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -1,0 +1,122 @@
+#!/bin/sh
+# create-profile [-m|--move] <@source> [<@dest>] - materialize a bootable PROFILE (a writable
+# bootable root) named exactly <@dest> from <@source>. Takes effect after rebooting into <@dest>.
+#
+#   <@source> a snapshot or golden base, by its full top-level path: @snapshots/<name>
+#             (RO restore point), @<profile>_<stamp> (top-level snapshot), or
+#             @<profile>_stock (a profile's golden base).
+#   <@dest>   exact name of the profile (a bootable top-level subvol) to write. Defaults to
+#             the currently booted profile. May also be current|booted.
+#   -m,--move MOVE <@source> into <@dest> (rename) instead of snapshotting it: <@source> is
+#             consumed but its parent_uuid is PRESERVED. (A snapshot would re-parent <@dest>
+#             onto <@source>.) Use to promote a received incremental snapshot back to its
+#             profile root while keeping its _stock parent.
+#
+# If <@dest> does not exist it is created and a BLS boot entry is generated for it. If it
+# already exists it is replaced and the previous copy kept as <@dest>.old_<ts> (recoverable;
+# existing profiles already have their own boot entry, so none is added). The result is always
+# writable, even when <@source> is read-only.
+#
+# Examples:
+#   create-profile @snapshots/@SourceProfile @DestinationProfile      # writable copy -> new profile
+#   create-profile -m @snapshots/@SourceProfile @DestinationProfile   # MOVE (consume source, keep parent)
+set -eu
+. /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+need_root
+need_btrfs
+
+move=0
+while :; do
+    case "${1:-}" in
+        -m|--move) move=1; shift ;;
+        *) break ;;
+    esac
+done
+[ $# -ge 1 ] || die "Usage: create-profile [-m|--move] <@source> [<@dest>|current]"
+src_name=$1
+dest=${2:-current}
+case "$src_name" in *..*|/*) die "Invalid source name: $src_name" ;; esac
+
+mount_top
+
+# full top-level path; no guessing
+resolve() { [ -e "$TOP/$1" ] && printf '%s' "$1"; }
+
+src_rel=$(resolve "$src_name")
+[ -n "$src_rel" ] || die "No such snapshot: $src_name (give the full path, e.g. @snapshots/@Minimal)"
+src="$TOP/$src_rel"
+
+# dest -> exact top-level name (default: booted root)
+case "$dest" in
+    current|booted|"") rel=$(findmnt -no FSROOT / | sed 's,^/,,')
+                       [ -n "$rel" ] || die "Cannot determine booted subvolume" ;;
+    *)                 case "$dest" in *..*|/*|*/*) die "Invalid dest: $dest (top-level name only, e.g. @Desktop-2)" ;; esac
+                       rel=$dest ;;
+esac
+is_reserved_subvol "$rel" && die "Refusing to write reserved subvolume: $rel"
+case "$rel" in
+    @?*) ;;
+    *) die "Profile name must start with '@' (e.g. @Desktop-2): $rel" ;;
+esac
+[ "$rel" = "$src_rel" ] && die "Dest and source are the same subvolume"
+
+existed=0; [ -e "$TOP/$rel" ] && existed=1
+if [ "$move" = 1 ]; then
+    how="by MOVING '$src_name' into it (source consumed, parent preserved)"
+else
+    how="with a writable copy of '$src_name'"
+fi
+if [ "$existed" = 1 ]; then
+    confirm "$(printf "Replace existing profile '%s' %s on %s?\nThe current '%s' is kept as %s.old_<ts>." \
+        "$rel" "$how" "$ROOTDEV" "$rel" "$rel")"
+else
+    confirm "Create bootable profile '$rel' $how on $ROOTDEV?"
+fi
+
+tgt="$TOP/$rel"
+aside=""
+# For a move, clear ro on the source first (EROFS blocks renaming a ro subvol; -f keeps
+# parent_uuid, drops received_uuid). Before touching the target, so a failure changes nothing.
+if [ "$move" = 1 ]; then
+    btrfs property set -f "$src" ro false || die "Could not clear ro on $src_name (needed to move it)"
+fi
+if [ "$existed" = 1 ]; then
+    ts=$(date +%Y-%m-%d_%H-%M-%S)
+    aside="$tgt.old_$ts"
+    mv "$tgt" "$aside"
+fi
+if [ "$move" = 1 ]; then
+    if ! mv "$src" "$tgt"; then
+        [ -n "$aside" ] && mv "$aside" "$tgt"
+        die "Move failed; ${aside:+previous $rel restored, }nothing changed"
+    fi
+else
+    if ! btrfs subvolume snapshot "$src" "$tgt" >/dev/null; then
+        [ -n "$aside" ] && mv "$aside" "$tgt"
+        die "Snapshot failed; ${aside:+previous $rel restored, }nothing changed"
+    fi
+fi
+# make writable; on a moved snapshot preserves parent_uuid, drops received_uuid
+btrfs property set "$tgt" ro false 2>/dev/null || true
+
+# BLS entry + /etc/kernel/entry-token via flipper-bls.sh, in a subshell so its die can't abort
+# us. Pass the SOURCE as origin hint so the root lands in that profile's band if parent_uuid is
+# left dangling.
+lib=/usr/lib/flipper-bls.sh
+if [ -r "$lib" ]; then
+    ( . "$lib"; flipper_write_entry "$rel" "$tgt" "$src_rel" ) \
+        || echo "Warning: Boot entry not created for $rel" >&2
+else
+    echo "Warning: $lib not found; no boot entry created for $rel" >&2
+fi
+
+if [ "$move" = 1 ]; then verb="moved"; else verb="created"; fi
+if [ "$existed" = 1 ]; then
+    echo "Profile '$rel' $verb from '$src_name' (writable); previous kept as ${rel}.old_$ts"
+    echo "Reboot into '$rel' to use it; remove the old copy later with:"
+    echo "  sudo delete-profile ${rel}.old_$ts"
+else
+    echo "Profile '$rel' $verb from '$src_name' (writable, boot entry added)"
+    echo "Reboot and pick '$rel' from the boot menu to use it"
+fi
+[ "$move" = 1 ] && echo "(Source consumed; parent_uuid preserved)" || true

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -73,6 +73,7 @@ else
     confirm "Create bootable profile '$rel' $how on $ROOTDEV?"
 fi
 
+set_lock
 tgt="$TOP/$rel"
 aside=""
 # For a move, clear ro on the source first (EROFS blocks renaming a ro subvol; -f keeps

--- a/overlays/usr/local/sbin/create-snapshot
+++ b/overlays/usr/local/sbin/create-snapshot
@@ -1,0 +1,36 @@
+#!/bin/sh
+# create-snapshot [tag...] - read-only snapshot of the running root (/), kept as a restore
+# point inside @snapshots. To turn a snapshot into a writable, bootable root, use
+# create-profile <@source> <@dest>.
+# naming: @<root>_YYYY-MM-DD_HH-MM-SS[_tag]  e.g. @Minimal_2026-06-29_19-52-31
+#         (<root> = the source subvol of /, e.g. @Desktop/@Minimal; tag slugified)
+# Works via a subvolid=5 (top-level) mount, so /.snapshots need not be mounted.
+#
+# Example:
+#   create-snapshot pre-upgrade   # RO snapshot of the booted @SourceProfile -> @snapshots/
+set -eu
+. /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+need_root
+need_btrfs
+
+case "${1:-}" in
+    -w|--rw) die "Read-only tool; make a writable bootable root with create-profile <@source> <@dest>" ;;
+    -r|--ro) shift ;;
+esac
+
+tag=$*
+if [ -n "$tag" ]; then
+    tag=$(printf '%s' "$tag" | tr -c 'A-Za-z0-9._-' '-' | sed 's/-\{1,\}/-/g; s/^-//; s/-$//')
+fi
+# name after /'s source subvol, e.g. @Minimal_2026-06-29_19-52-31
+src=$(btrfs subvolume show / 2>/dev/null | head -n1); src=${src##*/}
+[ -n "$src" ] || die "Cannot determine the source subvolume of /"
+name="${src}_$(date +%Y-%m-%d_%H-%M-%S)${tag:+_$tag}"
+
+mount_top
+[ -d "$TOP/@snapshots" ] || die "@snapshots not found at top level"
+dest="$TOP/@snapshots/$name"; rel="@snapshots/$name"
+[ -e "$dest" ] && die "Already exists: $rel"
+
+btrfs subvolume snapshot -r / "$dest" >/dev/null
+echo "Created $(btrfs subvolume show "$dest" | head -n1) (read-only)"

--- a/overlays/usr/local/sbin/create-snapshot
+++ b/overlays/usr/local/sbin/create-snapshot
@@ -27,6 +27,7 @@ src=$(btrfs subvolume show / 2>/dev/null | head -n1); src=${src##*/}
 [ -n "$src" ] || die "Cannot determine the source subvolume of /"
 name="${src}_$(date +%Y-%m-%d_%H-%M-%S)${tag:+_$tag}"
 
+set_lock
 mount_top
 [ -d "$TOP/@snapshots" ] || die "@snapshots not found at top level"
 dest="$TOP/@snapshots/$name"; rel="@snapshots/$name"

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -1,0 +1,53 @@
+#!/bin/sh
+# delete-profile <@profile> - delete a bootable PROFILE at the btrfs top level (as listed by
+# list-profiles): a profile root (@Desktop, @Desktop-2, ...), a _stock golden base, or an
+# @<profile>.old_* leftover. Also removes its BLS boot entry. For @snapshots restore points,
+# use delete-snapshot.
+# Confirms once; AGAIN if the target is read-only; a THIRD time (with a warning) for a _stock
+# golden base. Refuses layout subvolumes and the currently booted profile.
+#
+# Example:
+#   delete-profile @DestinationProfile   # remove a profile (and its boot entry)
+set -eu
+. /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+need_root
+need_btrfs
+
+[ $# -ge 1 ] || die "Usage: delete-profile <@profile>"
+arg=$1
+case "$arg" in *..*|/*) die "Invalid name: $arg" ;; esac
+case "$arg" in
+    @snapshots/*) die "Top-level profiles only; for a restore point use: delete-snapshot $arg" ;;
+esac
+
+mount_top
+cur_id=$(booted_id)
+[ -e "$TOP/$arg" ] || die "No such profile: $arg (see list-profiles)"
+rel=$arg
+is_reserved_subvol "$rel" && die "Refusing to delete reserved subvolume: $rel"
+info=$(btrfs subvolume show "$TOP/$rel" 2>/dev/null) || die "Not a profile: $rel"
+tgt_id=$(get "$info" "Subvolume ID")
+[ -n "$cur_id" ] && [ "$tgt_id" = "$cur_id" ] && die "Refusing to delete the currently booted profile ($rel)"
+
+is_ro=0;    case "$(get "$info" "Flags")" in *readonly*) is_ro=1 ;; esac
+is_stock=0; case "${rel##*/}" in *_stock) is_stock=1 ;; esac
+
+# tiered: once always; again if ro; a third time for _stock
+confirm "Delete profile '$rel'?"
+[ "$is_ro" = 1 ] && confirm "'$rel' is READ-ONLY (stock / received); delete anyway?"
+if [ "$is_stock" = 1 ]; then
+    echo "WARNING: '$rel' is a _stock GOLDEN BASE, the factory-reset source for its profile;" >&2
+    echo "         deleting it means that profile can no longer be reset to factory." >&2
+    confirm "Confirm a THIRD time: permanently delete the golden base '$rel'?"
+fi
+
+btrfs subvolume delete "$TOP/$rel" >/dev/null
+echo "Deleted '$rel'"
+
+# drop this profile's BLS entries + /boot/<token>/ staging
+lib=/usr/lib/flipper-bls.sh
+if [ -r "$lib" ]; then
+    ( . "$lib"; remove_root_entries "$rel" ) || echo "Warning: Entries/staging not fully removed for $rel" >&2
+else
+    echo "Warning: $lib not found; boot entry/staging not removed for $rel" >&2
+fi

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -41,6 +41,7 @@ if [ "$is_stock" = 1 ]; then
     confirm "Confirm a THIRD time: permanently delete the golden base '$rel'?"
 fi
 
+set_lock
 btrfs subvolume delete "$TOP/$rel" >/dev/null
 echo "Deleted '$rel'"
 

--- a/overlays/usr/local/sbin/delete-snapshot
+++ b/overlays/usr/local/sbin/delete-snapshot
@@ -1,0 +1,27 @@
+#!/bin/sh
+# delete-snapshot <@snapshots/@name> - delete a read-only restore-point SNAPSHOT under
+# @snapshots (as listed by list-snapshots). For bootable profiles, their _stock bases, or
+# .old leftovers, use delete-profile. Confirms once. Works via a subvolid=5 (top-level) mount.
+#
+# Example:
+#   delete-snapshot @snapshots/@SourceProfile_2026-06-29_19-52-31
+set -eu
+. /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+need_root
+need_btrfs
+
+[ $# -ge 1 ] || die "Usage: delete-snapshot <@snapshots/@name>"
+arg=$1
+case "$arg" in *..*|/*) die "Invalid name: $arg" ;; esac
+case "$arg" in
+    @snapshots/?*) ;;
+    *) die "Only @snapshots restore points here; for a profile use: delete-profile $arg" ;;
+esac
+
+mount_top
+[ -e "$TOP/$arg" ] || die "No such snapshot: $arg (see list-snapshots)"
+btrfs subvolume show "$TOP/$arg" >/dev/null 2>&1 || die "Not a snapshot: $arg"
+
+confirm "Delete restore-point snapshot '$arg'?"
+btrfs subvolume delete "$TOP/$arg" >/dev/null
+echo "Deleted '$arg'"

--- a/overlays/usr/local/sbin/delete-snapshot
+++ b/overlays/usr/local/sbin/delete-snapshot
@@ -23,5 +23,6 @@ mount_top
 btrfs subvolume show "$TOP/$arg" >/dev/null 2>&1 || die "Not a snapshot: $arg"
 
 confirm "Delete restore-point snapshot '$arg'?"
+set_lock
 btrfs subvolume delete "$TOP/$arg" >/dev/null
 echo "Deleted '$arg'"

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -1,0 +1,52 @@
+#!/bin/sh
+# list-profiles - list the bootable PROFILES at the btrfs top level: the profile roots
+# (@Desktop, @Minimal, ...), their _stock golden bases, and @<profile>.old_* leftovers from
+# create-profile. KIND tags each (profile/stock/old); PARENT is what it was snapshotted from
+# (via Parent UUID). Names are top-level paths (what create-profile/rename-profile/delete-profile
+# take). The booted profile is marked  <- booted. For restore points, see list-snapshots.
+# Works via a subvolid=5 (top-level) mount.
+#
+# Example:
+#   list-profiles   # @SourceProfile / @DestinationProfile roots, _stock bases and .old leftovers
+set -eu
+. /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+need_root
+need_btrfs
+
+map=$(mktemp)
+rows=$(mktemp)
+TOP_TMPFILES="$map $rows"
+mount_top
+build_uuid_map "$TOP" "$map"
+
+cur=$(btrfs subvolume show / 2>/dev/null) || cur=
+cur_id=$(get "$cur" "Subvolume ID")
+cur_path=$(printf '%s\n' "$cur" | head -n1)
+[ -n "$cur_path" ] && echo "Booted profile: $cur_path (id ${cur_id:-?})"
+echo
+
+emit() {  # $1=display name  $2=fs path
+    info=$(btrfs subvolume show "$2" 2>/dev/null) || return 0
+    id=$(get "$info" "Subvolume ID")
+    otime=$(get "$info" "Creation time"); otime=${otime% +*}
+    flags=$(get "$info" "Flags"); case "$flags" in *readonly*) flags=ro ;; *) flags=rw ;; esac
+    parent=$(parent_of "$map" "$(get "$info" "Parent UUID")")
+    case "$1" in
+        *_stock) kind=stock ;;
+        *.old_*) kind=old ;;
+        *)       kind=profile ;;
+    esac
+    mark=""; [ -n "$cur_id" ] && [ "$id" = "$cur_id" ] && mark="<- booted"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$kind" "${id:-?}" "${otime:-?}" "$flags" "$parent" "$mark" >> "$rows"
+}
+
+printf 'NAME\tKIND\tID\tCREATED\tRO\tPARENT\t\n' > "$rows"
+# top-level roots, _stock bases, @.old_* leftovers; skip shared subvols + @snapshots
+for d in "$TOP"/@*; do
+    [ -e "$d" ] || continue
+    n=${d##*/}
+    is_reserved_subvol "$n" && continue
+    btrfs subvolume show "$d" >/dev/null 2>&1 || continue
+    emit "$n" "$d"
+done
+align_table "$rows"

--- a/overlays/usr/local/sbin/list-snapshots
+++ b/overlays/usr/local/sbin/list-snapshots
@@ -1,0 +1,34 @@
+#!/bin/sh
+# list-snapshots - list the read-only restore-point SNAPSHOTS under @snapshots (made by
+# create-snapshot). PARENT is what each was snapshotted or received from (via Parent UUID);
+# names are top-level paths (what create-profile and delete-snapshot take). For bootable
+# profiles, see list-profiles. Works via a subvolid=5 (top-level) mount.
+#
+# Example:
+#   list-snapshots   # RO restore points, named @snapshots/@SourceProfile_<ts>
+set -eu
+. /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+need_root
+need_btrfs
+
+map=$(mktemp)
+rows=$(mktemp)
+TOP_TMPFILES="$map $rows"
+mount_top
+[ -d "$TOP/@snapshots" ] || die "@snapshots not found at top level"
+build_uuid_map "$TOP" "$map"
+
+emit() {  # $1=display name  $2=fs path
+    info=$(btrfs subvolume show "$2" 2>/dev/null) || return 0
+    id=$(get "$info" "Subvolume ID")
+    otime=$(get "$info" "Creation time"); otime=${otime% +*}
+    parent=$(parent_of "$map" "$(get "$info" "Parent UUID")")
+    printf '%s\t%s\t%s\t%s\n' "$1" "${id:-?}" "${otime:-?}" "$parent" >> "$rows"
+}
+
+printf 'NAME\tID\tCREATED\tPARENT\n' > "$rows"
+for s in "$TOP"/@snapshots/*; do
+    [ -e "$s" ] || continue
+    emit "@snapshots/${s##*/}" "$s"
+done
+align_table "$rows"

--- a/overlays/usr/local/sbin/receive-snapshot
+++ b/overlays/usr/local/sbin/receive-snapshot
@@ -1,0 +1,41 @@
+#!/bin/sh
+# receive-snapshot <file> - receive a send-snapshot stream into @snapshots.
+# The received subvolume keeps the name it had when sent (the leading '@' too, carried in
+# the stream) and is read-only; put it onto a root with create-profile. For an
+# incremental stream (sent with -p/-i), its parent must already exist here (e.g. the _stock
+# base it was diffed against, found by UUID wherever it lives), so receive the full base first.
+#
+# Examples:
+#   receive-snapshot /mnt/usb/SourceProfile_2026-..._pack.zst      # -> @snapshots/@SourceProfile...
+#   receive-snapshot /mnt/usb/SourceProfile_2026-..._inc_pack.zst  # needs the matching @SourceProfile_stock
+#   ssh host 'send-snapshot @SourceProfile -' | receive-snapshot -
+set -eu
+. /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+need_root
+need_btrfs
+need_cmd zstd "apt install zstd"
+have_pv=0; command -v pv >/dev/null 2>&1 && have_pv=1
+
+[ $# -ge 1 ] || die "Usage: receive-snapshot <file>"
+src=$1
+[ "$src" = "-" ] || [ -f "$src" ] || die "No such file: $src"
+
+mount_top
+target="$TOP/@snapshots"
+[ -d "$target" ] || die "@snapshots not found at top level"
+
+before=$(btrfs subvolume list -o "$target" 2>/dev/null | wc -l)
+
+# file src -> pv shows %/ETA; silence zstd so the two don't collide on one line.
+# No pipefail in POSIX sh, so the pipeline's status is btrfs receive's (the meaningful end).
+set +e
+if   [ "$have_pv" = 1 ] && [ "$src" != "-" ]; then pv "$src" | zstd -dc --no-progress | btrfs receive "$target"
+elif [ "$have_pv" = 1 ];                      then zstd -dc --no-progress | pv -btr   | btrfs receive "$target"
+elif [ "$src" != "-" ];                       then zstd -dc "$src"        | btrfs receive "$target"
+else                                               zstd -dc               | btrfs receive "$target"
+fi
+rc=$?
+set -e
+[ "$rc" = 0 ] || die "Receive failed (rc=$rc); check the stream and that any parent snapshot exists here"
+
+echo "Received into @snapshots/ (now $(btrfs subvolume list -o "$target" 2>/dev/null | wc -l) entries, was $before)"

--- a/overlays/usr/local/sbin/receive-snapshot
+++ b/overlays/usr/local/sbin/receive-snapshot
@@ -20,6 +20,7 @@ have_pv=0; command -v pv >/dev/null 2>&1 && have_pv=1
 src=$1
 [ "$src" = "-" ] || [ -f "$src" ] || die "No such file: $src"
 
+set_lock
 mount_top
 target="$TOP/@snapshots"
 [ -d "$target" ] || die "@snapshots not found at top level"

--- a/overlays/usr/local/sbin/rename-profile
+++ b/overlays/usr/local/sbin/rename-profile
@@ -24,6 +24,7 @@ case "$new" in
     *) die "New profile name must start with '@' (e.g. @Desktop-2): $new" ;;
 esac
 
+set_lock
 mount_top
 cur_id=$(booted_id)
 [ -e "$TOP/$old" ] || die "No such profile: $old (see list-profiles)"

--- a/overlays/usr/local/sbin/rename-profile
+++ b/overlays/usr/local/sbin/rename-profile
@@ -1,0 +1,50 @@
+#!/bin/sh
+# rename-profile <@old> <@new> - rename a bootable PROFILE at the btrfs top level (as listed by
+# list-profiles) and reissue its BLS boot entry under the new name. Both are top-level names
+# (e.g. @Desktop-2). The profile keeps its contents and btrfs parent; only its name and boot
+# entry change. Cannot rename the currently booted profile (boot into another first).
+# Works via a subvolid=5 (top-level) mount.
+#
+# Example:
+#   rename-profile @SourceProfile @DestinationProfile   # old -> new (keeps contents + parent)
+set -eu
+. /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+need_root
+need_btrfs
+
+[ $# -ge 2 ] || die "Usage: rename-profile <@old> <@new>"
+old=$1; new=$2
+for n in "$old" "$new"; do
+    case "$n" in *..*|/*|*/*) die "Invalid name: $n (top-level names only, e.g. @Desktop-2)" ;; esac
+done
+[ "$old" = "$new" ] && die "Old and new names are the same"
+is_reserved_subvol "$new" && die "Refusing to use reserved name: $new"
+case "$new" in
+    @?*) ;;
+    *) die "New profile name must start with '@' (e.g. @Desktop-2): $new" ;;
+esac
+
+mount_top
+cur_id=$(booted_id)
+[ -e "$TOP/$old" ] || die "No such profile: $old (see list-profiles)"
+[ -e "$TOP/$new" ] && die "Target already exists: $new"
+is_reserved_subvol "$old" && die "Refusing to rename reserved subvolume: $old"
+info=$(btrfs subvolume show "$TOP/$old" 2>/dev/null) || die "Not a profile: $old"
+old_id=$(get "$info" "Subvolume ID")
+[ -n "$cur_id" ] && [ "$old_id" = "$cur_id" ] \
+    && die "Refusing to rename the currently booted profile ($old); boot into another profile first"
+
+# top-level dir entry: mv keeps UUID + btrfs parent
+mv "$TOP/$old" "$TOP/$new"
+echo "Renamed profile '$old' -> '$new'"
+
+# drop old name's BLS entry + staging, reissue for <@new>; parent chain intact -> right band
+lib=/usr/lib/flipper-bls.sh
+if [ -r "$lib" ]; then
+    ( . "$lib"; remove_root_entries "$old"; flipper_write_entry "$new" "$TOP/$new" ) \
+        || echo "Warning: Boot entry not updated for $new" >&2
+else
+    echo "Warning: $lib not found; boot entry not updated for $new" >&2
+fi
+
+echo "Reboot and pick '$new' from the boot menu to use it"

--- a/overlays/usr/local/sbin/send-snapshot
+++ b/overlays/usr/local/sbin/send-snapshot
@@ -43,6 +43,7 @@ fi
 
 send_stat=$(mktemp)
 TOP_TMPFILES="$send_stat"
+set_lock
 mount_top
 
 resolve() { [ -e "$TOP/$1" ] && printf '%s' "$1"; }   # full top-level path -> echoed if it exists

--- a/overlays/usr/local/sbin/send-snapshot
+++ b/overlays/usr/local/sbin/send-snapshot
@@ -1,0 +1,133 @@
+#!/bin/sh
+# send-snapshot [-p PARENT | -i] <@snapshot> <file|dir>
+#   <@snapshot> a snapshot or root by its full top-level path, e.g. @snapshots/<name>.
+#               A read-write source is snapshotted read-only automatically into @snapshots
+#               (btrfs send needs a ro source) with a timestamped name; that ro snapshot
+#               is KEPT as a restore point.
+#   <file|dir> output file, a DIRECTORY (writes <dir>/<leaf>_pack.zst, or _inc_pack.zst
+#               for an incremental send), or - for stdout
+#   -p PARENT   incremental: send only the changes since PARENT, a ro snapshot that must
+#               ALSO exist on the receiver (matched by UUID); use for backup chains (diff
+#               vs the previous snapshot) or any base that is not a _stock.
+#   -i          shortcut for incremental against the source's own btrfs parent, but only if
+#               it is a _stock base (else a full send); for backing up a profile vs _stock.
+# The stream is zstd-compressed.
+#
+# Examples:
+#   send-snapshot -i @SourceProfile              /mnt/usb/   # delta vs @SourceProfile_stock if parent
+#   send-snapshot @SourceProfile                 /mnt/usb/   # rw root -> auto ro snapshot, then send
+#   send-snapshot @snapshots/@SourceProfile_x    /mnt/usb/   # -> /mnt/usb/SourceProfile_x_pack.zst
+#   send-snapshot @SourceProfile_x - | ssh host 'receive-snapshot -'
+set -eu
+. /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+need_root
+need_btrfs
+need_cmd zstd "apt install zstd"
+have_pv=0; command -v pv >/dev/null 2>&1 && have_pv=1
+
+parent=""; incremental=0
+while :; do
+    case "${1:-}" in
+        -p) [ $# -ge 2 ] || die "-p requires a PARENT snapshot"; parent=$2; shift 2 ;;
+        -i) incremental=1; shift ;;
+        *)  break ;;
+    esac
+done
+[ $# -ge 2 ] || die "Usage: send-snapshot [-p PARENT | -i] <@snapshot> <file|dir>"
+src_name=$1; dest=$2
+case "$src_name" in *..*) die "Invalid name: $src_name" ;; esac
+# fail fast on an existing non-dir dest; a dir dest is named below from the leaf sent
+if [ "$dest" != "-" ] && [ ! -d "$dest" ] && [ -e "$dest" ]; then
+    die "Dest already exists: $dest"
+fi
+
+send_stat=$(mktemp)
+TOP_TMPFILES="$send_stat"
+mount_top
+
+resolve() { [ -e "$TOP/$1" ] && printf '%s' "$1"; }   # full top-level path -> echoed if it exists
+parent_path_of() {  # $1 = fs path -> top-relative path of its parent subvol (empty if none)
+    pu=$(btrfs subvolume show "$1" 2>/dev/null | awk -F':[[:space:]]+' '/Parent UUID/{print $2; exit}')
+    case "$pu" in ''|'-') return ;; esac
+    btrfs subvolume list -u "$TOP" 2>/dev/null | awk -v u="$pu" '
+        { p=""; uu=""
+          for (i=1;i<=NF;i++) { if($i=="uuid")uu=$(i+1); else if($i=="path"){p=$(i+1);for(j=i+2;j<=NF;j++)p=p" "$j} }
+          if (uu==u){print p; exit} }'
+}
+
+srel=$(resolve "$src_name"); [ -n "$srel" ] || die "No such snapshot: $src_name"
+srcpath="$TOP/$srel"
+
+# -i: incremental against the source's parent, but only if that parent is a _stock base
+if [ "$incremental" = 1 ] && [ -z "$parent" ]; then
+    pp=$(parent_path_of "$srcpath")
+    case "${pp##*/}" in
+        ?*_stock) parent=$pp; echo "Incremental: parent $pp is a _stock base" >&2 ;;
+        *)        echo "Parent ${pp:-(none)} is not a _stock base; sending full" >&2 ;;
+    esac
+fi
+
+if ! is_ro "$srcpath"; then
+    # btrfs send needs a ro source; snapshot the rw one ro into @snapshots (kept as a
+    # restore point) and send that. Each send captures current state, so re-sends never collide.
+    [ -d "$TOP/@snapshots" ] || die "@snapshots not found at top level (needed for a ro snapshot)"
+    rosnap="@snapshots/${src_name##*/}_$(date +%Y-%m-%d_%H-%M-%S)"
+    [ -e "$TOP/$rosnap" ] && die "Snapshot already exists: $rosnap"
+    btrfs subvolume snapshot -r "$srcpath" "$TOP/$rosnap" >/dev/null || die "Failed to make a ro snapshot of $src_name"
+    echo "Source is read-write; made ro snapshot $rosnap (kept) and sending it" >&2
+    srel=$rosnap; srcpath="$TOP/$rosnap"
+fi
+
+# dir dest -> name file after the sent leaf, sans leading '@' (_inc_pack.zst if incremental)
+if [ "$dest" != "-" ] && [ -d "$dest" ]; then
+    leaf=${srel##*/}; leaf=${leaf#@}
+    suf=_pack; [ -n "$parent" ] && suf=_inc_pack
+    dest="${dest%/}/${leaf}${suf}.zst"
+    [ -e "$dest" ] && die "Dest already exists: $dest"
+fi
+
+parentpath=""; prel=""
+if [ -n "$parent" ]; then
+    prel=$(resolve "$parent"); [ -n "$prel" ] || die "No such parent snapshot: $parent"
+    parentpath="$TOP/$prel"
+    is_ro "$parentpath" || die "Parent $parent must be read-only"
+fi
+
+do_send() {  # record btrfs send's exit; the pipe hides it (no pipefail in POSIX sh)
+    if [ -n "$parentpath" ]; then btrfs send -p "$parentpath" "$srcpath"
+    else btrfs send "$srcpath"; fi
+    echo $? >"$send_stat"
+}
+emit() {  # silence zstd when pv shows progress (avoid two bars on one line)
+    pg=""; [ "$have_pv" = 1 ] && pg="--no-progress"
+    if [ "$dest" = "-" ]; then zstd -T0 $pg; else zstd -T0 $pg -o "$dest"; fi
+}
+
+# estimate uncompressed size for pv: full -> apparent total; incremental -> exclusive bytes
+sz=0
+if [ "$have_pv" = 1 ]; then
+    duline=$(btrfs filesystem du -s --raw "$srcpath" 2>/dev/null | awk 'NR==2{print $1, $2}')
+    if [ -n "$parentpath" ]; then sz=$(printf '%s\n' "$duline" | awk '{print $2}')
+    else                          sz=$(printf '%s\n' "$duline" | awk '{print $1}'); fi
+    case "$sz" in ''|*[!0-9]*) sz=0 ;; esac
+fi
+
+echo "Sending $srel${parentpath:+ (incremental from $prel)}${dest:+ -> $dest}" >&2
+# no pipefail: run under set +e and check both ends (send via $send_stat, and compress);
+# discard partial output on any failure so a bad send never looks like a complete backup
+set +e
+if   [ "$have_pv" = 1 ] && [ "$sz" -gt 0 ]; then do_send | pv -pterb -s "$sz" | emit
+elif [ "$have_pv" = 1 ];                    then do_send | pv -btr | emit
+else                                              do_send | emit
+fi
+emit_rc=$?
+set -e
+send_rc=$(cat "$send_stat" 2>/dev/null || echo 1)
+if [ "${send_rc:-1}" != 0 ] || [ "$emit_rc" != 0 ]; then
+    if [ "$dest" != "-" ] && [ -f "$dest" ]; then
+        rm -f "$dest"
+        die "Send failed (btrfs send=${send_rc:-?}, compress=$emit_rc); removed incomplete $dest"
+    fi
+    die "Send failed (btrfs send=${send_rc:-?}, compress=$emit_rc)"
+fi
+[ "$dest" = "-" ] || echo "Done: $dest ($(du -h "$dest" | cut -f1))" >&2


### PR DESCRIPTION
On-device tooling to manage the per-profile btrfs roots and snapshots, plus a shared library they source. Ships via the existing `overlays/usr/local` and `overlays/usr/lib` overlay steps.

## Tools (`/usr/local/sbin`)

| command | purpose |
|---|---|
| `create-profile` | materialize a writable bootable profile from a snapshot/base (`-m` moves, preserving `parent_uuid`); writes the BLS entry via `flipper-bls.sh` |
| `rename-profile` | rename a profile and reissue its BLS entry |
| `delete-profile` | delete a profile + its BLS entry/staging (tiered confirm for read-only and `_stock` golden bases) |
| `list-profiles` | list roots, `_stock` bases and `.old` leftovers |
| `create-snapshot` | read-only restore point under `@snapshots` |
| `delete-snapshot` | delete a restore point |
| `list-snapshots` | list restore points |
| `send-snapshot` | zstd-compressed `btrfs send` (full or incremental via `-p`/`-i`) |
| `receive-snapshot` | receive a stream into `@snapshots` |
| `btrfs-show-space` | per-subvolume space usage |
| `btrfs-maintenance` | `check` / `fix` / `dedup` / `balance` |

## Shared library

`/usr/lib/flipper-btrfs.sh` — sourced by every tool: root/btrfs preamble, `subvolid=5` top-level mount + cleanup, `confirm`, reserved-subvol guard, and the field / parent-uuid / table helpers. Alongside the existing `flipper-bls.sh` (whose comments were updated to the new command names).