### PR TITLE
Rename profile menu labels and put version after them

### DIFF
--- a/overlays/configs/kernel/flipper-profiles
+++ b/overlays/configs/kernel/flipper-profiles
@@ -14,7 +14,7 @@
 # Columns (pipe-separated; '#' starts a comment line):
 #   1 token        short id used in the entry filename. The generator also prepends a
 #                  position-derived "NN-" prefix so this list's order becomes the menu order.
-#   2 suffix       appended to the menu title, e.g. "[ROUTER]"
+#   2 label        shown at the start of the menu title, before the version, e.g. "Router"
 #   3 cmdline      extra kernel command-line fragment: root selection
 #                  (rootflags=subvol=@<name>) and/or tweaks (may be empty)
 #   4 gate         required kernel config symbol(s) (=y/=m in /boot/config-<ver>);
@@ -36,12 +36,12 @@
 # the btrfs snapshot parent chain), so clones sit just above. Reorder these lines to reorder the
 # menu. (See flipper-bls.sh's emit_entry header for the full scheme.)
 
-desktop|[DESKTOP]     |rootflags=subvol=@Desktop       |               |          |Default desktop (KDE/sddm)
-tvbox  |[TV MEDIA BOX]|rootflags=subvol=@TV-Media-Box  |               |hdmi-cec  |Kodi media-box session
-router |[ROUTER]      |rootflags=subvol=@Router        |               |          |Wi-Fi router mode
-minimal|[MINIMAL]     |rootflags=subvol=@Minimal       |               |          |No desktop (cog kiosk only)
-nogfx  |[NO GRAPHICS] |rootflags=subvol=@No-Graphics   |               |!rk3576-no-graphics|Headless (VOP/HDMI/GPU off)
-#hdmi4k|[HDMI-4K]     |dyndbg="file drivers/gpu/drm/rockchip/dw-dp.c +p"|ROCKCHIP_DW_DP|!rk3576-evb1-v10-typec-base rk3576-evb1-v10-typec-hdmi-dp|HDMI 4k (on @Desktop)
-#dp4k  |[DP-4K]       |dyndbg="file drivers/gpu/drm/rockchip/dw-dp.c +p"|ROCKCHIP_DW_DP|!rk3576-evb1-v10-typec-base rk3576-evb1-v10-typec-dp-hdmi|DisplayPort 4k (on @Desktop)
-#fan   |[FAN]         |                                |               |!rk3576-evb1-v10-fan-pwm|PWM fan control
-#ncm   |[USB NCM]     |systemd.wants=usb-ncm-gadget.service|USB_CONFIGFS_NCM USB_F_NCM|usb-ncm|USB NCM Ethernet gadget
+desktop|Desktop       |rootflags=subvol=@Desktop       |               |          |Default desktop (KDE/sddm)
+tvbox  |TV Media Box  |rootflags=subvol=@TV-Media-Box  |               |hdmi-cec  |Kodi media-box session
+router |Router        |rootflags=subvol=@Router        |               |          |Wi-Fi router mode
+minimal|Minimal       |rootflags=subvol=@Minimal       |               |          |No desktop (cog kiosk only)
+nogfx  |No Graphics   |rootflags=subvol=@No-Graphics   |               |!rk3576-no-graphics|Headless (VOP/HDMI/GPU off)
+#hdmi4k|HDMI 4K       |dyndbg="file drivers/gpu/drm/rockchip/dw-dp.c +p"|ROCKCHIP_DW_DP|!rk3576-evb1-v10-typec-base rk3576-evb1-v10-typec-hdmi-dp|HDMI 4k (on @Desktop)
+#dp4k  |DP 4K         |dyndbg="file drivers/gpu/drm/rockchip/dw-dp.c +p"|ROCKCHIP_DW_DP|!rk3576-evb1-v10-typec-base rk3576-evb1-v10-typec-dp-hdmi|DisplayPort 4k (on @Desktop)
+#fan   |Fan           |                                |               |!rk3576-evb1-v10-fan-pwm|PWM fan control
+#ncm   |USB NCM       |systemd.wants=usb-ncm-gadget.service|USB_CONFIGFS_NCM USB_F_NCM|usb-ncm|USB NCM Ethernet gadget

--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -168,12 +168,13 @@ clone_slot() {  # $1 = mounted path (default /); $2 = origin hint (optional)
 }
 
 # Menu titles must fit the small screen: cap total at TITLE_MAX by trimming the (long) version
-# while keeping the suffix intact. (Filenames + the 'version' field keep the full version.)
+# while keeping the label intact. Label leads, the (possibly trimmed) version follows.
+# (Filenames + the 'version' field keep the full version.)
 make_title() {
     _suf="$1"
     _avail=$(( TITLE_MAX - ${#_suf} - 1 ))
     if [ "$_avail" -ge 1 ]; then
-        printf '%s %s' "$(printf '%s' "$KERNEL_VERSION" | cut -c"1-$_avail")" "$_suf"
+        printf '%s %s' "$_suf" "$(printf '%s' "$KERNEL_VERSION" | cut -c"1-$_avail")"
     else
         printf '%s' "$_suf" | cut -c"1-$TITLE_MAX"
     fi


### PR DESCRIPTION
## Summary

Cleans up the boot-menu profile titles:

- **Bracket-less labels** in `flipper-profiles`: `[DESKTOP]` -> `Desktop`, `[MINIMAL]` -> `Minimal`, `[NO GRAPHICS]` -> `No Graphics`, and so on for every band (including the commented examples).
- **Label leads the title**: `make_title` now emits `<label> <version>` (e.g. `Desktop 6.1.75-...`) instead of `<version> <label>`. The `TITLE_MAX` cap is unchanged: the label is kept intact and the version is trimmed to fit.
- Header/column comment updated (column 2 is now a leading label, not a suffix).

## Why it is safe

The label is display-only. Entry matching (`90-loaderentry.install`, build fan-out in `img.yaml`) keys off the subvolume (`rootflags=subvol=`), and menu band numbers derive from line position + subvolume via `profile_base_nn`, which never reads the label. Verified: band slots unchanged (desktop 900 ... nogfx 500), `sh -n` clean, no script parses the title back or matches bracketed labels.
