### PR TITLE
overlays/sbin: add -h/--help to the btrfs tools

### DIFF
--- a/overlays/usr/local/sbin/btrfs-maintenance
+++ b/overlays/usr/local/sbin/btrfs-maintenance
@@ -12,11 +12,34 @@
 #   btrfs-maintenance all   # scrub + dedup + balance across all profile/snapshot subvols
 set -eu
 . /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+
+usage() {
+    cat <<EOF
+Usage: btrfs-maintenance <check|fix|dedup|balance|all>
+  check     read-only scrub (verify checksums, no writes)
+  fix       scrub with repair (only where a good copy exists)
+  dedup     offline dedup via duperemove across ALL subvolumes
+  balance   light filtered balance to reclaim partly-empty chunks
+  all       check + dedup + balance
+EOF
+}
+
+do_scrub=0; scrub_ro=; dedup=0; balance=0; lock=1
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+    check)     do_scrub=1; scrub_ro=-r; lock=0 ;;
+    fix)       do_scrub=1 ;;
+    dedup)     dedup=1 ;;
+    balance)   balance=1 ;;
+    all)       do_scrub=1; scrub_ro=-r; dedup=1; balance=1 ;;
+    -?*)       echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+    "")        usage >&2; exit 1 ;;
+    *)         echo "Error: unknown command: $1" >&2; usage >&2; exit 1 ;;
+esac
+
 need_root
 need_btrfs
 MNT=/
-
-usage() { sed -n '2,9p' "$0"; exit 1; }
 
 # Dedup across every profile/snapshot: duperemove must run on the btrfs TOP LEVEL (subvolid=5),
 # where all subvolumes appear as subdirectories. Run on / and it only sees the booted root.
@@ -27,15 +50,8 @@ do_dedup() {
     duperemove -dhr "$TOP" || die "Duperemove failed (rc=$?)"
 }
 
-[ $# -ge 1 ] || usage
-case "$1" in
-    check)   btrfs scrub start -B -r "$MNT" ;;
-    fix)     set_lock; btrfs scrub start -B "$MNT" ;;
-    dedup)   set_lock; do_dedup ;;
-    balance) set_lock; btrfs balance start -dusage=50 -musage=50 "$MNT" ;;
-    all)     set_lock
-             btrfs scrub start -B -r "$MNT"
-             do_dedup
-             btrfs balance start -dusage=50 -musage=50 "$MNT" ;;
-    *)       usage ;;
-esac
+[ "$lock" = 1 ]     && set_lock
+[ "$do_scrub" = 1 ] && btrfs scrub start -B $scrub_ro "$MNT"
+[ "$dedup" = 1 ]    && do_dedup
+[ "$balance" = 1 ]  && btrfs balance start -dusage=50 -musage=50 "$MNT"
+exit 0

--- a/overlays/usr/local/sbin/btrfs-show-space
+++ b/overlays/usr/local/sbin/btrfs-show-space
@@ -15,11 +15,24 @@
 #   btrfs-show-space --quick   # usage + per-subvol space (skips the slow REFERENCED column)
 set -eu
 . /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
-need_root
-need_btrfs
+
+usage() {
+    cat <<EOF
+Usage: btrfs-show-space [-q|--quick]
+  Btrfs usage plus per-root-subvolume space (UNIQUE / REFERENCED / TOTAL).
+  -q,--quick  skip the compsize REFERENCED column (one less extent-walk per subvol)
+EOF
+}
 
 quick=0
-case "${1:-}" in -q|--quick) quick=1; shift ;; esac
+case "${1:-}" in
+    -h|--help)  usage; exit 0 ;;
+    -q|--quick) quick=1; shift ;;
+    -?*)        echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+esac
+
+need_root
+need_btrfs
 have_cs=0
 if [ "$quick" = 0 ] && command -v compsize >/dev/null 2>&1; then have_cs=1; fi
 

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -22,17 +22,29 @@
 #   create-profile -m @snapshots/@SourceProfile @DestinationProfile   # MOVE (consume source, keep parent)
 set -eu
 . /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
-need_root
-need_btrfs
+
+usage() {
+    cat <<EOF
+Usage: create-profile [-m|--move] <@source> [<@dest>|current]
+  -m,--move   move <@source> into <@dest> (consume source, preserve parent_uuid)
+  <@source>   @snapshots/<name>, @<profile>_<stamp>, or @<profile>_stock
+  <@dest>     profile to write (default: booted profile; or current|booted)
+EOF
+}
 
 move=0
 while :; do
     case "${1:-}" in
-        -m|--move) move=1; shift ;;
-        *) break ;;
+        -m|--move)  move=1; shift ;;
+        -h|--help)  usage; exit 0 ;;
+        -?*)        echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)          break ;;
     esac
 done
