### PR TITLE
btrfs: move _stock golden bases into @stock-snapshots

### DIFF
--- a/debian-rk3576-img.yaml
+++ b/debian-rk3576-img.yaml
@@ -60,15 +60,17 @@ actions:
       ROOTPART="$({{ $rootdev }})"
 
       # debos has the top level (subvolid=5) mounted here; create subvolumes on it.
-      # @Minimal_stock is the common base / build target (the RO golden image every profile
-      # snapshots from); @snapshots holds runtime snapshots.
-      for sv in @Minimal_{{ $buildid }}_stock boot @home @snapshots @var-log @var-cache; do
+      # @stock-snapshots holds the RO golden bases (@<Profile>_<buildid>_stock); @snapshots holds
+      # runtime snapshots. @Minimal_stock (nested under @stock-snapshots) is the common base / build
+      # target the profiles snapshot from; create @stock-snapshots before nesting it.
+      for sv in boot @home @snapshots @stock-snapshots @var-log @var-cache; do
         btrfs subvolume create "$IMAGEMNTDIR/$sv"
       done
+      btrfs subvolume create "$IMAGEMNTDIR/@stock-snapshots/@Minimal_{{ $buildid }}_stock"
       umount "$IMAGEMNTDIR"
 
       # Mount @Minimal_stock at the mount point debos owns, then nest the rest under it.
-      mount -t btrfs -o "{{ $btrfsopts }},subvol=@Minimal_{{ $buildid }}_stock" "$ROOTPART" "$IMAGEMNTDIR"
+      mount -t btrfs -o "{{ $btrfsopts }},subvol=@stock-snapshots/@Minimal_{{ $buildid }}_stock" "$ROOTPART" "$IMAGEMNTDIR"
       mkdir -p "$IMAGEMNTDIR/boot" \
                "$IMAGEMNTDIR/home" \
                "$IMAGEMNTDIR/var/log" \
@@ -230,8 +232,8 @@ actions:
       # @Minimal is a writable snapshot of the golden base, matching every other profile
       # (each a snapshot of its _stock). Its entry-token, baked before the kernel install,
       # is inherited via the snapshot.
-      btrfs property set "$TOP/@Minimal_{{ $buildid }}_stock" ro true
-      btrfs subvolume snapshot "$TOP/@Minimal_{{ $buildid }}_stock" "$TOP/@Minimal"
+      btrfs property set "$TOP/@stock-snapshots/@Minimal_{{ $buildid }}_stock" ro true
+      btrfs subvolume snapshot "$TOP/@stock-snapshots/@Minimal_{{ $buildid }}_stock" "$TOP/@Minimal"
 
   # --- @Desktop ------------------------------------------------------------------
   - action: run
@@ -241,8 +243,8 @@ actions:
       set -eu
       TOP="${IMAGEMNTDIR%/}.toplevel"
       ROOTPART="$(findmnt -fn --nofsroot -o SOURCE --target "$TOP")"
-      btrfs subvolume snapshot "$TOP/@Minimal_{{ $buildid }}_stock" "$TOP/@Desktop_{{ $buildid }}_stock"
-      mount -t btrfs -o "{{ $btrfsopts }},subvol=@Desktop_{{ $buildid }}_stock" "$ROOTPART" "$IMAGEMNTDIR"
+      btrfs subvolume snapshot "$TOP/@stock-snapshots/@Minimal_{{ $buildid }}_stock" "$TOP/@stock-snapshots/@Desktop_{{ $buildid }}_stock"
+      mount -t btrfs -o "{{ $btrfsopts }},subvol=@stock-snapshots/@Desktop_{{ $buildid }}_stock" "$ROOTPART" "$IMAGEMNTDIR"
   - action: apt
     description: KDE desktop packages
     recommends: false        # image is minbase/no-recommends; deps are listed explicitly
@@ -293,8 +295,8 @@ actions:
       set -eu
       TOP="${IMAGEMNTDIR%/}.toplevel"
       umount "$IMAGEMNTDIR"
-      btrfs property set "$TOP/@Desktop_{{ $buildid }}_stock" ro true
-      btrfs subvolume snapshot "$TOP/@Desktop_{{ $buildid }}_stock" "$TOP/@Desktop"
+      btrfs property set "$TOP/@stock-snapshots/@Desktop_{{ $buildid }}_stock" ro true
+      btrfs subvolume snapshot "$TOP/@stock-snapshots/@Desktop_{{ $buildid }}_stock" "$TOP/@Desktop"
 
   # --- @TV-Media-Box ---------------------------------------------------------
   - action: run
