### PR TITLE
Fix LINUX_OUT defaults to prevent parallel kernel cross-contamination (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Once you have bootloader outputs in `prebuilt/u-boot/` and kernel outputs in `pr
 
 This produces compressed images for each board whose bootloader is present. The kernel and root filesystem are shared; only the bootloader partition differs per board. Output files: `out/debian-<sector-size>-<board>-<timestamp>.img.gz` with a matching `.bmap` file, for both 512-byte and 4096-byte sector variants. When run inside the container, images go to `out/images/` instead (the container sets `IMG_OUT=/artifacts/images`).
 
-Don't run the mainline and BSP kernel scripts in parallel against the same output directory — both write to the same `prebuilt/linux/` path and the final packaging step will fail. Run one, then the other (or set separate `LINUX_OUT` paths).
+The mainline and BSP kernel scripts now default to separate output directories (`prebuilt/linux-mainline` and `prebuilt/linux-bsp`), so they can safely be run in parallel. If you need a custom path, set `LINUX_OUT` in the environment.
 
 ### Writing the image to SD/eMMC
 

--- a/build-kernel-bsp.sh
+++ b/build-kernel-bsp.sh
@@ -3,7 +3,7 @@
 : "${VENDOR_DTS:=vendor-dts}"
 : "${PATCHES_DIR:=patches/bsp}"
 : "${KEEP_SRC:=no}"
-: "${LINUX_OUT:=prebuilt/linux}"
+: "${LINUX_OUT:=prebuilt/linux-bsp}"
 : "${CROSS_COMPILE:=aarch64-linux-gnu-}"
 : "${CONFIGS:=configs/linux-bsp}"
 

--- a/build-kernel-mainline.sh
+++ b/build-kernel-mainline.sh
@@ -2,7 +2,7 @@
 : "${LINUX_DIR:=src/linux}"
 : "${VENDOR_DTS:=vendor-dts}"
 : "${KEEP_SRC:=no}"
-: "${LINUX_OUT:=prebuilt/linux}"
+: "${LINUX_OUT:=prebuilt/linux-mainline}"
 : "${CROSS_COMPILE:=aarch64-linux-gnu-}"
 : "${BASE_CONFIG:=configs/minconfig-mainline}"
 : "${CONFIGS:=configs/linux}"


### PR DESCRIPTION
## Summary

Both `build-kernel-mainline.sh` and `build-kernel-bsp.sh` defaulted to `LINUX_OUT=prebuilt/linux`. Running them in parallel (even with `--no-kernel` on one) corrupted each other's output since both wrote to the same directory. This is the audit remediation from ponytail audit item in task 158.

## Changes

1. **build-kernel-mainline.sh** — changed default `LINUX_OUT` from `prebuilt/linux` to `prebuilt/linux-mainline`
2. **build-kernel-bsp.sh** — changed default `LINUX_OUT` from `prebuilt/linux` to `prebuilt/linux-bsp`
3. **README.md** — replaced the warning against parallel runs with a note explaining they now use separate output directories

## Testing

The scripts continue to use the same `LINUX_OUT` env var override mechanism, so existing CI and manual builds that set `LINUX_OUT` explicitly are unaffected. Only the fallback default changes.

Closes #79