### PR TITLE
Compress final images with zstd instead of pigz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get install -y \
     systemd-container \
     systemd-resolved \
     pipx \
-    pigz \
+    zstd \
     cargo \
     golang \
     libglib2.0-dev \

--- a/build-images.sh
+++ b/build-images.sh
@@ -55,7 +55,7 @@ EOF
 		echo " - Creating a block map"
 		bmaptool create -o "$IMG_OUT"/debian-"$s"-"$i"-"$BUILD_ID".img.bmap "$TMPDIR"/debian-"$s"-"$i"-"$BUILD_ID".img
 		echo " - Compressing the final image"
-		pigz -c "$TMPDIR"/debian-"$s"-"$i"-"$BUILD_ID".img > "$IMG_OUT"/debian-"$s"-"$i"-"$BUILD_ID".img.gz
+		zstd -f -T0 -8 -o "$IMG_OUT"/debian-"$s"-"$i"-"$BUILD_ID".img.zst "$TMPDIR"/debian-"$s"-"$i"-"$BUILD_ID".img
 		rm -f "$TMPDIR"/debian-"$s"-"$i"-"$BUILD_ID".img
 	done
 
@@ -63,7 +63,7 @@ EOF
 	echo " - Creating a block map"
 	bmaptool create -o "$IMG_OUT"/debian-"$s"-nobootloader-"$BUILD_ID".img.bmap "$TMPDIR"/debian-"$s"-nobootloader-"$BUILD_ID".img
 	echo " - Compressing the final image"
-	pigz -c "$TMPDIR"/debian-"$s"-nobootloader-"$BUILD_ID".img > "$IMG_OUT"/debian-"$s"-nobootloader-"$BUILD_ID".img.gz
+	zstd -f -T0 -8 -o "$IMG_OUT"/debian-"$s"-nobootloader-"$BUILD_ID".img.zst "$TMPDIR"/debian-"$s"-nobootloader-"$BUILD_ID".img
 	rm -f "$TMPDIR"/debian-"$s"-nobootloader-"$BUILD_ID".img
 done
 


### PR DESCRIPTION
Switches the final flashable image compression from pigz (gzip) to zstd.

## Changes
- `build-images.sh`: `pigz -c … > …img.gz` → `zstd -f -T0 -8 -o …img.zst …`, for both the bootloader and `-nobootloader` images.
- `Dockerfile`: build dependency `pigz` → `zstd`.

## Blocked on: rockusb
The device flashing path (rockusb) must decompress `.zst` images — today it expects `.img.gz`. Draft until that lands.

## Also needs a buildbot config change
Artifact-collection steps that glob `debian-*.img.gz` must be updated to `.img.zst` (buildbot master config, not this repo).