### PR TITLE
Per-profile user DT overlay drop-ins (/etc/kernel/dtbo) + add-dtbo

### DIFF
--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -321,6 +321,15 @@ discover_devicetreedir() {
     OVERLAY_DIR="${DEVICETREEDIR_SRC:-$DTB_DIR}/$VENDOR"
 }
 
+# devicetree-overlay value for an entry: profile overlays ($2 = dtbos names) + user drop-ins,
+# subvol-prefixed from $1 (options). Empty if none. Shared by emit_entry and flipper_rewrite_overlay.
+dt_overlay_line() {
+    _p="$(fdt_prefix "$1")"
+    _o="$(overlay_paths "$_p" $2 2>/dev/null)" || _o=""
+    _u="$(user_overlay_paths "$_p")"
+    printf '%s' "$_o${_o:+${_u:+ }}$_u"
+}
+
 # emit_entry SUF EXTRA GATE DTBOS -> write one BLS entry for the current $ENTRY_TOKEN.
 # The filename is $ENTRY_TOKEN-$KERNEL_VERSION.conf. The token is <NN>-flipperos-<subvol>, so it
 # LEADS with the 3-digit menu band and U-Boot's bls (filename sort, descending) orders entries by
@@ -337,25 +346,14 @@ emit_entry() {
     _opts="$BASE_OPTS"
     [ -n "$_extra" ] && _opts="$_opts $_extra"
     _fn="$ENTRIES/$ENTRY_TOKEN-$KERNEL_VERSION.conf"
-    _user="$(user_overlay_paths "$(fdt_prefix "$_opts")")"   # user drop-ins, always optional
-
-    if [ -z "$_dtbos" ]; then
-        write_entry "$_fn" "$(make_title "$_suf")" "$_opts" "$_user"
-        return 0
-    fi
-
-    # A leading '!' on the overlay list = required (skip the entry if the overlays are
-    # absent); otherwise optional (the entry is still written, sans overlay).
+    # a leading '!' on the list = required: skip the whole entry if those profile overlays are absent
     _required=0
     case "$_dtbos" in '!'*) _required=1; _dtbos="$(trim "${_dtbos#\!}")" ;; esac
-
-    _paths="$(overlay_paths "$(fdt_prefix "$_opts")" $_dtbos)" || _paths=""
-    if [ -z "$_paths" ] && [ "$_required" = 1 ]; then
-        log "skip $ENTRY_TOKEN (overlays not found for $KERNEL_VERSION)"
+    if [ "$_required" = 1 ] && [ -z "$(overlay_paths "$(fdt_prefix "$_opts")" $_dtbos 2>/dev/null)" ]; then
+        log "skip $ENTRY_TOKEN (required overlays not found for $KERNEL_VERSION)"
         return 0
     fi
-    # profile overlays first, then the user's drop-ins layered on top
-    write_entry "$_fn" "$(make_title "$_suf")" "$_opts" "$_paths${_paths:+${_user:+ }}$_user"
+    write_entry "$_fn" "$(make_title "$_suf")" "$_opts" "$(dt_overlay_line "$_opts" "$_dtbos")"
 }
 
 # flipper_write_entry <subvol> <mounted-path> [<origin-hint>]: write a BLS entry for an EXISTING
