### PR TITLE
btrfs: stop forcing the boot set uncompressed

### DIFF
--- a/debian-rk3576-img.yaml
+++ b/debian-rk3576-img.yaml
@@ -76,10 +76,6 @@ actions:
                "$IMAGEMNTDIR/var/log" \
                "$IMAGEMNTDIR/var/cache"
       mount -t btrfs -o "{{ $btrfsopts }},subvol=boot"       "$ROOTPART" "$IMAGEMNTDIR/boot"
-      # Keep /boot uncompressed so U-Boot can read the kernel/dtb/initrd regardless
-      # of whether its btrfs driver was built with zstd support. The property is
-      # stored on the subvolume and inherited by files added later (kernel updates).
-      btrfs property set "$IMAGEMNTDIR/boot" compression none
       mount -t btrfs -o "{{ $btrfsopts }},subvol=@home"      "$ROOTPART" "$IMAGEMNTDIR/home"
       mount -t btrfs -o "{{ $btrfsopts }},subvol=@var-log"   "$ROOTPART" "$IMAGEMNTDIR/var/log"
       mount -t btrfs -o "{{ $btrfsopts }},subvol=@var-cache" "$ROOTPART" "$IMAGEMNTDIR/var/cache"

--- a/overlays/configs/kernel/install.d/55-flipper-initrd.install
+++ b/overlays/configs/kernel/install.d/55-flipper-initrd.install
@@ -3,9 +3,7 @@
 #
 # Move the initrd (initramfs-tools writes it to /boot) into /usr/lib/modules/<ver>/initrd so a
 # profile carries its whole boot set and ships bootable in a btrfs send stream, leaving /boot clean.
-# Kernel+initrd must stay uncompressed: U-Boot's btrfs driver cannot read inline zstd extents.
 set -e
-. /usr/lib/flipper-bls.sh
 
 [ "$KERNEL_INSTALL_LAYOUT" = bls ] || exit 0
 KERNEL_VERSION="${2:?}"
@@ -18,10 +16,7 @@ fi
 [ "$1" = add ] || exit 0
 [ -d "$UM" ] || exit 0
 
-# new files here inherit compression=none; the dpkg-installed vmlinuz is rewritten below
-command -v btrfs >/dev/null 2>&1 && btrfs property set "$UM" compression none 2>/dev/null || :
-
-# reflink the initrd in (shares /boot's uncompressed extents), then drop the /boot copy
+# reflink the initrd in (shares /boot's extents), then drop the /boot copy
 for IRD in "$KERNEL_INSTALL_STAGING_AREA/initrd" "/boot/initrd.img-$KERNEL_VERSION" ""; do
     [ -n "$IRD" ] && [ -f "$IRD" ] && break
 done
@@ -30,5 +25,4 @@ if [ -n "$IRD" ]; then
         && rm -f "/boot/initrd.img-$KERNEL_VERSION"
 fi
 
-uncompress "$UM/vmlinuz"
 exit 0

--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -18,17 +18,6 @@ trim() { printf '%s' "$1" | sed 's/^ *//; s/ *$//'; }
 # copy a file into the entry dir as root:root 0644
 stage_file() { install -m 0644 -o root -g root "$1" "$2" || die "could not copy '$1'"; }
 
-# Rewrite a file uncompressed: set its dir to compression=none (new files inherit it), then rewrite
-# via a real copy. U-Boot cannot read inline zstd extents, so the kernel/initrd/dtb it reads must be
-# uncompressed. Best-effort; no-op off btrfs.
-uncompress() {
-    [ -f "$1" ] || return 0
-    btrfs property set "${1%/*}" compression none 2>/dev/null || :
-    if cp --reflink=never -p "$1" "$1.tmp" && mv -f "$1.tmp" "$1"; then return 0; fi
-    rm -f "$1.tmp" 2>/dev/null || :
-    echo "flipper-bls: could not rewrite '$1' uncompressed" >&2
-}
-
 # absolute path under BOOT_ROOT -> path as it must appear inside a BLS entry (relative to the
 # boot partition; identical to the absolute path while /boot is on the rootfs). On Flipper One
 # BOOT_MNT=/ (/boot is a subvol on the root partition, never a separate boot partition).


### PR DESCRIPTION
## What

Stop forcing the boot set uncompressed now that U-Boot can read zstd-compressed btrfs extents.

- `flipper-bls.sh`: drop the `uncompress()` helper (no callers left)
- `55-flipper-initrd.install`: drop the modules-dir `compression=none` and the vmlinuz rewrite; the initrd move is unchanged
- `debian-rk3576-img.yaml`: drop the `/boot` `compression=none` property

New boot files inherit the filesystem default (`compress=zstd`). Compressible files (dtb, dtbo, BLS loader entries) are stored zstd; vmlinuz/initrd stay raw since they are already image-compressed containers.

## Why

The forced-uncompress worked around U-Boot's old zstd failing to read small files that btrfs stores as inline extents (the dtbo overlays and loader entries went through the inline decode path). That is fixed by the u-boot zstd 1.5.7 import in flipperdevices/u-boot#37.

## Validation (RK3576, on hardware)

Fresh build from this branch running u-boot with flipperdevices/u-boot#37:

- No `compression=none` on any boot dir; dtb / dtbo / loader entries stored zstd
- Realtime compression on fresh writes confirmed (rename + no-reflink copy comes back zstd), so a kernel install compresses on the fly with no manual step
- Boots `@No-Graphics` with a compressed base dtb, a compressed `rk3576-no-graphics.dtbo` (read and applied), and compressed BLS loader entries

Boot log and full details in flipperdevices/u-boot#37.
