### PR TITLE
profile tooling: reject invalid profile names on create/rename

### DIFF
--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -30,6 +30,21 @@ is_reserved_subvol() {
     esac
 }
 
+# Reject a profile (top-level subvol) name that would break rootflags=subvol= on the kernel
+# cmdline and leave the profile unbootable. Requires a leading '@' and only [A-Za-z0-9_-].
+validate_profile_name() {
+    case "$1" in
+        *..*|/*|*/*) die "Invalid profile name: $1 (top-level name only, e.g. @Desktop-2)" ;;
+    esac
+    case "$1" in
+        @?*) ;;
+        *) die "Profile name must start with '@' (e.g. @Desktop-2): $1" ;;
+    esac
+    case "$1" in
+        *[!@A-Za-z0-9_-]*) die "Profile name has symbols that are not allowed: $1 (use only letters, digits, '-', '_')" ;;
+    esac
+}
+
 # Serialize our writers: an exclusive advisory lock (flock) held on FD 9 for the script's
 # lifetime, released on any exit (including crash/kill). The holder records "PID (tool)" in the
 # file so a blocked waiter can say who it is waiting on. Read-only tools do not take it, and it

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -61,14 +61,9 @@ src="$TOP/$src_rel"
 case "$dest" in
     current|booted|"") rel=$(findmnt -no FSROOT / | sed 's,^/,,')
                        [ -n "$rel" ] || die "Cannot determine booted subvolume" ;;
-    *)                 case "$dest" in *..*|/*|*/*) die "Invalid dest: $dest (top-level name only, e.g. @Desktop-2)" ;; esac
-                       rel=$dest ;;
+    *)                 rel=$dest; validate_profile_name "$rel" ;;
 esac
 is_reserved_subvol "$rel" && die "Refusing to write reserved subvolume: $rel"
-case "$rel" in
-    @?*) ;;
-    *) die "Profile name must start with '@' (e.g. @Desktop-2): $rel" ;;
-esac
 [ "$rel" = "$src_rel" ] && die "Dest and source are the same subvolume"
 
 existed=0; [ -e "$TOP/$rel" ] && existed=1

--- a/overlays/usr/local/sbin/rename-profile
+++ b/overlays/usr/local/sbin/rename-profile
@@ -27,15 +27,10 @@ old=$1; new=$2
 
 need_root
 need_btrfs
-for n in "$old" "$new"; do
-    case "$n" in *..*|/*|*/*) die "Invalid name: $n (top-level names only, e.g. @Desktop-2)" ;; esac
-done
+case "$old" in *..*|/*|*/*) die "Invalid name: $old (top-level names only, e.g. @Desktop-2)" ;; esac
+validate_profile_name "$new"
 [ "$old" = "$new" ] && die "Old and new names are the same"
 is_reserved_subvol "$new" && die "Refusing to use reserved name: $new"
-case "$new" in
-    @?*) ;;
-    *) die "New profile name must start with '@' (e.g. @Desktop-2): $new" ;;
-esac
 
 set_lock
 mount_top


### PR DESCRIPTION
Closes #131

## What

Reject invalid profile names in `create-profile` / `rename-profile` instead of letting them reach the subvolume name and BLS entry.

Adds `validate_profile_name` to `flipper-btrfs.sh`: requires a leading `@` and a body of `[A-Za-z0-9_-]` only, and aborts with a clear message on anything else (spaces included) rather than rewriting the name. Both tools run the typed name through it, replacing the weaker `*..*|/*|*/*` guard.

## Why

`create-profile @Desktop "@New Desktop"` produced subvolume `@New Desktop`; the space went into `rootflags=subvol=` and split the kernel cmdline, leaving the profile unbootable. See #131.

## Behavior

```
@New Desktop  -> Error: profile name has symbols that are not allowed
@a;reboot     -> Error: profile name has symbols that are not allowed
@bad/slash    -> Error: invalid profile name
Desktop       -> Error: must start with '@'
@Desktop-2    -> accepted
```