@@ -401,4 +399,45 @@ flipper_write_entry() {
     remove_entries "$_name" "$KERNEL_VERSION"
     emit_entry "$(printf '%s' "$_name" | tr -d '@')" "rootflags=subvol=$_name" "" ""
     echo "flipper-bls: wrote entry for $_name (kernel $KERNEL_VERSION, token $ENTRY_TOKEN)"
+}
+
+# Rewrite the devicetree-overlay line of the booted profile's BLS entries in place from the current
+# profile overlays + /etc/kernel/dtbo drop-ins, so changes take effect next boot without a full
+# kernel-install (no re-staging, no initrd rebuild).
+#   $1 scope: ""=the RUNNING kernel's entry only, "all"=every installed kernel of this profile
+# Root only; reboot afterwards.
+flipper_rewrite_overlay() {
+    _scope="${1:-}"
+    [ "$(id -u)" -eq 0 ] || { echo "flipper-bls: must run as root (use sudo)" >&2; return 1; }
+    ENTRIES="${KERNEL_INSTALL_BOOT_ROOT:-/boot}/loader/entries"
+    CONF_ROOT="${KERNEL_INSTALL_CONF_ROOT:-/etc/kernel}"
+    OVERLAY_USER_ROOT=""                        # these are the running root's own entries
+    _sv="$(booted_subvol)"
+    [ -n "$_sv" ] || { echo "flipper-bls: cannot determine the booted subvol" >&2; return 1; }
+    _run="$(uname -r)"
+
+    _dtbos=""
+    _pf="${FLIPPER_PROFILES:-$CONF_ROOT/flipper-profiles}"
+    if [ -f "$_pf" ]; then
+        while IFS='|' read -r _t _s _e _g _d _r; do
+            case "$_t" in ''|\#*) continue ;; esac
+            if [ "$(subvol_of "$(trim "$_e")")" = "$_sv" ]; then _dtbos="$(trim "${_d#\!}")"; break; fi
+        done <"$_pf"
+    fi
+
+    _n=0
+    for _f in "$ENTRIES"/*.conf; do
+        [ -f "$_f" ] || continue
+        _opts="$(sed -n 's/^options[[:space:]]*//p' "$_f")"
+        [ "$(subvol_of "$_opts")" = "$_sv" ] || continue
+        KERNEL_VERSION="$(sed -n 's/^version[[:space:]]*//p' "$_f")"
+        [ -n "$KERNEL_VERSION" ] || continue
+        [ "$_scope" = all ] || [ "$KERNEL_VERSION" = "$_run" ] || continue
+        set_dtb_dirs; OVERLAY_DIR="$DTB_DIR/$VENDOR"
+        _line="$(dt_overlay_line "$_opts" "$_dtbos")"
+        sed -i '/^devicetree-overlay[[:space:]]/d' "$_f"
+        [ -n "$_line" ] && printf 'devicetree-overlay %s\n' "$_line" >>"$_f"
+        _n=$((_n + 1)); echo "flipper-bls: updated ${_f##*/}"
+    done
+    [ "$_n" -gt 0 ] || { echo "flipper-bls: no matching entries for $_sv" >&2; return 1; }
 }

--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -409,12 +409,20 @@ flipper_write_entry() {
 flipper_rewrite_overlay() {
     _scope="${1:-}"
     [ "$(id -u)" -eq 0 ] || { echo "flipper-bls: must run as root (use sudo)" >&2; return 1; }
-    ENTRIES="${KERNEL_INSTALL_BOOT_ROOT:-/boot}/loader/entries"
-    CONF_ROOT="${KERNEL_INSTALL_CONF_ROOT:-/etc/kernel}"
-    OVERLAY_USER_ROOT=""                        # these are the running root's own entries
-    _sv="$(booted_subvol)"
+    # Defaults describe the running root. A caller working on a mounted target sets TARGET_SUBVOL
+    # and the three roots first (add-dtbo -d does, through with_bls).
+    ENTRIES="${ENTRIES:-${KERNEL_INSTALL_BOOT_ROOT:-/boot}/loader/entries}"
+    CONF_ROOT="${CONF_ROOT:-${KERNEL_INSTALL_CONF_ROOT:-/etc/kernel}}"
+    OVERLAY_USER_ROOT="${OVERLAY_USER_ROOT:-}"
+    _sv="${TARGET_SUBVOL:-$(booted_subvol)}"
     [ -n "$_sv" ] || { echo "flipper-bls: cannot determine the booted subvol" >&2; return 1; }
-    _run="$(uname -r)"
+    if [ -n "${TARGET_SUBVOL:-}" ]; then
+        # no running kernel over there, so the default scope is the newest it has, the one it boots
+        _run="$(ls -1d "$OVERLAY_USER_ROOT"/usr/lib/linux-image-* 2>/dev/null | sed 's,.*/linux-image-,,' | sort -V | tail -n1)"
+        [ -n "$_run" ] || { echo "flipper-bls: no kernel found in $_sv" >&2; return 1; }
+    else
+        _run="$(uname -r)"
+    fi
 
     _dtbos=""
     _pf="${FLIPPER_PROFILES:-$CONF_ROOT/flipper-profiles}"

--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -245,6 +245,23 @@ overlay_paths() {  # $1 = subvol prefix (e.g. /@Desktop); remaining args = overl
     printf '%s' "$_paths"
 }
 
+# Per-profile user drop-in overlays: every *.dtbo under this root's /etc/kernel/dtbo, applied to
+# each of the profile's entries. One layout, two views: OVERLAY_USER_ROOT picks whose drop-ins to
+# scan ("" = the running root, a mountpoint for any other), while the in-entry path is always the
+# same subvol-prefixed /etc/kernel/dtbo, since that is where the file sits inside the profile.
+# Silent no-op when the dir is absent or empty.
+OVERLAY_USER_PATH=/etc/kernel/dtbo
+user_overlay_paths() {  # $1 = subvol prefix (e.g. /@Desktop)
+    _udir="${OVERLAY_USER_ROOT:-}$OVERLAY_USER_PATH"
+    [ -d "$_udir" ] || return 0
+    _upaths=""
+    for _uf in "$_udir"/*.dtbo; do
+        [ -f "$_uf" ] || continue                     # unmatched glob -> skip
+        _upaths="$_upaths${_upaths:+ }$1$OVERLAY_USER_PATH/${_uf##*/}"
+    done
+    printf '%s' "$_upaths"
+}
+
 # Set BASE_OPTS from CONF_ROOT/cmdline (root=UUID + policy) + this kernel's console layout.
 # FIQ kernel -> console=ttyFIQ0 ; mainline -> console=ttyS0 + ttyS4 + fbcon=map:1.
 compute_base_opts() {
@@ -320,9 +337,10 @@ emit_entry() {
     _opts="$BASE_OPTS"
     [ -n "$_extra" ] && _opts="$_opts $_extra"
     _fn="$ENTRIES/$ENTRY_TOKEN-$KERNEL_VERSION.conf"
+    _user="$(user_overlay_paths "$(fdt_prefix "$_opts")")"   # user drop-ins, always optional
 
     if [ -z "$_dtbos" ]; then
-        write_entry "$_fn" "$(make_title "$_suf")" "$_opts" ""
+        write_entry "$_fn" "$(make_title "$_suf")" "$_opts" "$_user"
         return 0
     fi
 
@@ -336,7 +354,8 @@ emit_entry() {
         log "skip $ENTRY_TOKEN (overlays not found for $KERNEL_VERSION)"
         return 0
     fi
-    write_entry "$_fn" "$(make_title "$_suf")" "$_opts" "$_paths"
+    # profile overlays first, then the user's drop-ins layered on top
+    write_entry "$_fn" "$(make_title "$_suf")" "$_opts" "$_paths${_paths:+${_user:+ }}$_user"
 }
 
 # flipper_write_entry <subvol> <mounted-path> [<origin-hint>]: write a BLS entry for an EXISTING
@@ -372,6 +391,7 @@ flipper_write_entry() {
     # devicetreedir is the target root's OWN kernel dir (KERNEL_VERSION came from it, so it exists).
     DEVICETREEDIR_REL="/usr/lib/linux-image-$KERNEL_VERSION"
     OVERLAY_DIR="$DTB_DIR/$VENDOR"
+    OVERLAY_USER_ROOT="$_snap"                  # scan the TARGET root's drop-ins, not the running one
     # pin the root's own entry-token so a later runtime apt install in it lands in the same band
     mkdir -p "$_snap/etc/kernel" && printf '%s\n' "$ENTRY_TOKEN" > "$_snap/etc/kernel/entry-token"
     # Remove any existing entry for this root+version first. The entry filename holds a sort

--- a/overlays/usr/local/sbin/add-dtbo
+++ b/overlays/usr/local/sbin/add-dtbo
@@ -1,0 +1,84 @@
+#!/bin/sh
+# add-dtbo - manage this profile's user device-tree overlays in /etc/kernel/dtbo and apply them to
+# the booted profile's BLS boot entry without a full kernel-install. Reboot to load changes. By
+# default only the BOOTED kernel's entry is touched; --all-kernels does every installed kernel.
+set -eu
+. /usr/lib/flipper-bls.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-bls.sh not found" >&2; exit 1; }
+DROPDIR="$OVERLAY_USER_PATH"   # the library owns the path; deriving keeps the two in step
+
+usage() {
+    cat <<EOF
+Usage: add-dtbo [--all-kernels] FILE.dtbo ...    copy each FILE into $DROPDIR, then apply
+       add-dtbo [--all-kernels] --rm NAME ...    remove each named overlay from $DROPDIR, then apply
+       add-dtbo [--all-kernels] --apply          apply the overlays already in $DROPDIR
+       add-dtbo [--all-kernels] --clear          remove all user overlays from $DROPDIR, then apply
+       add-dtbo --list                           list the *.dtbo in $DROPDIR
+       add-dtbo --help                           show this help
+EOF
+}
+
+_scope=""; _action=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --all-kernels) _scope=all ;;
+        --rm)          _action=rm ;;
+        --apply)       _action=apply ;;
+        --clear)       _action=clear ;;
+        --list)        _action=list ;;
+        -h|--help)     usage; exit 0 ;;
+        --)            shift; break ;;
+        -?*)           echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)             break ;;
+    esac
+    shift
+done
+
+if [ $# -gt 0 ]; then
+    case "$_action" in
+        '') _action=apply ;;
+        apply|rm) ;;
+        *) echo "Error: files cannot be combined with --$_action" >&2; exit 1 ;;
+    esac
+elif [ "$_action" = rm ]; then
+    echo "Error: --rm needs at least one NAME" >&2; exit 1
+fi
+[ -n "$_action" ] || { usage; exit 0; }
+
+if [ "$_action" = list ]; then
+    echo "User overlays in $DROPDIR:"
+    if ls "$DROPDIR"/*.dtbo >/dev/null 2>&1; then
+        for f in "$DROPDIR"/*.dtbo; do echo "  ${f##*/}"; done
+    else
+        echo "  (none)"
+    fi
+    exit 0
+fi
+
+[ "$(id -u)" -eq 0 ] || { echo "Error: must run as root (use sudo)" >&2; exit 1; }
+
+case "$_action" in
+    clear)
+        rm -f "$DROPDIR"/*.dtbo
+        echo "Removed all user overlays from $DROPDIR"
+        ;;
+    rm)
+        for f in "$@"; do
+            _t="$DROPDIR/${f##*/}"
+            [ -f "$_t" ] || { echo "Error: no such overlay: ${f##*/}" >&2; exit 1; }
+            rm -f "$_t"
+            echo "removed ${f##*/}"
+        done
+        ;;
+    apply)
+        install -d -m 755 "$DROPDIR"
+        for f in "$@"; do
+            [ -f "$f" ] || { echo "Error: no such file: $f" >&2; exit 1; }
+            case "$f" in *.dtbo) ;; *) echo "Error: not a .dtbo: $f" >&2; exit 1 ;; esac
+            cp -f "$f" "$DROPDIR/"
+            echo "copied ${f##*/} -> $DROPDIR/"
+        done
+        ;;
+esac
+
+flipper_rewrite_overlay "$_scope"
+echo "Reboot to load changes."