-[ $# -ge 1 ] || die "Usage: create-profile [-m|--move] <@source> [<@dest>|current]"
+[ $# -ge 1 ] || { usage >&2; exit 1; }
+
+need_root
+need_btrfs
 src_name=$1
 dest=${2:-current}
 case "$src_name" in *..*|/*) die "Invalid source name: $src_name" ;; esac

--- a/overlays/usr/local/sbin/create-snapshot
+++ b/overlays/usr/local/sbin/create-snapshot
@@ -10,13 +10,23 @@
 #   create-snapshot pre-upgrade   # RO snapshot of the booted @SourceProfile -> @snapshots/
 set -eu
 . /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
-need_root
-need_btrfs
+
+usage() {
+    cat <<EOF
+Usage: create-snapshot [tag...]
+  Read-only snapshot of the booted root (/) into @snapshots, named
+  @<root>_YYYY-MM-DD_HH-MM-SS[_tag]. Snapshots are always read-only;
+  for a writable/bootable root use create-profile <@source> <@dest>.
+EOF
+}
 
 case "${1:-}" in
-    -w|--rw) die "Read-only tool; make a writable bootable root with create-profile <@source> <@dest>" ;;
-    -r|--ro) shift ;;
+    -h|--help) usage; exit 0 ;;
+    -?*)       echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
 esac
+
+need_root
+need_btrfs
 
 tag=$*
 if [ -n "$tag" ]; then
@@ -34,4 +44,4 @@ dest="$TOP/@snapshots/$name"; rel="@snapshots/$name"
 [ -e "$dest" ] && die "Already exists: $rel"
 
 btrfs subvolume snapshot -r / "$dest" >/dev/null
-echo "Created $(btrfs subvolume show "$dest" | head -n1) (read-only)"
+echo "Created $(btrfs subvolume show "$dest" | head -n1)"

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -10,10 +10,24 @@
 #   delete-profile @DestinationProfile   # remove a profile (and its boot entry)
 set -eu
 . /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+
+usage() {
+    cat <<EOF
+Usage: delete-profile <@profile>
+  Delete a bootable profile at the btrfs top level (see list-profiles) and its
+  boot entry: a profile root, a _stock base, or an @<profile>.old_* leftover.
+  For @snapshots restore points use delete-snapshot.
+EOF
+}
+
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+    -?*)       echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+esac
+[ $# -ge 1 ] || { usage >&2; exit 1; }
+
 need_root
 need_btrfs
-
-[ $# -ge 1 ] || die "Usage: delete-profile <@profile>"
 arg=$1
 case "$arg" in *..*|/*) die "Invalid name: $arg" ;; esac
 case "$arg" in

--- a/overlays/usr/local/sbin/delete-snapshot
+++ b/overlays/usr/local/sbin/delete-snapshot
@@ -7,10 +7,23 @@
 #   delete-snapshot @snapshots/@SourceProfile_2026-06-29_19-52-31
 set -eu
 . /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+
+usage() {
+    cat <<EOF
+Usage: delete-snapshot <@snapshots/@name>
+  Delete a read-only restore-point snapshot under @snapshots (see list-snapshots).
+  For profiles, _stock bases, or .old leftovers use delete-profile.
+EOF
+}
+
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+    -?*)       echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+esac
+[ $# -ge 1 ] || { usage >&2; exit 1; }
+
 need_root
 need_btrfs
-
-[ $# -ge 1 ] || die "Usage: delete-snapshot <@snapshots/@name>"
 arg=$1
 case "$arg" in *..*|/*) die "Invalid name: $arg" ;; esac
 case "$arg" in

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -10,6 +10,20 @@
 #   list-profiles   # @SourceProfile / @DestinationProfile roots, _stock bases and .old leftovers
 set -eu
 . /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+
+usage() {
+    cat <<EOF
+Usage: list-profiles
+  List bootable profiles at the btrfs top level: profile roots, their _stock golden
+  bases, and @<profile>.old_* leftovers. For restore points, see list-snapshots.
+EOF
+}
+
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+    ?*)        echo "Error: unexpected argument: $1" >&2; usage >&2; exit 1 ;;
+esac
+
 need_root
 need_btrfs
 

--- a/overlays/usr/local/sbin/list-snapshots
+++ b/overlays/usr/local/sbin/list-snapshots
@@ -8,6 +8,20 @@
 #   list-snapshots   # RO restore points, named @snapshots/@SourceProfile_<ts>
 set -eu
 . /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+
+usage() {
+    cat <<EOF
+Usage: list-snapshots
+  List read-only restore-point snapshots under @snapshots (made by create-snapshot).
+  For bootable profiles, see list-profiles.
+EOF
+}
+
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+    ?*)        echo "Error: unexpected argument: $1" >&2; usage >&2; exit 1 ;;
+esac
+
 need_root
 need_btrfs
 

--- a/overlays/usr/local/sbin/receive-snapshot
+++ b/overlays/usr/local/sbin/receive-snapshot
@@ -11,13 +11,26 @@
 #   ssh host 'send-snapshot @SourceProfile -' | receive-snapshot -
 set -eu
 . /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+
+usage() {
+    cat <<EOF
+Usage: receive-snapshot <file|->
+  Receive a send-snapshot stream into @snapshots (read-only). Put it onto a root
+  with create-profile. Incremental streams need their parent to exist here first.
+EOF
+}
+
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+    -?*)       echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+esac
+[ $# -ge 1 ] || { usage >&2; exit 1; }
+src=$1
+
 need_root
 need_btrfs
 need_cmd zstd "apt install zstd"
 have_pv=0; command -v pv >/dev/null 2>&1 && have_pv=1
-
-[ $# -ge 1 ] || die "Usage: receive-snapshot <file>"
-src=$1
 [ "$src" = "-" ] || [ -f "$src" ] || die "No such file: $src"
 
 set_lock

--- a/overlays/usr/local/sbin/rename-profile
+++ b/overlays/usr/local/sbin/rename-profile
@@ -9,11 +9,24 @@
 #   rename-profile @SourceProfile @DestinationProfile   # old -> new (keeps contents + parent)
 set -eu
 . /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+
+usage() {
+    cat <<EOF
+Usage: rename-profile <@old> <@new>
+  Rename a bootable profile at the btrfs top level (see list-profiles) and reissue
+  its boot entry. Both are top-level names. Cannot rename the booted profile.
+EOF
+}
+
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+    -?*)       echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+esac
+[ $# -ge 2 ] || { usage >&2; exit 1; }
+old=$1; new=$2
+
 need_root
 need_btrfs
-
-[ $# -ge 2 ] || die "Usage: rename-profile <@old> <@new>"
-old=$1; new=$2
 for n in "$old" "$new"; do
     case "$n" in *..*|/*|*/*) die "Invalid name: $n (top-level names only, e.g. @Desktop-2)" ;; esac
 done

--- a/overlays/usr/local/sbin/send-snapshot
+++ b/overlays/usr/local/sbin/send-snapshot
@@ -20,20 +20,33 @@
 #   send-snapshot @SourceProfile_x - | ssh host 'receive-snapshot -'
 set -eu
 . /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
-need_root
-need_btrfs
-need_cmd zstd "apt install zstd"
-have_pv=0; command -v pv >/dev/null 2>&1 && have_pv=1
+
+usage() {
+    cat <<EOF
+Usage: send-snapshot [-p PARENT | -i] <@snapshot> <file|dir|->
+  -p PARENT   incremental: send only changes since PARENT (ro, must exist on receiver)
+  -i          incremental vs the source's _stock parent (else a full send)
+  <@snapshot> full top-level path, e.g. @snapshots/<name> (rw source auto-snapshotted ro)
+  <file|dir>  output file, a directory (writes <leaf>_pack.zst), or - for stdout
+EOF
+}
 
 parent=""; incremental=0
 while :; do
     case "${1:-}" in
-        -p) [ $# -ge 2 ] || die "-p requires a PARENT snapshot"; parent=$2; shift 2 ;;
-        -i) incremental=1; shift ;;
-        *)  break ;;
+        -p)        [ $# -ge 2 ] || die "-p requires a PARENT snapshot"; parent=$2; shift 2 ;;
+        -i)        incremental=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        -?*)       echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)         break ;;
     esac
 done
