### PR TITLE
profile tooling: fix fstab UUID and duplicate boot entry on re-create

### DIFF
--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -362,6 +362,11 @@ flipper_write_entry() {
     OVERLAY_DIR="$DTB_DIR/$VENDOR"
     # pin the root's own entry-token so a later runtime apt install in it lands in the same band
     mkdir -p "$_snap/etc/kernel" && printf '%s\n' "$ENTRY_TOKEN" > "$_snap/etc/kernel/entry-token"
+    # Remove any existing entry for this root+version first. The entry filename holds a sort
+    # number tied to the profile's btrfs snapshot depth, which changes when a profile is
+    # re-created; a new entry would then get a different filename instead of overwriting the
+    # old one, leaving a duplicate. Deleting first refreshes it in place.
+    remove_entries "$_name" "$KERNEL_VERSION"
     emit_entry "$(printf '%s' "$_name" | tr -d '@')" "rootflags=subvol=$_name" "" ""
     echo "flipper-bls: wrote entry for $_name (kernel $KERNEL_VERSION, token $ENTRY_TOKEN)"
 }

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -14,7 +14,7 @@
 #
 # If <@dest> does not exist it is created and a BLS boot entry is generated for it. If it
 # already exists it is replaced and the previous copy kept as <@dest>.old_<ts> (recoverable;
-# existing profiles already have their own boot entry, so none is added). The result is always
+# its boot entry is refreshed in place, so no duplicate is left behind). The result is always
 # writable, even when <@source> is read-only.
 #
 # Examples:
@@ -114,6 +114,17 @@ btrfs property set "$tgt" ro false 2>/dev/null || true
 # reset machine-id so the profile first-boots (fresh id + hostname/banner) instead of inheriting the source's
 printf 'uninitialized\n' > "$tgt/etc/machine-id" 2>/dev/null || true
 rm -f "$tgt/var/lib/dbus/machine-id" 2>/dev/null || true
+
+# rewrite the profile's fstab btrfs UUID to THIS device's fs, so a profile built or received on
+# another machine (different fs UUID) still mounts boot/@home/@var-* here (the kernel cmdline root=
+# UUID is rewritten separately by flipper-bls). The build-time UUID is whatever its own root (/)
+# entry uses; swap every occurrence for the live one.
+fst="$tgt/etc/fstab"
+if [ -f "$fst" ]; then
+    cur=$(findmnt -no UUID / 2>/dev/null)
+    old=$(awk '$2=="/"{for(i=1;i<=NF;i++) if($i ~ /^UUID=/){sub(/^UUID=/,"",$i); print $i; exit}}' "$fst")
+    [ -n "$cur" ] && [ -n "$old" ] && [ "$cur" != "$old" ] && { sed -i "s/$old/$cur/g" "$fst"; echo "fstab: rewrote fs UUID $old -> $cur"; }
+fi
 
 # BLS entry + /etc/kernel/entry-token via flipper-bls.sh, in a subshell so its die can't abort
 # us. Pass the SOURCE as origin hint so the root lands in that profile's band if parent_uuid is


### PR DESCRIPTION
Two fixes in the btrfs profile tooling, hit when a profile is built from a stock created on another machine, or when create-profile is re-run on an existing profile.

## fstab UUID
A profile made from a stock built or received on another machine kept that build's btrfs filesystem UUID in `/etc/fstab`, so `boot`/`@home`/`@var-*` failed to mount on this device (only the kernel cmdline `root=UUID` was being rewritten). `create-profile` now rewrites the profile's fstab UUID to the live filesystem's UUID.

## Duplicate boot entry
Re-running `create-profile` on an existing profile left a duplicate BLS boot entry: the sort band is derived from the btrfs parent-chain depth, which grows on each restore, so the new entry got a different filename and the old one was never removed. `flipper_write_entry` now drops any existing entry for the same root and version before writing.

Touches `overlays/usr/local/sbin/create-profile` and `overlays/usr/lib/flipper-bls.sh`.