### PR TITLE
kernel: boot kernel+initrd from the profile subvol, not /boot

### DIFF
--- a/debian-rk3576-img.yaml
+++ b/debian-rk3576-img.yaml
@@ -165,14 +165,14 @@ actions:
       mkdir -p "$ENTRIES"; SORT_KEY="$(os_sort_key)"
       for _k in /boot/vmlinuz-*; do
         [ -e "$_k" ] || continue
-        KERNEL_VERSION="${_k#/boot/vmlinuz-}"; KCONFIG="/boot/config-$KERNEL_VERSION"
+        KERNEL_VERSION="${_k#/boot/vmlinuz-}"; resolve_kconfig
         set_dtb_dirs; discover_devicetreedir; compute_base_opts
         _i=0
         while IFS='|' read -r tok suf extra gate dtbos legend; do
           tok="$(echo "$tok" | tr -d '[:space:]')"; case "$tok" in ''|\#*) continue ;; esac
           extra="$(trim "$extra")"; _sv="$(subvol_of "$extra")"
           ENTRY_TOKEN="$(make_token "$(printf '%03d' "$((900 - _i * 100))")" "$_sv")"
-          remove_entries "$_sv" "$KERNEL_VERSION"; stage_kernel_reflink
+          remove_entries "$_sv" "$KERNEL_VERSION"; resolve_kernel_paths "$_sv"
           emit_entry "$(trim "$suf")" "$extra" "$(trim "$gate")" "$(trim "$dtbos")"
           _i=$((_i + 1))
         done <"$PROFILES"

--- a/overlays/configs/initramfs/post-update.d/zz-flipper-kernel-install
+++ b/overlays/configs/initramfs/post-update.d/zz-flipper-kernel-install
@@ -1,0 +1,16 @@
+#!/bin/sh
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# `update-initramfs -u` (a config-change rebuild, not a kernel install) writes a fresh initrd to
+# /boot without calling kernel-install, so re-invoke it here to relocate the initrd into the profile
+# and refresh the entry. Idempotent; also fires harmlessly on kernel installs (via -c).
+# Args from initramfs-tools: $1 = version, $2 = initrd path (unused).
+set -e
+[ -n "$1" ] || exit 0
+command -v kernel-install >/dev/null 2>&1 || exit 0
+
+img="/usr/lib/modules/$1/vmlinuz"
+[ -f "$img" ] || img="/boot/vmlinuz-$1"
+[ -f "$img" ] || exit 0
+
+kernel-install add "$1" "$img"

--- a/overlays/configs/kernel/install.d/55-flipper-initrd.install
+++ b/overlays/configs/kernel/install.d/55-flipper-initrd.install
@@ -1,0 +1,34 @@
+#!/bin/sh
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Move the initrd (initramfs-tools writes it to /boot) into /usr/lib/modules/<ver>/initrd so a
+# profile carries its whole boot set and ships bootable in a btrfs send stream, leaving /boot clean.
+# Kernel+initrd must stay uncompressed: U-Boot's btrfs driver cannot read inline zstd extents.
+set -e
+. /usr/lib/flipper-bls.sh
+
+[ "$KERNEL_INSTALL_LAYOUT" = bls ] || exit 0
+KERNEL_VERSION="${2:?}"
+UM="/usr/lib/modules/$KERNEL_VERSION"
+
+if [ "$1" = remove ]; then
+    rm -f "$UM/initrd"          # untracked by dpkg
+    exit 0
+fi
+[ "$1" = add ] || exit 0
+[ -d "$UM" ] || exit 0
+
+# new files here inherit compression=none; the dpkg-installed vmlinuz is rewritten below
+command -v btrfs >/dev/null 2>&1 && btrfs property set "$UM" compression none 2>/dev/null || :
+
+# reflink the initrd in (shares /boot's uncompressed extents), then drop the /boot copy
+for IRD in "$KERNEL_INSTALL_STAGING_AREA/initrd" "/boot/initrd.img-$KERNEL_VERSION" ""; do
+    [ -n "$IRD" ] && [ -f "$IRD" ] && break
+done
+if [ -n "$IRD" ]; then
+    cp --reflink=auto "$IRD" "$UM/initrd" && chmod 0644 "$UM/initrd" \
+        && rm -f "/boot/initrd.img-$KERNEL_VERSION"
+fi
+
+uncompress "$UM/vmlinuz"
+exit 0

--- a/overlays/configs/kernel/install.d/90-loaderentry.install
+++ b/overlays/configs/kernel/install.d/90-loaderentry.install
@@ -22,8 +22,6 @@ set -e
 COMMAND="${1:?}"
 KERNEL_VERSION="${2:?}"
 ENTRY_DIR_ABS="${3:?}"