@@ -304,8 +306,8 @@ actions:
       set -eu
       TOP="${IMAGEMNTDIR%/}.toplevel"
       ROOTPART="$(findmnt -fn --nofsroot -o SOURCE --target "$TOP")"
-      btrfs subvolume snapshot "$TOP/@Minimal_{{ $buildid }}_stock" "$TOP/@TV-Media-Box_{{ $buildid }}_stock"
-      mount -t btrfs -o "{{ $btrfsopts }},subvol=@TV-Media-Box_{{ $buildid }}_stock" "$ROOTPART" "$IMAGEMNTDIR"
+      btrfs subvolume snapshot "$TOP/@stock-snapshots/@Minimal_{{ $buildid }}_stock" "$TOP/@stock-snapshots/@TV-Media-Box_{{ $buildid }}_stock"
+      mount -t btrfs -o "{{ $btrfsopts }},subvol=@stock-snapshots/@TV-Media-Box_{{ $buildid }}_stock" "$ROOTPART" "$IMAGEMNTDIR"
   - action: apt
     description: TV media box packages
     recommends: false
@@ -339,8 +341,8 @@ actions:
       set -eu
       TOP="${IMAGEMNTDIR%/}.toplevel"
       umount "$IMAGEMNTDIR"
-      btrfs property set "$TOP/@TV-Media-Box_{{ $buildid }}_stock" ro true
-      btrfs subvolume snapshot "$TOP/@TV-Media-Box_{{ $buildid }}_stock" "$TOP/@TV-Media-Box"
+      btrfs property set "$TOP/@stock-snapshots/@TV-Media-Box_{{ $buildid }}_stock" ro true
+      btrfs subvolume snapshot "$TOP/@stock-snapshots/@TV-Media-Box_{{ $buildid }}_stock" "$TOP/@TV-Media-Box"
 
   # --- @Router ---------------------------------------------------------------
   - action: run
@@ -350,8 +352,8 @@ actions:
       set -eu
       TOP="${IMAGEMNTDIR%/}.toplevel"
       ROOTPART="$(findmnt -fn --nofsroot -o SOURCE --target "$TOP")"
-      btrfs subvolume snapshot "$TOP/@Minimal_{{ $buildid }}_stock" "$TOP/@Router_{{ $buildid }}_stock"
-      mount -t btrfs -o "{{ $btrfsopts }},subvol=@Router_{{ $buildid }}_stock" "$ROOTPART" "$IMAGEMNTDIR"
+      btrfs subvolume snapshot "$TOP/@stock-snapshots/@Minimal_{{ $buildid }}_stock" "$TOP/@stock-snapshots/@Router_{{ $buildid }}_stock"
+      mount -t btrfs -o "{{ $btrfsopts }},subvol=@stock-snapshots/@Router_{{ $buildid }}_stock" "$ROOTPART" "$IMAGEMNTDIR"
   # @Router needs no packages beyond Minimal (NetworkManager + dnsmasq-base + wpa_supplicant
   # are common); it just adds the AP/WAN connections + ip-forwarding via the overlay. Its
   # default session stays multi-user (inherited); NM autoconnect brings the router up.
@@ -377,8 +379,8 @@ actions:
       set -eu
       TOP="${IMAGEMNTDIR%/}.toplevel"
       umount "$IMAGEMNTDIR"
-      btrfs property set "$TOP/@Router_{{ $buildid }}_stock" ro true
-      btrfs subvolume snapshot "$TOP/@Router_{{ $buildid }}_stock" "$TOP/@Router"
+      btrfs property set "$TOP/@stock-snapshots/@Router_{{ $buildid }}_stock" ro true
+      btrfs subvolume snapshot "$TOP/@stock-snapshots/@Router_{{ $buildid }}_stock" "$TOP/@Router"
 
   # --- @No-Graphics ----------------------------------------------------------
   # Headless @Minimal: same userspace, no extra packages. The graphics pipeline (VOP/HDMI/
@@ -391,8 +393,8 @@ actions:
       set -eu
       TOP="${IMAGEMNTDIR%/}.toplevel"
       ROOTPART="$(findmnt -fn --nofsroot -o SOURCE --target "$TOP")"