--- a/overlays/usr/local/sbin/add-dtbo
+++ b/overlays/usr/local/sbin/add-dtbo
@@ -1,10 +1,15 @@
 #!/bin/sh
-# add-dtbo - manage this profile's user device-tree overlays in /etc/kernel/dtbo and apply them to
-# the booted profile's BLS boot entry without a full kernel-install. Reboot to load changes. By
-# default only the BOOTED kernel's entry is touched; --all-kernels does every installed kernel.
+# add-dtbo - manage a profile's user device-tree overlays in /etc/kernel/dtbo and apply them to its
+# BLS boot entry without a full kernel-install. Reboot to load changes. By default only the BOOTED
+# kernel's entry is touched; --all-kernels does every installed kernel.
+#
+# Without -d/-p this is the booted profile. With them it is a profile on another filesystem, which
+# is how a bad overlay gets removed from a profile that no longer boots (from a recovery boot).
+# There is no running kernel over there, so the default scope is that profile's newest.
 set -eu
 . /usr/lib/flipper-bls.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-bls.sh not found" >&2; exit 1; }
 DROPDIR="$OVERLAY_USER_PATH"   # the library owns the path; deriving keeps the two in step
+DROPSHOW="$DROPDIR"            # what we print: under -d the real path is a temp mountpoint
 
 usage() {
     cat <<EOF
@@ -14,13 +19,19 @@ Usage: add-dtbo [--all-kernels] FILE.dtbo ...    copy each FILE into $DROPDIR, t
        add-dtbo [--all-kernels] --clear          remove all user overlays from $DROPDIR, then apply
        add-dtbo --list                           list the *.dtbo in $DROPDIR
        add-dtbo --help                           show this help
+  -d,--device DEV   operate on btrfs filesystem DEV instead of the booted root (needs -p)
+  -p,--profile @X   the profile to act on, instead of the booted one
 EOF
 }
 
