### PR TITLE
fix: isolate parallel kernel build output directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ The same `KEEP_SRC` variants work here too.
 
 ### Assembling disk images
 
-Once you have bootloader outputs in `prebuilt/u-boot/` and kernel outputs in `prebuilt/linux/`, run:
+Once you have bootloader outputs in `prebuilt/u-boot/` and kernel outputs in `prebuilt/linux-mainline/` and `prebuilt/linux-bsp/`, run:
 
 ```bash
 ./build-images.sh
@@ -226,7 +226,7 @@ Once you have bootloader outputs in `prebuilt/u-boot/` and kernel outputs in `pr
 
 This produces compressed images for each board whose bootloader is present. The kernel and root filesystem are shared; only the bootloader partition differs per board. Output files: `out/debian-<sector-size>-<board>-<timestamp>.img.gz` with a matching `.bmap` file, for both 512-byte and 4096-byte sector variants. When run inside the container, images go to `out/images/` instead (the container sets `IMG_OUT=/artifacts/images`).
 
-Don't run the mainline and BSP kernel scripts in parallel against the same output directory — both write to the same `prebuilt/linux/` path and the final packaging step will fail. Run one, then the other (or set separate `LINUX_OUT` paths).
+The mainline and BSP kernel scripts now default to separate output directories (`prebuilt/linux-mainline` and `prebuilt/linux-bsp`), so they can safely be run in parallel. If you need a custom path, set `LINUX_OUT` in the environment.
 
 ### Writing the image to SD/eMMC
 

--- a/build-kernel-bsp.sh
+++ b/build-kernel-bsp.sh
@@ -3,7 +3,7 @@
 : "${VENDOR_DTS:=vendor-dts}"
 : "${PATCHES_DIR:=patches/bsp}"
 : "${KEEP_SRC:=no}"
-: "${LINUX_OUT:=prebuilt/linux}"
+: "${LINUX_OUT:=prebuilt/linux-bsp}"
 : "${CROSS_COMPILE:=aarch64-linux-gnu-}"
 : "${CONFIGS:=configs/linux-bsp}"
 

--- a/build-kernel-mainline.sh
+++ b/build-kernel-mainline.sh
@@ -2,7 +2,7 @@
 : "${LINUX_DIR:=src/linux}"
 : "${VENDOR_DTS:=vendor-dts}"
 : "${KEEP_SRC:=no}"
-: "${LINUX_OUT:=prebuilt/linux}"
+: "${LINUX_OUT:=prebuilt/linux-mainline}"
 : "${CROSS_COMPILE:=aarch64-linux-gnu-}"
 : "${BASE_CONFIG:=configs/minconfig-mainline}"
 : "${CONFIGS:=configs/linux}"


### PR DESCRIPTION
Changes `LINUX_OUT` defaults so `build-kernel-mainline.sh` writes to `prebuilt/linux-mainline` and `build-kernel-bsp.sh` writes to `prebuilt/linux-bsp`, preventing cross-contamination during parallel builds.

- **build-kernel-mainline.sh** (line 5): `LINUX_OUT=prebuilt/linux` → `LINUX_OUT=prebuilt/linux-mainline`
- **build-kernel-bsp.sh** (line 6): `LINUX_OUT=prebuilt/linux` → `LINUX_OUT=prebuilt/linux-bsp`
- **README.md**: Updated two references — the assembling disk images path (`prebuilt/linux/` → `prebuilt/linux-mainline/` and `prebuilt/linux-bsp/`) and the "parallel build warning" paragraph (now states it is safe to run in parallel).

Closes #79