-      btrfs subvolume snapshot "$TOP/@Minimal_{{ $buildid }}_stock" "$TOP/@No-Graphics_{{ $buildid }}_stock"
-      mount -t btrfs -o "{{ $btrfsopts }},subvol=@No-Graphics_{{ $buildid }}_stock" "$ROOTPART" "$IMAGEMNTDIR"
+      btrfs subvolume snapshot "$TOP/@stock-snapshots/@Minimal_{{ $buildid }}_stock" "$TOP/@stock-snapshots/@No-Graphics_{{ $buildid }}_stock"
+      mount -t btrfs -o "{{ $btrfsopts }},subvol=@stock-snapshots/@No-Graphics_{{ $buildid }}_stock" "$ROOTPART" "$IMAGEMNTDIR"
   - action: run
     description: Pin @No-Graphics's kernel entry-token (NN from flipper-profiles)
     chroot: true
@@ -407,8 +409,8 @@ actions:
       set -eu
       TOP="${IMAGEMNTDIR%/}.toplevel"
       umount "$IMAGEMNTDIR"
-      btrfs property set "$TOP/@No-Graphics_{{ $buildid }}_stock" ro true
-      btrfs subvolume snapshot "$TOP/@No-Graphics_{{ $buildid }}_stock" "$TOP/@No-Graphics"
+      btrfs property set "$TOP/@stock-snapshots/@No-Graphics_{{ $buildid }}_stock" ro true
+      btrfs subvolume snapshot "$TOP/@stock-snapshots/@No-Graphics_{{ $buildid }}_stock" "$TOP/@No-Graphics"
 
   # Export each _stock as versioned send streams (receive-snapshot format): a FULL stream
   # (_pack.zst) for all, plus an INCREMENTAL vs @Minimal (_inc_pack.zst) for the rest.
@@ -419,12 +421,12 @@ actions:
       set -eu
       TOP="${IMAGEMNTDIR%/}.toplevel"
       MIN="@Minimal_{{ $buildid }}_stock"
-      for s in "$TOP"/@*_stock; do
+      for s in "$TOP"/@stock-snapshots/@*_stock; do
         [ -d "$s" ] || continue
         name=$(basename "$s")
         btrfs send "$s" | zstd -T0 -o "$ARTIFACTDIR/${name#@}_pack.zst"
         if [ "$name" != "$MIN" ]; then
-          btrfs send -p "$TOP/$MIN" "$s" | zstd -T0 -o "$ARTIFACTDIR/${name#@}_inc_pack.zst"
+          btrfs send -p "$TOP/@stock-snapshots/$MIN" "$s" | zstd -T0 -o "$ARTIFACTDIR/${name#@}_inc_pack.zst"
         fi
       done
 

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -25,7 +25,7 @@ confirm() {
 # Reserved subvolumes the tools must never write/delete/rename.
 is_reserved_subvol() {
     case "$1" in
-        @|@home|@root|@snapshots|@var-log|@var-cache|boot) return 0 ;;
+        @|@home|@root|@snapshots|@stock-snapshots|@var-log|@var-cache|boot) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -58,6 +58,17 @@ top_cleanup() {
     [ -n "${TOP:-}" ] && { umount "$TOP" 2>/dev/null || true; rmdir "$TOP" 2>/dev/null || true; }
     [ -n "${TOP_TMPFILES:-}" ] && rm -f $TOP_TMPFILES
     return 0
+}
+
+# Resolve a subvol NAME to its top-relative path: as given ($TOP/<name>, e.g. a full
+# @snapshots/<name> or @stock-snapshots/@X_stock path), else a bare name found under @snapshots
+# (restore points) or @stock-snapshots (golden bases). Prints the path relative to $TOP; empty if
+# none exists. Needs $TOP.
+resolve_rel() {
+    if   [ -e "$TOP/$1" ];                  then printf '%s' "$1"
+    elif [ -e "$TOP/@snapshots/$1" ];       then printf '%s' "@snapshots/$1"
+    elif [ -e "$TOP/@stock-snapshots/$1" ]; then printf '%s' "@stock-snapshots/$1"
+    fi
 }
 
 # One field from `btrfs subvolume show` output. $1 = output text, $2 = key label.

--- a/overlays/usr/local/sbin/btrfs-show-space
+++ b/overlays/usr/local/sbin/btrfs-show-space
@@ -1,8 +1,8 @@
 #!/bin/sh
 # btrfs-show-space [-q|--quick] - btrfs usage + per-root-subvolume space.
 # (-q/--quick skips the compsize REFERENCED column, one less extent-walk per subvol.)
-# Lists profile roots and _stock bases, every snapshot under @snapshots, and any other
-# top-level @* (e.g. @.old_*). Shared @home/@var-* are not listed.
+# Lists EVERY subvolume: profile roots and @.old_* leftovers, the snapshots under @snapshots,
+# the _stock bases under @stock-snapshots, and the shared @home / @var-* / boot.
 #   UNIQUE     - data only this subvolume holds; freed if you delete IT ALONE,
 #                others kept (btrfs fi du, exact, uncompressed)
 #   REFERENCED - real on-disk size of all data it references, compressed