-KERNEL_IMAGE="$4"
-INITRD_SHIFT=4
 
 [ "$KERNEL_INSTALL_LAYOUT" = "bls" ] || exit 0
 
@@ -33,7 +31,7 @@ MACHINE_ID="${KERNEL_INSTALL_MACHINE_ID:-}"
 CONF_ROOT="${KERNEL_INSTALL_CONF_ROOT:-/etc/kernel}"
 ENTRIES="$BOOT_ROOT/loader/entries"
 PROFILES="${FLIPPER_PROFILES:-/etc/kernel/flipper-profiles}"
-KCONFIG="$BOOT_ROOT/config-$KERNEL_VERSION"
+resolve_kconfig
 set_dtb_dirs
 [ -n "${BOOT_MNT:-}" ] || BOOT_MNT="/"
 
@@ -52,7 +50,6 @@ fi
 [ "$COMMAND" = "add" ] || exit 0
 
 ENTRY_DIR="$(boot_rel "$ENTRY_DIR_ABS")"
-[ -d "$ENTRY_DIR_ABS" ] || die "entry directory '$ENTRY_DIR_ABS' does not exist"
 mkdir -p "$ENTRIES" || die "could not create '$ENTRIES'"
 
 # Base cmdline shared by every entry (profiles append their rootflags=subvol=).
@@ -61,14 +58,12 @@ compute_base_opts
 # Standard BLS sort-key (os-release IMAGE_ID, else ID).
 SORT_KEY="$(os_sort_key)"
 
-# Kernel image.
-stage_file "$KERNEL_IMAGE" "$ENTRY_DIR_ABS/linux"
-KERNEL_ENTRY="$ENTRY_DIR/linux"
-
-# devicetree (single, optional): copied into the entry dir.
+# devicetree (single, optional): copied into the entry dir (the only thing that still uses it, so
+# create it on demand rather than relying on kernel-install's core having made it).
 DEVICETREE=""; DEVICETREE_ENTRY=""
 [ -f "$CONF_ROOT/devicetree" ] && read -r DEVICETREE <"$CONF_ROOT/devicetree" || :
 if [ -n "$DEVICETREE" ]; then
+    mkdir -p "$ENTRY_DIR_ABS"
     for p in "$CONF_ROOT" $DTB_DIRS; do
         [ -f "$p/$DEVICETREE" ] || continue
         stage_file "$p/$DEVICETREE" "$ENTRY_DIR_ABS/${DEVICETREE##*/}"
@@ -81,31 +76,13 @@ fi
 # devicetreedir (U-Boot fdtdir extension) + overlay dir.
 discover_devicetreedir
 
-# initrd(s): from the kernel-install staging area, positional args, or well-known names.
-shift "$INITRD_SHIFT"
-INITRD_ENTRIES=""
-add_initrd() { INITRD_ENTRIES="$INITRD_ENTRIES${INITRD_ENTRIES:+ }$1"; }
-for i in "$KERNEL_INSTALL_STAGING_AREA"/microcode* "$@" "$KERNEL_INSTALL_STAGING_AREA"/initrd*; do
-    if [ ! -f "$i" ]; then
-        case "$i" in
-            "$KERNEL_INSTALL_STAGING_AREA"/initrd* | "$KERNEL_INSTALL_STAGING_AREA"/microcode*) continue ;;
-        esac
-        die "'$i' is not a file"
-    fi
-    _bn="${i##*/}"
-    stage_file "$i" "$ENTRY_DIR_ABS/$_bn"
-    add_initrd "$ENTRY_DIR/$_bn"
-done
-[ -z "$INITRD_ENTRIES" ] && [ -f "$ENTRY_DIR_ABS/initrd" ] && add_initrd "$ENTRY_DIR/initrd"
-[ -z "$INITRD_ENTRIES" ] && [ -f "$BOOT_ROOT/initramfs-$KERNEL_VERSION.img" ] && add_initrd "$(boot_rel "$BOOT_ROOT/initramfs-$KERNEL_VERSION.img")"
-[ -z "$INITRD_ENTRIES" ] && [ -f "$BOOT_ROOT/initrd.img-$KERNEL_VERSION" ] && add_initrd "$(boot_rel "$BOOT_ROOT/initrd.img-$KERNEL_VERSION")"
-
-# Write this root's entry. apt/dpkg only ever touch the booted root, so emit ONLY its entry. The
-# entry-token (from kernel-install, baked per root as <NN>-flipperos-<subvol>) already carries the
-# menu band and IS the /boot/<token>/ staging dir, so there is no slot math here: match the booted
-# root to a profile line for its title/overlays, else treat it as a clone (title = name, own root).
+# Write this root's entry. apt/dpkg only ever touch the booted root, so emit ONLY its entry: match
+# the booted root to a profile line for its title/overlays, else treat it as a clone (title = name).
 CUR_SUBVOL="$(current_subvol)"
 [ -n "$CUR_SUBVOL" ] || die "cannot determine current root subvol (findmnt)"
