### PR TITLE
Add @No-Graphics headless profile

### DIFF
--- a/debian-rk3576-img.yaml
+++ b/debian-rk3576-img.yaml
@@ -368,6 +368,36 @@ actions:
       btrfs property set "$TOP/@Router_stock" ro true
       btrfs subvolume snapshot "$TOP/@Router_stock" "$TOP/@Router"
 
+  # --- @No-Graphics ----------------------------------------------------------
+  # Headless @Minimal: same userspace, no extra packages. The graphics pipeline (VOP/HDMI/
+  # DP/GPU) is powered off entirely by the rk3576-no-graphics DT overlay its BLS entry applies
+  # (dtbos column), so it only needs its own root subvol + pinned entry-token.
+  - action: run
+    description: Snapshot writable @No-Graphics_stock and mount it
+    chroot: false
+    command: |
+      set -eu
+      TOP="${IMAGEMNTDIR%/}.toplevel"
+      ROOTPART="$(findmnt -fn --nofsroot -o SOURCE --target "$TOP")"
+      btrfs subvolume snapshot "$TOP/@Minimal_stock" "$TOP/@No-Graphics_stock"
+      mount -t btrfs -o "{{ $btrfsopts }},subvol=@No-Graphics_stock" "$ROOTPART" "$IMAGEMNTDIR"
+  - action: run
+    description: Pin @No-Graphics's kernel entry-token (NN from flipper-profiles)
+    chroot: true
+    command: |
+      set -eu
+      . /usr/lib/flipper-bls.sh
+      make_token "$(profile_base_nn @No-Graphics)" @No-Graphics > /etc/kernel/entry-token
+  - action: run
+    description: Lock @No-Graphics_stock RO and spawn writable @No-Graphics
+    chroot: false
+    command: |
+      set -eu
+      TOP="${IMAGEMNTDIR%/}.toplevel"
+      umount "$IMAGEMNTDIR"
+      btrfs property set "$TOP/@No-Graphics_stock" ro true
+      btrfs subvolume snapshot "$TOP/@No-Graphics_stock" "$TOP/@No-Graphics"
+
   # Unmount the top level and remount @Minimal at the mountpoint debos owns, so its
   # image-partition Cleanup can unmount it and detach the loop. (The profile builds left
   # $IMAGEMNTDIR unmounted, and the lingering top-level mount would hold the loop busy.)

--- a/overlays/configs/kernel/flipper-profiles
+++ b/overlays/configs/kernel/flipper-profiles
@@ -2,7 +2,7 @@
 #
 # Every bootable session, including the default desktop, is a line below; there is no
 # separate base entry. Each lives in its own btrfs root subvolume (@Desktop, @Minimal,
-# @TV-Media-Box, @Router) selected by its OWN `rootflags=subvol=@<name>` (the cmdline no
+# @No-Graphics, @TV-Media-Box, @Router) selected by its OWN `rootflags=subvol=@<name>` (the cmdline no
 # longer carries one). The session (KDE/kodi/router) is baked into each root's
 # default.target; no systemd.unit= needed.
 #
@@ -40,6 +40,7 @@ desktop|[DESKTOP]     |rootflags=subvol=@Desktop       |               |        
 tvbox  |[TV MEDIA BOX]|rootflags=subvol=@TV-Media-Box  |               |hdmi-cec  |Kodi media-box session
 router |[ROUTER]      |rootflags=subvol=@Router        |               |          |Wi-Fi router mode
 minimal|[MINIMAL]     |rootflags=subvol=@Minimal       |               |          |No desktop (cog kiosk only)
+nogfx  |[NO GRAPHICS] |rootflags=subvol=@No-Graphics   |               |!rk3576-no-graphics|Headless (VOP/HDMI/GPU off)
 #hdmi4k|[HDMI-4K]     |dyndbg="file drivers/gpu/drm/rockchip/dw-dp.c +p"|ROCKCHIP_DW_DP|!rk3576-evb1-v10-typec-base rk3576-evb1-v10-typec-hdmi-dp|HDMI 4k (on @Desktop)
 #dp4k  |[DP-4K]       |dyndbg="file drivers/gpu/drm/rockchip/dw-dp.c +p"|ROCKCHIP_DW_DP|!rk3576-evb1-v10-typec-base rk3576-evb1-v10-typec-dp-hdmi|DisplayPort 4k (on @Desktop)
 #fan   |[FAN]         |                                |               |!rk3576-evb1-v10-fan-pwm|PWM fan control


### PR DESCRIPTION
## Summary

Adds a headless `@No-Graphics` boot profile:

- **Headless variant of `@Minimal`**: same userspace, no extra packages. The graphics pipeline (VOP / HDMI / DP / GPU) is powered off entirely by the `rk3576-no-graphics` DT overlay its BLS entry applies.
- **New btrfs root**: `@No-Graphics` snapshotted from `@Minimal_stock`, with its own read-only `@No-Graphics_stock` golden base, following the same per-profile subvolume pattern as the other profiles.
- **Pinned kernel entry-token** (`make_token` with the band NN from `flipper-profiles`) so a later in-profile `apt install` lands in the right menu band.
- **New `flipper-profiles` band** (`nogfx`) whose `dtbos` column marks `rk3576-no-graphics` as REQUIRED (`!` prefix), so the entry is only emitted on kernels that ship the overlay.

## Dependency

Requires the kernel-side `rk3576-no-graphics` DT overlay. Because the overlay is marked required, the profile's BLS entry is skipped on kernels that lack it, so this is safe to merge ahead of the overlay landing; the entry simply will not appear until the overlay is present.