@@ -62,17 +62,11 @@ row() {  # $1=display name  $2=fs path  -> append a TSV row
     printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$mark" "$(human "$exc")" "$ref_h" "$(human "$tot")" >> "$rows"
 }
 
-# collect subvols (cheap), then measure with progress: each row walks extents (slow on flash)
-for s in "$TOP"/@snapshots/*; do
-    [ -e "$s" ] || continue
-    printf '%s\t%s\n' "@snapshots/${s##*/}" "$s" >> "$list"
-done
-for d in "$TOP"/@*; do
-    [ -e "$d" ] || continue
-    n=${d##*/}
-    is_reserved_subvol "$n" && continue
-    btrfs subvolume show "$d" >/dev/null 2>&1 || continue
-    printf '%s\t%s\n' "$n" "$d" >> "$list"
+# collect EVERY subvolume (cheap), then measure with progress: each row walks extents (slow on
+# flash). btrfs subvolume list gives top-relative paths: profile roots + @.old_*, the nested
+# @snapshots/* and @stock-snapshots/* children, and the shared @home / @var-* / boot.
+btrfs subvolume list "$TOP" 2>/dev/null | sed -n 's/.* path //p' | sort | while read -r p; do
+    printf '%s\t%s\n' "$p" "$TOP/$p" >> "$list"
 done
 total=$(wc -l < "$list" 2>/dev/null | tr -d ' '); [ -n "$total" ] || total=0
 
@@ -89,7 +83,7 @@ while IFS="$tab" read -r nm pth; do
 done < "$list"
 { [ -t 2 ] && [ "$total" -gt 0 ] && printf '\r\033[K' >&2; } || true
 
-echo "== root subvolumes & snapshots =="
+echo "== subvolumes =="
 # align: NAME auto-width; marker column after NAME; numeric columns right-justified
 awk -F'\t' '
 { r[NR]=$0; if (length($1) > w) w = length($1) }

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -2,7 +2,7 @@
 # create-profile [-m|--move] <@source> [<@dest>] - materialize a bootable PROFILE (a writable
 # bootable root) named exactly <@dest> from <@source>. Takes effect after rebooting into <@dest>.
 #
-#   <@source> a snapshot or golden base, by its full top-level path: @snapshots/<name>
+#   <@source> a snapshot or golden base, by full path or bare name: @snapshots/<name>
 #             (RO restore point), @<profile>_<stamp> (top-level snapshot), or
 #             @<profile>_stock (a profile's golden base).
 #   <@dest>   exact name of the profile (a bootable top-level subvol) to write. Defaults to
@@ -27,7 +27,7 @@ usage() {
     cat <<EOF
 Usage: create-profile [-m|--move] <@source> [<@dest>|current]
   -m,--move   move <@source> into <@dest> (consume source, preserve parent_uuid)
-  <@source>   @snapshots/<name>, @<profile>_<stamp>, or @<profile>_stock
+  <@source>   full path or bare name: @snapshots/<name>, @<profile>_<stamp>, @<profile>_stock
   <@dest>     profile to write (default: booted profile; or current|booted)
 EOF
 }
@@ -51,11 +51,10 @@ case "$src_name" in *..*|/*) die "Invalid source name: $src_name" ;; esac
 
 mount_top
 
-# full top-level path; no guessing
-resolve() { [ -e "$TOP/$1" ] && printf '%s' "$1"; }
-
-src_rel=$(resolve "$src_name")
-[ -n "$src_rel" ] || die "No such snapshot: $src_name (give the full path, e.g. @snapshots/@Minimal)"
+# resolve source: a full top-level path (@snapshots/<name>, @stock-snapshots/@X_stock) or a bare
+# _stock name (found under @stock-snapshots)
+src_rel=$(resolve_rel "$src_name")
+[ -n "$src_rel" ] || die "No such source: $src_name (e.g. @snapshots/@Minimal, @Desktop_stock)"
 src="$TOP/$src_rel"
 
 # dest -> exact top-level name (default: booted root)

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -1,10 +1,10 @@
 #!/bin/sh
 # delete-profile <@profile> - delete a bootable PROFILE at the btrfs top level (as listed by
-# list-profiles): a profile root (@Desktop, @Desktop-2, ...), a _stock golden base, or an
-# @<profile>.old_* leftover. Also removes its BLS boot entry. For @snapshots restore points,
-# use delete-snapshot.
-# Confirms once; AGAIN if the target is read-only; a THIRD time (with a warning) for a _stock
-# golden base. Refuses layout subvolumes and the currently booted profile.
+# list-profiles): a profile root (@Desktop, @Desktop-2, ...) or an @<profile>.old_* leftover. Also
+# removes its BLS boot entry. For @snapshots restore points and _stock golden bases (under
+# @stock-snapshots), use delete-snapshot.
+# Confirms once; AGAIN if the target is read-only. Refuses layout subvolumes and the currently
+# booted profile.
 #
 # Example:
 #   delete-profile @DestinationProfile   # remove a profile (and its boot entry)
@@ -14,9 +14,9 @@ set -eu
 usage() {
     cat <<EOF
 Usage: delete-profile <@profile>
-  Delete a bootable profile at the btrfs top level (see list-profiles) and its
-  boot entry: a profile root, a _stock base, or an @<profile>.old_* leftover.
-  For @snapshots restore points use delete-snapshot.
+  Delete a bootable profile at the btrfs top level (see list-profiles) and its boot
+  entry: a profile root or an @<profile>.old_* leftover. For restore points and
+  _stock golden bases use delete-snapshot.
 EOF
 }
 
@@ -30,9 +30,11 @@ need_root
 need_btrfs
 arg=$1
 case "$arg" in *..*|/*) die "Invalid name: $arg" ;; esac
+# snapshots and _stock golden bases (under @snapshots / @stock-snapshots) are delete-snapshot's job
 case "$arg" in
-    @snapshots/*) die "Top-level profiles only; for a restore point use: delete-snapshot $arg" ;;
+    @snapshots/*|@stock-snapshots/*) die "Top-level profiles only; for that use: delete-snapshot $arg" ;;
 esac
+case "${arg##*/}" in *_stock) die "Top-level profiles only; for a golden base use: delete-snapshot $arg" ;; esac
 
 mount_top
 cur_id=$(booted_id)