+
+# kernel + initrd from this root's own /usr/lib/modules/<ver>/, else /boot (resolve_kernel_paths)
+resolve_kernel_paths "$CUR_SUBVOL"
 
 matched=0
 if [ -f "$PROFILES" ]; then

--- a/overlays/configs/kernel/install.d/99-flipper-clean-staging.install
+++ b/overlays/configs/kernel/install.d/99-flipper-clean-staging.install
@@ -1,0 +1,16 @@
+#!/bin/sh
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# kernel-install's core creates the BLS entry dir $BOOT/<token>/<ver>/ before running plugins, but we
+# reference kernel/initrd from the profile subvol, so it stays empty. Remove it (and its now-empty
+# parent) here, after 90-loaderentry/90-uki-copy, so /boot has no leftover staging dirs. rmdir only
+# removes empty dirs (a staged single 'devicetree' keeps <ver>/, another version keeps the parent)
+# and never fails the install.
+set -e
+[ "$KERNEL_INSTALL_LAYOUT" = bls ] || exit 0
+[ "$1" = add ] || exit 0
+ENTRY_DIR_ABS="${3:-}"
+[ -n "$ENTRY_DIR_ABS" ] || exit 0
+
+rmdir "$ENTRY_DIR_ABS" 2>/dev/null && rmdir "${ENTRY_DIR_ABS%/*}" 2>/dev/null || :
+exit 0

--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -84,8 +84,21 @@ fdt_prefix() {  # $1 = options string -> "/<rootflags-subvol>" (or $FDT_SUBVOL_P
     return 0
 }
 
-# btrfs subvol of the currently-booted root (e.g. @Desktop); empty if not a subvol.
-current_subvol() { findmnt -nro FSROOT / 2>/dev/null | sed 's,^/,,'; }
+# btrfs subvol of the current root (e.g. @Desktop); empty if not one. findmnt answers on a booted
+# system; in a chroot it can't, so fall back to the mount-agnostic btrfs subvolume show.
+current_subvol() {
+    _cs=$(findmnt -nro FSROOT / 2>/dev/null | sed 's,^/,,')
+    [ -n "$_cs" ] || _cs=$(btrfs subvolume show / 2>/dev/null | sed -n '1{s,^/*,,;s,[[:space:]]*$,,;p}')
+    printf '%s\n' "$_cs"
+}
+
+# btrfs FS UUID of the current root; empty if unknown. findmnt on a booted system, btrfs filesystem
+# show as the chroot-safe fallback (like current_subvol).
+current_fsuuid() {
+    _fu=$(findmnt -nro UUID / 2>/dev/null)
+    [ -n "$_fu" ] || _fu=$(btrfs filesystem show / 2>/dev/null | sed -n 's/.*[[:space:]]uuid:[[:space:]]*//p' | head -1)
+    printf '%s\n' "$_fu"
+}
 
 # Remove loader entries whose options select SUBVOL and whose version == VERSION. Content-based
 # (token/filename-agnostic), so it leaves every other root's entries untouched. Uses $ENTRIES.
