### PR TITLE
kernel/install.conf: set initrd_generator=none

### DIFF
--- a/overlays/configs/kernel/install.conf
+++ b/overlays/configs/kernel/install.conf
@@ -1,2 +1,2 @@
 layout=bls
-initrd_generator=dracut
+initrd_generator=none


### PR DESCRIPTION
dracut is not installed in the image (only initramfs-tools), so kernel-install's `initrd_generator=dracut` was a no-op: it left the staging area empty and the loaderentry plugin fell back to initramfs-tools' /boot/initrd.img-<ver>. Set the generator to `none` to reflect that initramfs-tools produces the initrd via its own postinst.d hook, not kernel-install.