@@ -43,17 +45,11 @@ info=$(btrfs subvolume show "$TOP/$rel" 2>/dev/null) || die "Not a profile: $rel
 tgt_id=$(get "$info" "Subvolume ID")
 [ -n "$cur_id" ] && [ "$tgt_id" = "$cur_id" ] && die "Refusing to delete the currently booted profile ($rel)"
 
-is_ro=0;    case "$(get "$info" "Flags")" in *readonly*) is_ro=1 ;; esac
-is_stock=0; case "${rel##*/}" in *_stock) is_stock=1 ;; esac
+is_ro=0; case "$(get "$info" "Flags")" in *readonly*) is_ro=1 ;; esac
 
-# tiered: once always; again if ro; a third time for _stock
+# once always; again if the target is read-only
 confirm "Delete profile '$rel'?"
-[ "$is_ro" = 1 ] && confirm "'$rel' is READ-ONLY (stock / received); delete anyway?"
-if [ "$is_stock" = 1 ]; then
-    echo "WARNING: '$rel' is a _stock GOLDEN BASE, the factory-reset source for its profile;" >&2
-    echo "         deleting it means that profile can no longer be reset to factory." >&2
-    confirm "Confirm a THIRD time: permanently delete the golden base '$rel'?"
-fi
+[ "$is_ro" = 1 ] && confirm "'$rel' is READ-ONLY; delete anyway?"
 
 set_lock
 btrfs subvolume delete "$TOP/$rel" >/dev/null

--- a/overlays/usr/local/sbin/delete-snapshot
+++ b/overlays/usr/local/sbin/delete-snapshot
@@ -1,18 +1,21 @@
 #!/bin/sh
-# delete-snapshot <@snapshots/@name> - delete a read-only restore-point SNAPSHOT under
-# @snapshots (as listed by list-snapshots). For bootable profiles, their _stock bases, or
-# .old leftovers, use delete-profile. Confirms once. Works via a subvolid=5 (top-level) mount.
+# delete-snapshot <@snapshots/@name | @stock-snapshots/@X_stock | @X_stock> - delete a read-only
+# restore-point SNAPSHOT under @snapshots or a _stock GOLDEN BASE under @stock-snapshots (as listed
+# by list-snapshots); a bare _stock name resolves under @stock-snapshots. Confirms once, plus again
+# for a golden base. For bootable profiles or .old leftovers, use delete-profile. Works via a
+# subvolid=5 (top-level) mount.
 #
-# Example:
+# Examples:
 #   delete-snapshot @snapshots/@SourceProfile_2026-06-29_19-52-31
