### PR TITLE
btrfs tools: cloned-profile first-boot fix and clearer booted marker

### DIFF
--- a/overlays/usr/local/sbin/btrfs-show-space
+++ b/overlays/usr/local/sbin/btrfs-show-space
@@ -59,7 +59,7 @@ row() {  # $1=display name  $2=fs path  -> append a TSV row
     fi
     id=$(subvol_id "$2")
     mark=""; [ -n "$cur_id" ] && [ "$id" = "$cur_id" ] && mark="<- booted"
-    printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$(human "$exc")" "$ref_h" "$(human "$tot")" "$mark" >> "$rows"
+    printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$mark" "$(human "$exc")" "$ref_h" "$(human "$tot")" >> "$rows"
 }
 
 # collect subvols (cheap), then measure with progress: each row walks extents (slow on flash)
@@ -76,7 +76,7 @@ for d in "$TOP"/@*; do
 done
 total=$(wc -l < "$list" 2>/dev/null | tr -d ' '); [ -n "$total" ] || total=0
 
-printf 'NAME\tUNIQUE\tREFERENCED\tTOTAL\t\n' > "$rows"
+printf 'NAME\t\tUNIQUE\tREFERENCED\tTOTAL\n' > "$rows"
 if [ "$total" -gt 0 ]; then
     if [ "$have_cs" = 1 ]; then note="du + compsize"; else note="du only"; fi
     printf 'Measuring %s subvolume(s) (%s), please wait...\n' "$total" "$note" >&2
@@ -90,15 +90,13 @@ done < "$list"
 { [ -t 2 ] && [ "$total" -gt 0 ] && printf '\r\033[K' >&2; } || true
 
 echo "== root subvolumes & snapshots =="
-# align: NAME auto-width; numeric columns right-justified; marker appended
+# align: NAME auto-width; marker column after NAME; numeric columns right-justified
 awk -F'\t' '
 { r[NR]=$0; if (length($1) > w) w = length($1) }
 END {
     for (i = 1; i <= NR; i++) {
         split(r[i], f, "\t")
-        printf "%-*s  %11s %11s %11s", w, f[1], f[2], f[3], f[4]
-        if (f[5] != "") printf "  %s", f[5]
-        printf "\n"
+        printf "%-*s  %-9s %11s %11s %11s\n", w, f[1], f[2], f[3], f[4], f[5]
     }
 }' "$rows"
 

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -112,6 +112,10 @@ fi
 # make writable; on a moved snapshot preserves parent_uuid, drops received_uuid
 btrfs property set "$tgt" ro false 2>/dev/null || true
 
+# reset machine-id so the profile first-boots (fresh id + hostname/banner) instead of inheriting the source's
+printf 'uninitialized\n' > "$tgt/etc/machine-id" 2>/dev/null || true
+rm -f "$tgt/var/lib/dbus/machine-id" 2>/dev/null || true
+
 # BLS entry + /etc/kernel/entry-token via flipper-bls.sh, in a subshell so its die can't abort
 # us. Pass the SOURCE as origin hint so the root lands in that profile's band if parent_uuid is
 # left dangling.

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -36,7 +36,7 @@ build_uuid_map "$TOP" "$map"
 cur=$(btrfs subvolume show / 2>/dev/null) || cur=
 cur_id=$(get "$cur" "Subvolume ID")
 cur_path=$(printf '%s\n' "$cur" | head -n1)
-[ -n "$cur_path" ] && echo "Booted profile: $cur_path (id ${cur_id:-?})"
+[ -n "$cur_path" ] && echo "Currently booted profile: $cur_path (id ${cur_id:-?})"
 echo
 
 emit() {  # $1=display name  $2=fs path
@@ -51,10 +51,10 @@ emit() {  # $1=display name  $2=fs path
         *)       kind=profile ;;
     esac
     mark=""; [ -n "$cur_id" ] && [ "$id" = "$cur_id" ] && mark="<- booted"
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$kind" "${id:-?}" "${otime:-?}" "$flags" "$parent" "$mark" >> "$rows"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$mark" "$kind" "${id:-?}" "${otime:-?}" "$flags" "$parent" >> "$rows"
 }
 
-printf 'NAME\tKIND\tID\tCREATED\tRO\tPARENT\t\n' > "$rows"
+printf 'NAME\t\tKIND\tID\tCREATED\tRO\tPARENT\n' > "$rows"
 # top-level roots, _stock bases, @.old_* leftovers; skip shared subvols + @snapshots
 for d in "$TOP"/@*; do
     [ -e "$d" ] || continue


### PR DESCRIPTION
Two small fixes to the btrfs profile tooling.

**create-profile: reset machine-id so new profiles first-boot**

A profile snapshotted from a booted one inherits its committed
`/etc/machine-id`, so systemd does not treat the new profile as a first
boot and skips the `ConditionFirstBoot=yes` units (hostname, SSH banner).
The profile then keeps the source's stale banner (naming the source) and
shares its machine-id.

`create-profile` now writes the `uninitialized` sentinel to
`/etc/machine-id` (an empty file would NOT count as first boot per
`machine-id(5)`) and drops the dbus copy, so the new profile first-boots:
systemd generates a fresh unique id and re-runs first-boot setup for it.

**list-profiles, btrfs-show-space: move booted marker next to the name**

The `<- booted` marker sat in a trailing column after PARENT
(list-profiles) and TOTAL (btrfs-show-space), where it read as pointing at
that value. Move it to its own column right after NAME so it points back
at the name.

```
NAME                       KIND     ID   CREATED              RO  PARENT
@Desktop        <- booted  profile  265  2026-07-03 12:14:21  rw  @Desktop_stock (264)
@Minimal                   profile  263  2026-07-03 12:10:22  rw  @Minimal_stock (262)
```
