### PR TITLE
apt: pre-snapshot the booted profile before package changes

### DIFF
--- a/overlays/configs/apt/apt.conf.d/80-flipper-snapshot
+++ b/overlays/configs/apt/apt.conf.d/80-flipper-snapshot
@@ -1,0 +1,5 @@
+// Creates a read-only snapshot of the booted profile before apt changes packages, tagged
+// apt-<action>. Runs only when apt is about to call dpkg; $PPID is the apt process, so its cmdline
+// gives the subcommand. The case is the allowlist we protect. Skips build-time chroot apt; never
+// aborts apt. Single line: apt.conf strings cannot span multiple lines.
+DPkg::Pre-Invoke { "[ -d /run/systemd/system ] && [ -x /usr/local/sbin/create-snapshot ] || exit 0; V=$(xargs -0 -n1 </proc/$PPID/cmdline 2>/dev/null | awk 'NR==1{next} s{s=0;next} /^-[octap]$/{s=1;next} /^-/{next} {print;exit}'); case $V in ''|install|reinstall|remove|purge|autoremove|upgrade|full-upgrade|dist-upgrade|build-dep|satisfy|dselect-upgrade) create-snapshot apt-$V || true ;; esac"; };


### PR DESCRIPTION
## What

Adds a `DPkg::Pre-Invoke` drop-in (`/etc/apt/apt.conf.d/80-flipper-snapshot`) that takes a
read-only btrfs snapshot of the booted profile before apt changes packages, so a bad
install / upgrade / removal can be rolled back with `create-profile` from the snapshot.

## How

- Fires only when apt is about to invoke dpkg, so read-only ops (`update`/`list`/`search`/`download`) never trigger it.
- `$PPID` is the apt process (the hook runs as its `sh -c` child), so its cmdline gives the subcommand; the snapshot is tagged `apt-<action>` (e.g. `@Minimal_<stamp>_apt-install`).
- A `case` allowlist limits snapshots to package-changing subcommands: install, reinstall, remove, purge, autoremove, upgrade, full-upgrade, dist-upgrade, build-dep, satisfy, dselect-upgrade.
- Guarded to a booted system (`/run/systemd/system`), so build-time (chroot) apt - in both fakemachine and no-fakemachine workers - is skipped.
- Best-effort (`|| true`): a failed snapshot never aborts apt. Non-root apt also fails at the dpkg frontend lock before the hook runs, so no snapshot is attempted.

Reuses the existing `create-snapshot` tool; no new scripts. Must be a single line, since apt.conf strings cannot span multiple lines.

## On-device validation (@Minimal, trixie)

Build-time apt is correctly skipped - a freshly built image has no snapshots:

```
$ sudo list-snapshots
NAME                                                 ID   CREATED              PARENT
```

`install` and `purge` each produce a tagged snapshot:

```
$ sudo apt install fastfetch -y
...
Created @snapshots/@Minimal_2026-07-09_15-04-08_apt-install (read-only)
...
$ sudo apt purge fastfetch -y
...
Created @snapshots/@Minimal_2026-07-09_15-05-02_apt-purge (read-only)

$ sudo list-snapshots
NAME                                                 ID   CREATED              PARENT
@snapshots/@Minimal_2026-07-09_15-04-08_apt-install  271  2026-07-09 15:04:08  @Minimal (263)
@snapshots/@Minimal_2026-07-09_15-05-02_apt-purge    272  2026-07-09 15:05:03  @Minimal (263)
```