+#   delete-snapshot @Desktop_694_stock            # a golden base under @stock-snapshots
 set -eu
 . /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
 
 usage() {
     cat <<EOF
-Usage: delete-snapshot <@snapshots/@name>
-  Delete a read-only restore-point snapshot under @snapshots (see list-snapshots).
-  For profiles, _stock bases, or .old leftovers use delete-profile.
+Usage: delete-snapshot <@snapshots/@name | @stock-snapshots/@X_stock | @X_stock>
+  Delete a restore-point snapshot under @snapshots or a _stock golden base under
+  @stock-snapshots (see list-snapshots). For profiles or .old leftovers use delete-profile.
 EOF
 }
 
@@ -26,16 +29,25 @@ need_root
 need_btrfs
 arg=$1
 case "$arg" in *..*|/*) die "Invalid name: $arg" ;; esac
-case "$arg" in
-    @snapshots/?*) ;;
-    *) die "Only @snapshots restore points here; for a profile use: delete-profile $arg" ;;
-esac
 
 mount_top
-[ -e "$TOP/$arg" ] || die "No such snapshot: $arg (see list-snapshots)"
-btrfs subvolume show "$TOP/$arg" >/dev/null 2>&1 || die "Not a snapshot: $arg"
+# accept a @snapshots restore point or a @stock-snapshots golden base, by full path or a bare
+# _stock name; a top-level profile is delete-profile's job
+rel=$(resolve_rel "$arg")
+[ -n "$rel" ] || die "No such snapshot: $arg (see list-snapshots)"
+case "$rel" in
+    @snapshots/?*|@stock-snapshots/?*) ;;
+    *) die "Only @snapshots restore points and @stock-snapshots golden bases here; for a profile use: delete-profile $arg" ;;
+esac
+btrfs subvolume show "$TOP/$rel" >/dev/null 2>&1 || die "Not a snapshot: $rel"
 
-confirm "Delete restore-point snapshot '$arg'?"
+is_stock=0; case "${rel##*/}" in *_stock) is_stock=1 ;; esac
+confirm "Delete '$rel'?"
+if [ "$is_stock" = 1 ]; then
+    echo "WARNING: '$rel' is a _stock GOLDEN BASE, the factory-reset source for its profile;" >&2
+    echo "         deleting it means that profile can no longer be reset to factory." >&2
+    confirm "Confirm again: permanently delete the golden base '$rel'?"
+fi
 set_lock
-btrfs subvolume delete "$TOP/$arg" >/dev/null
-echo "Deleted '$arg'"
+btrfs subvolume delete "$TOP/$rel" >/dev/null
+echo "Deleted '$rel'"

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -1,9 +1,9 @@
 #!/bin/sh
 # list-profiles - list the bootable PROFILES at the btrfs top level: the profile roots
-# (@Desktop, @Minimal, ...), their _stock golden bases, and @<profile>.old_* leftovers from
-# create-profile. KIND tags each (profile/stock/old); PARENT is what it was snapshotted from
-# (via Parent UUID). Names are top-level paths (what create-profile/rename-profile/delete-profile
-# take). The booted profile is marked  <- booted. For restore points, see list-snapshots.
+# (@Desktop, @Minimal, ...) and @<profile>.old_* leftovers from create-profile. KIND tags each
+# (profile/old); PARENT is what it was snapshotted from (via Parent UUID). Names are top-level
+# paths (what create-profile/rename-profile/delete-profile take). The booted profile is marked
+# <- booted. For _stock golden bases and restore points, see list-snapshots.
 # Works via a subvolid=5 (top-level) mount.
 #
 # Example:
@@ -14,8 +14,8 @@ set -eu
 usage() {
     cat <<EOF
 Usage: list-profiles
-  List bootable profiles at the btrfs top level: profile roots, their _stock golden
-  bases, and @<profile>.old_* leftovers. For restore points, see list-snapshots.
+  List bootable profiles at the btrfs top level: profile roots and @<profile>.old_*
+  leftovers. For _stock golden bases and restore points, see list-snapshots.
 EOF
 }
 
@@ -46,7 +46,6 @@ emit() {  # $1=display name  $2=fs path
     flags=$(get "$info" "Flags"); case "$flags" in *readonly*) flags=ro ;; *) flags=rw ;; esac
     parent=$(parent_of "$map" "$(get "$info" "Parent UUID")")
     case "$1" in
-        *_stock) kind=stock ;;
         *.old_*) kind=old ;;
         *)       kind=profile ;;
     esac
@@ -55,7 +54,8 @@ emit() {  # $1=display name  $2=fs path
 }
 
 printf 'NAME\t\tKIND\tID\tCREATED\tRO\tPARENT\n' > "$rows"