-_scope=""; _action=""
+_scope=""; _action=""; _dev=""; _prof=""
 while [ $# -gt 0 ]; do
     case "$1" in
         --all-kernels) _scope=all ;;
+        -d|--device)   shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; exit 1; }; _dev=$1 ;;
+        --device=*)    _dev=${1#*=} ;;
+        -p|--profile)  shift; [ $# -ge 1 ] || { echo "Error: --profile needs an argument" >&2; exit 1; }; _prof=$1 ;;
+        --profile=*)   _prof=${1#*=} ;;
         --rm)          _action=rm ;;
         --apply)       _action=apply ;;
         --clear)       _action=clear ;;
@@ -44,8 +55,29 @@ elif [ "$_action" = rm ]; then
 fi
 [ -n "$_action" ] || { usage; exit 0; }
 
+# -d/-p work on a mounted filesystem: everything below then reads DROPDIR and the bls context from
+# the target instead of the running root. -d alone cannot say WHICH profile, so it needs -p.
+TOP=""
+if [ -n "$_dev" ] || [ -n "$_prof" ]; then
+    [ -n "$_prof" ] || { echo "Error: -d/--device needs -p/--profile to say which profile" >&2; exit 1; }
+    . /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
+    need_root
+    need_btrfs
+    [ -n "$_dev" ] && ROOTDEV=$_dev
+    validate_profile_name "$_prof"
+    mount_top
+    set_lock
+    [ -d "$TOP/$_prof" ] || die "No such profile: $_prof (see list-profiles)"
+    DROPDIR="$TOP/$_prof$OVERLAY_USER_PATH"
+    TARGET_SUBVOL="$_prof"
+    OVERLAY_USER_ROOT="$TOP/$_prof"
+    CONF_ROOT="$TOP/$_prof/etc/kernel"
+    ENTRIES="$TOP/boot/loader/entries"
+    DROPSHOW="$_prof$OVERLAY_USER_PATH"
+fi
+
 if [ "$_action" = list ]; then