@@ -240,6 +253,11 @@ compute_base_opts() {
     else
         BASE_OPTS=""
     fi
+    BASE_OPTS="$(trim "$BASE_OPTS")"
+    # rewrite the shipped cmdline's build-time root=UUID to the fs we install onto, so a _stock
+    # received onto a device with a different btrfs UUID still boots.
+    _fsuuid="$(current_fsuuid)"
+    [ -n "$_fsuuid" ] && BASE_OPTS="$(printf '%s' " $BASE_OPTS " | sed "s/ root=UUID=[^ ]*/ root=UUID=$_fsuuid/")"
     BASE_OPTS="$(trim "$BASE_OPTS")"
     # Pin systemd.machine_id= only when entries are named after the machine-id (no-op otherwise).
     if [ -n "$MACHINE_ID" ] && [ "$ENTRY_TOKEN" = "$MACHINE_ID" ] && ! echo "$BASE_OPTS" | grep -q "systemd.machine_id="; then

--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -18,6 +18,17 @@ trim() { printf '%s' "$1" | sed 's/^ *//; s/ *$//'; }
 # copy a file into the entry dir as root:root 0644
 stage_file() { install -m 0644 -o root -g root "$1" "$2" || die "could not copy '$1'"; }
 
+# Rewrite a file uncompressed: set its dir to compression=none (new files inherit it), then rewrite
+# via a real copy. U-Boot cannot read inline zstd extents, so the kernel/initrd/dtb it reads must be
+# uncompressed. Best-effort; no-op off btrfs.
+uncompress() {
+    [ -f "$1" ] || return 0
+    btrfs property set "${1%/*}" compression none 2>/dev/null || :
+    if cp --reflink=never -p "$1" "$1.tmp" && mv -f "$1.tmp" "$1"; then return 0; fi
+    rm -f "$1.tmp" 2>/dev/null || :
+    echo "flipper-bls: could not rewrite '$1' uncompressed" >&2
+}
+
 # absolute path under BOOT_ROOT -> path as it must appear inside a BLS entry (relative to the
 # boot partition; identical to the absolute path while /boot is on the rootfs). On Flipper One
 # BOOT_MNT=/ (/boot is a subvol on the root partition, never a separate boot partition).
@@ -41,20 +52,26 @@ make_token() {  # $1 = NN (may be empty)  $2 = subvol
     [ -n "$1" ] && printf '%s-flipperos-%s' "$1" "$_n" || printf 'flipperos-%s' "$_n"
 }
 
-# Reflink the shared /boot kernel + initrd for $KERNEL_VERSION into this $ENTRY_TOKEN's staging
-# dir (/boot/$ENTRY_TOKEN/$KERNEL_VERSION); btrfs shares the extents, so per-root dirs are ~free.
-# Sets KERNEL_ENTRY + INITRD_ENTRIES. For paths the kernel-install plugin does not stage itself
-# (the build fan-out and the clone tooling).
-stage_kernel_reflink() {
-    _sd="/boot/$ENTRY_TOKEN/$KERNEL_VERSION"
-    mkdir -p "$_sd" || die "cannot create $_sd"
-    cp -a --reflink=auto "/boot/vmlinuz-$KERNEL_VERSION" "$_sd/linux" || die "no /boot/vmlinuz-$KERNEL_VERSION"
-    KERNEL_ENTRY="$(boot_rel "$_sd/linux")"
-    INITRD_ENTRIES=""
-    if [ -e "/boot/initrd.img-$KERNEL_VERSION" ]; then
-        cp -a --reflink=auto "/boot/initrd.img-$KERNEL_VERSION" "$_sd/initrd.img-$KERNEL_VERSION"
-        INITRD_ENTRIES="$(boot_rel "$_sd/initrd.img-$KERNEL_VERSION")"
-    fi
+# Set KERNEL_ENTRY + INITRD_ENTRIES for $KERNEL_VERSION, preferring the profile's own copies in
+# /usr/lib/modules/<ver>/ (referenced as /@<subvol>/..., which U-Boot resolves from subvolid 5),
+# else the shared /boot copies (BSP/pre-deb-pkg kernels). $1 = subvol; $2 = its mounted root (def /).
+resolve_kernel_paths() {
+    _rk_root="${2:-/}"; [ "$_rk_root" = / ] && _rk_root=""
+    _rk_um="/usr/lib/modules/$KERNEL_VERSION"
+    _rk_pfx="$(fdt_prefix "rootflags=subvol=$1")"
+    if   [ -f "$_rk_root$_rk_um/vmlinuz" ];        then KERNEL_ENTRY="$_rk_pfx$_rk_um/vmlinuz"
+    elif [ -f "/boot/vmlinuz-$KERNEL_VERSION" ];   then KERNEL_ENTRY="$(boot_rel "/boot/vmlinuz-$KERNEL_VERSION")"
+    else echo "flipper-bls: no kernel image for $KERNEL_VERSION (looked in $_rk_um and /boot)" >&2; return 1; fi
+    if   [ -f "$_rk_root$_rk_um/initrd" ];         then INITRD_ENTRIES="$_rk_pfx$_rk_um/initrd"
+    elif [ -f "/boot/initrd.img-$KERNEL_VERSION" ];then INITRD_ENTRIES="$(boot_rel "/boot/initrd.img-$KERNEL_VERSION")"
+    else INITRD_ENTRIES=""; fi
+}
+
+# KCONFIG for the has_config gates: profile's config first, /boot fallback. $1 = mounted root (def /).
+resolve_kconfig() {
+    _kc_root="${1:-/}"; [ "$_kc_root" = / ] && _kc_root=""
+    if [ -f "$_kc_root/usr/lib/modules/$KERNEL_VERSION/config" ]; then KCONFIG="$_kc_root/usr/lib/modules/$KERNEL_VERSION/config"
+    else KCONFIG="/boot/config-$KERNEL_VERSION"; fi
 }
 
 # U-Boot reads the btrfs TOP LEVEL (subvolid 5), so in-entry devicetreedir/overlay paths need the
@@ -303,9 +320,9 @@ emit_entry() {
 
 # flipper_write_entry <subvol> <mounted-path> [<origin-hint>]: write a BLS entry for an EXISTING
 # writable top-level subvol (a restored snapshot/clone). Token = <NN>-flipperos-<name>, NN from
-# clone_slot (origin base + depth; the origin hint is the dangling-parent fallback). Reflinks
-# the shared /boot kernel into the root's own /boot/<token>/ dir. Sourced by create-profile /
-# rename-profile. Returns non-zero (no exit) on a recoverable problem.
+# clone_slot (origin base + depth; the origin hint is the dangling-parent fallback). Points the
+# entry at the root's OWN kernel+initrd in /usr/lib/modules/<ver>/ (resolve_kernel_paths), so no
+# /boot staging. Sourced by create-profile / rename-profile. Returns non-zero on a recoverable problem.
 flipper_write_entry() {
     _name="$1"; _snap="$2"; _origin="${3:-}"
     { [ -n "$_name" ] && [ -d "$_snap" ]; } || { echo "flipper-bls: usage: flipper_write_entry <name> <mounted-path>" >&2; return 1; }
@@ -315,14 +332,13 @@ flipper_write_entry() {
     # version from the target's OWN tree, so modules + dtbs are self-consistent
     KERNEL_VERSION="$(ls -1d "$_snap"/usr/lib/linux-image-* 2>/dev/null | sed 's,.*/linux-image-,,' | sort -V | tail -n1)"
     [ -n "$KERNEL_VERSION" ] || { echo "flipper-bls: no /usr/lib/linux-image-* inside $_name" >&2; return 1; }
-    [ -e "/boot/vmlinuz-$KERNEL_VERSION" ] || { echo "flipper-bls: kernel not in /boot: vmlinuz-$KERNEL_VERSION" >&2; return 1; }
-    KCONFIG="/boot/config-$KERNEL_VERSION"
+    resolve_kconfig "$_snap"
     set_dtb_dirs
     SORT_KEY="$(os_sort_key)"
     ENTRY_TOKEN="$(make_token "$(clone_slot "$_snap" "$_origin")" "$_name")"
     mkdir -p "$ENTRIES" || { echo "flipper-bls: cannot create $ENTRIES" >&2; return 1; }
     compute_base_opts
-    stage_kernel_reflink
+    resolve_kernel_paths "$_name" "$_snap" || return 1
     # devicetreedir is the target root's OWN kernel dir (KERNEL_VERSION came from it, so it exists).
     DEVICETREEDIR_REL="/usr/lib/linux-image-$KERNEL_VERSION"
     OVERLAY_DIR="$DTB_DIR/$VENDOR"


### PR DESCRIPTION
Point the BLS `linux`/`initrd` at the profile's own `/usr/lib/modules/<ver>/` (referenced as `/@<subvol>/...`, which U-Boot resolves from subvolid 5) instead of staging copies into `/boot`, so a profile carries its whole boot set and a received `_stock` is bootable without the kernel pre-existing in `/boot`.

Verified on device: U-Boot's `bls` bootmeth loads both kernel and initrd from the profile subvol with `/boot` cleared.

## Changes
- `flipper-bls.sh`: `resolve_kernel_paths` / `resolve_kconfig` (profile first, `/boot` fallback for BSP/pre-usr-lib kernels) replace `stage_kernel_reflink`; shared, self-contained `uncompress()` helper.
- `55-flipper-initrd.install`: move initramfs-tools' initrd into `/usr/lib/modules/<ver>/initrd` and keep kernel+initrd uncompressed (U-Boot cannot read inline zstd extents).
- `99-flipper-clean-staging.install`: remove kernel-install's empty `/boot/<token>/<ver>/` staging dir so `/boot` has no leftovers.
- `90-loaderentry.install` + img.yaml fan-out: reference the profile, drop the `/boot` staging.
- initramfs `post-update.d` hook: re-run `kernel-install` on `update-initramfs -u` so a config-triggered rebuild relocates too.

## Depends on
The deb-pkg kernel installing `vmlinuz`/`config` under `/usr/lib/modules/<ver>/` (flipper-linux-kernel c24a597).