-# top-level roots, _stock bases, @.old_* leftovers; skip shared subvols + @snapshots
+# top-level profile roots + @.old_* leftovers; skip shared/reserved subvols (@snapshots,
+# @stock-snapshots, ...) so stocks (now nested under @stock-snapshots) are not listed here
 for d in "$TOP"/@*; do
     [ -e "$d" ] || continue
     n=${d##*/}

--- a/overlays/usr/local/sbin/list-snapshots
+++ b/overlays/usr/local/sbin/list-snapshots
@@ -1,7 +1,8 @@
 #!/bin/sh
 # list-snapshots - list the read-only restore-point SNAPSHOTS under @snapshots (made by
-# create-snapshot). PARENT is what each was snapshotted or received from (via Parent UUID);
-# names are top-level paths (what create-profile and delete-snapshot take). For bootable
+# create-snapshot) and, separately, the _stock GOLDEN BASES under @stock-snapshots (build/received
+# factory images). PARENT is what each was snapshotted or received from (via Parent UUID); names
+# are top-level paths (what create-profile and delete-snapshot/delete-profile take). For bootable
 # profiles, see list-profiles. Works via a subvolid=5 (top-level) mount.
 #
 # Example:
@@ -12,8 +13,8 @@ set -eu
 usage() {
     cat <<EOF
 Usage: list-snapshots
-  List read-only restore-point snapshots under @snapshots (made by create-snapshot).
-  For bootable profiles, see list-profiles.
+  List restore-point snapshots under @snapshots and _stock golden bases under
+  @stock-snapshots. For bootable profiles, see list-profiles.
 EOF
 }
 
@@ -40,9 +41,19 @@ emit() {  # $1=display name  $2=fs path
     printf '%s\t%s\t%s\t%s\n' "$1" "${id:-?}" "${otime:-?}" "$parent" >> "$rows"
 }
 
+echo "Restore-point snapshots (@snapshots):"
 printf 'NAME\tID\tCREATED\tPARENT\n' > "$rows"
 for s in "$TOP"/@snapshots/*; do
     [ -e "$s" ] || continue
     emit "@snapshots/${s##*/}" "$s"
+done
+align_table "$rows"
+
+echo
+echo "Golden bases (@stock-snapshots):"
+printf 'NAME\tID\tCREATED\tPARENT\n' > "$rows"
+for s in "$TOP"/@stock-snapshots/*; do
+    [ -e "$s" ] || continue
+    emit "@stock-snapshots/${s##*/}" "$s"
 done
 align_table "$rows"

--- a/overlays/usr/local/sbin/receive-snapshot
+++ b/overlays/usr/local/sbin/receive-snapshot
@@ -1,5 +1,5 @@
 #!/bin/sh
-# receive-snapshot <file> - receive a send-snapshot stream into @snapshots.
+# receive-snapshot <file> - receive a send-snapshot stream (a _stock base -> @stock-snapshots, else @snapshots).
 # The received subvolume keeps the name it had when sent (the leading '@' too, carried in
 # the stream) and is read-only; put it onto a root with create-profile. For an
 # incremental stream (sent with -p/-i), its parent must already exist here (e.g. the _stock
@@ -15,7 +15,7 @@ set -eu
 usage() {
     cat <<EOF
 Usage: receive-snapshot <file|->
-  Receive a send-snapshot stream into @snapshots (read-only). Put it onto a root
+  Receive a send-snapshot stream (a _stock base -> @stock-snapshots, else @snapshots). Put it onto a root
   with create-profile. Incremental streams need their parent to exist here first.
 EOF
 }
@@ -35,8 +35,15 @@ have_pv=0; command -v pv >/dev/null 2>&1 && have_pv=1
 
 set_lock
 mount_top
+# route a _stock golden base into @stock-snapshots; every other snapshot into @snapshots. The stream
+# carries the subvol name; peek it from a file (a pipe cannot be peeked, so it stays in @snapshots).
 target="$TOP/@snapshots"
-[ -d "$target" ] || die "@snapshots not found at top level"
+if [ "$src" != "-" ]; then
+    name=$(zstd -dc "$src" 2>/dev/null | head -c 262144 | btrfs receive --dump 2>/dev/null \
+           | awk '/^(subvol|snapshot)[[:space:]]/ { n=$2; sub(/^\.\//,"",n); print n; exit }')
+    case "$name" in ?*_stock) target="$TOP/@stock-snapshots" ;; esac
+fi
+[ -d "$target" ] || die "${target##*/} not found at top level"
 
 before=$(btrfs subvolume list -o "$target" 2>/dev/null | wc -l)
 