-    echo "User overlays in $DROPDIR:"
+    echo "User overlays in $DROPSHOW:"
     if ls "$DROPDIR"/*.dtbo >/dev/null 2>&1; then
         for f in "$DROPDIR"/*.dtbo; do echo "  ${f##*/}"; done
     else
@@ -59,7 +91,7 @@ fi
 case "$_action" in
     clear)
         rm -f "$DROPDIR"/*.dtbo
-        echo "Removed all user overlays from $DROPDIR"
+        echo "Removed all user overlays from $DROPSHOW"
         ;;
     rm)
         for f in "$@"; do
@@ -75,7 +107,7 @@ case "$_action" in
             [ -f "$f" ] || { echo "Error: no such file: $f" >&2; exit 1; }
             case "$f" in *.dtbo) ;; *) echo "Error: not a .dtbo: $f" >&2; exit 1 ;; esac
             cp -f "$f" "$DROPDIR/"
-            echo "copied ${f##*/} -> $DROPDIR/"
+            echo "copied ${f##*/} -> $DROPSHOW/"
         done
         ;;
 esac


### PR DESCRIPTION
## What

Lets a user drop device-tree overlays into a per-profile directory and have them applied to that
profile's boot, without rebuilding the image or a full kernel-install. Two parts:

1. **Per-profile user overlays** (`flipper-bls.sh`): every `*.dtbo` in a profile's
   `/etc/kernel/dtbo/` is merged into that profile's BLS `devicetree-overlay` line, subvol-prefixed
   (`/@<subvol>/etc/kernel/dtbo/...`), alongside the kernel-shipped profile overlays. Un-versioned,
   so drop-ins survive kernel updates.

2. **`add-dtbo` CLI**: apply/manage a profile's drop-in overlays in-place (rewrites only the booted
   profile's `devicetree-overlay` line via `sed`, no re-staging/initrd rebuild):
   - `add-dtbo FILE.dtbo ...` copy in + apply (multiple at once)
   - `add-dtbo --rm NAME ...` remove named overlay(s) + apply
   - `add-dtbo --clear` remove all (deletes the files, durable across kernel updates)
   - `add-dtbo --apply` re-sync the entry to the dir
   - `add-dtbo --list`, `add-dtbo --help`; `--all-kernels` scopes to every installed kernel
   Bare invocation prints usage; unknown options are rejected.

Overlays stay on the `compress=zstd` root as-is: U-Boot (zstd 1.5.7, PR #37) reads zstd-compressed
`.dtbo` / `.dtb` / loader entries directly, so no special filesystem handling is needed.

## On-device validation (flipper1, @Minimal)

- Adding one/multiple overlays updates only the booted profile + running-kernel entry, subvol-prefixed;
  U-Boot boot log shows it retrieving/applying `/@Minimal/etc/kernel/dtbo/<x>.dtbo`, and
  `/proc/device-tree/<node>` confirms it took effect after reboot.
- `--rm` drops just the named overlay; `--clear` empties the dir and the line.
- Non-root apt/tooling paths and `-h` behave correctly.