-[ $# -ge 2 ] || die "Usage: send-snapshot [-p PARENT | -i] <@snapshot> <file|dir>"
+[ $# -ge 2 ] || { usage >&2; exit 1; }
+
+need_root
+need_btrfs
+need_cmd zstd "apt install zstd"
+have_pv=0; command -v pv >/dev/null 2>&1 && have_pv=1
 src_name=$1; dest=$2
 case "$src_name" in *..*) die "Invalid name: $src_name" ;; esac
 # fail fast on an existing non-dir dest; a dir dest is named below from the leaf sent


### PR DESCRIPTION
## What

Adds a `-h`/`--help` mode to every btrfs profile/snapshot tool (`create-profile`,
`create-snapshot`, `delete-profile`, `delete-snapshot`, `list-profiles`, `list-snapshots`,
`rename-profile`, `send-snapshot`, `receive-snapshot`, `btrfs-show-space`, `btrfs-maintenance`).
Previously none had a working help flag.

## How

Each tool gains a `usage()` synopsis via a `cat <<EOF` heredoc — the convention used by the
Linux kernel's `scripts/config`, git, and systemd, and matching `add-dtbo`. Then:

- `-h`/`--help` → prints usage, exits 0, and **works unprivileged** (the `need_root`/`need_btrfs`
  checks were moved after argument parsing).
- Unknown options → `Error: unknown option: -x` + usage, exit 1.
- `btrfs-maintenance` rejects unknown commands; no-argument tools reject stray arguments.
- Missing required arguments → usage on stderr, exit 1 (replacing the old bare `die "Usage: ..."`).
- `-` (stdin/stdout) is still accepted by `send-snapshot`/`receive-snapshot`.