@@ -52,4 +59,4 @@ rc=$?
 set -e
 [ "$rc" = 0 ] || die "Receive failed (rc=$rc); check the stream and that any parent snapshot exists here"
 
-echo "Received into @snapshots/ (now $(btrfs subvolume list -o "$target" 2>/dev/null | wc -l) entries, was $before)"
+echo "Received into ${target##*/}/ (now $(btrfs subvolume list -o "$target" 2>/dev/null | wc -l) entries, was $before)"

--- a/overlays/usr/local/sbin/send-snapshot
+++ b/overlays/usr/local/sbin/send-snapshot
@@ -1,6 +1,6 @@
 #!/bin/sh
 # send-snapshot [-p PARENT | -i] <@snapshot> <file|dir>
-#   <@snapshot> a snapshot or root by its full top-level path, e.g. @snapshots/<name>.
+#   <@snapshot> a snapshot or root, by full path or bare name, e.g. @snapshots/<name>.
 #               A read-write source is snapshotted read-only automatically into @snapshots
 #               (btrfs send needs a ro source) with a timestamped name; that ro snapshot
 #               is KEPT as a restore point.
@@ -26,7 +26,7 @@ usage() {
 Usage: send-snapshot [-p PARENT | -i] <@snapshot> <file|dir|->
   -p PARENT   incremental: send only changes since PARENT (ro, must exist on receiver)
   -i          incremental vs the source's _stock parent (else a full send)
-  <@snapshot> full top-level path, e.g. @snapshots/<name> (rw source auto-snapshotted ro)
+  <@snapshot> full path or bare name, e.g. @snapshots/<name> (rw source auto-snapshotted ro)
   <file|dir>  output file, a directory (writes <leaf>_pack.zst), or - for stdout
 EOF
 }
@@ -59,7 +59,6 @@ TOP_TMPFILES="$send_stat"
 set_lock
 mount_top
 
-resolve() { [ -e "$TOP/$1" ] && printf '%s' "$1"; }   # full top-level path -> echoed if it exists
 parent_path_of() {  # $1 = fs path -> top-relative path of its parent subvol (empty if none)
     pu=$(btrfs subvolume show "$1" 2>/dev/null | awk -F':[[:space:]]+' '/Parent UUID/{print $2; exit}')
     case "$pu" in ''|'-') return ;; esac
@@ -69,7 +68,7 @@ parent_path_of() {  # $1 = fs path -> top-relative path of its parent subvol (em
           if (uu==u){print p; exit} }'
 }
 
-srel=$(resolve "$src_name"); [ -n "$srel" ] || die "No such snapshot: $src_name"
+srel=$(resolve_rel "$src_name"); [ -n "$srel" ] || die "No such snapshot: $src_name"
 srcpath="$TOP/$srel"
 
 # -i: incremental against the source's parent, but only if that parent is a _stock base
@@ -102,7 +101,7 @@ fi
 
 parentpath=""; prel=""
 if [ -n "$parent" ]; then
-    prel=$(resolve "$parent"); [ -n "$prel" ] || die "No such parent snapshot: $parent"
+    prel=$(resolve_rel "$parent"); [ -n "$prel" ] || die "No such parent snapshot: $parent"
     parentpath="$TOP/$prel"
     is_ro "$parentpath" || die "Parent $parent must be read-only"
 fi


### PR DESCRIPTION
Nest every `_stock` golden base under a new `@stock-snapshots` subvolume (`@stock-snapshots/@<Profile>_<buildid>_stock`) instead of the btrfs top level, so the top level holds only profile roots + shared subvols.

Verified on-device (build 713): `list-snapshots` shows the two sections; profiles/stocks resolve by bare or full name.

## Changes
- `flipper-btrfs.sh`: `@stock-snapshots` reserved; new `resolve_rel` accepts a full top-level path or a bare name (resolved under `@snapshots` for restore points, `@stock-snapshots` for golden bases).
- `debian-rk3576-img.yaml`: create `@stock-snapshots`, then build/snapshot/lock/export all stocks under it; profile roots stay at the top level.
- `create-profile` / `send-snapshot` / `delete-snapshot`: resolve stock/snapshot sources by bare or full name.
- `receive-snapshot`: route a received `_stock` stream into `@stock-snapshots`.
- `list-profiles`: profiles only. `list-snapshots`: adds a `@stock-snapshots` golden-bases section. `btrfs-show-space`: lists every subvolume.
- `delete-snapshot` owns `_stock` deletion (golden-base confirm); `delete-profile` redirects stocks to it.

