### PR TITLE
usb: retry the UDC bind and skip virtual UDCs

### DIFF
--- a/overlays/usr/local/bin/usb-gadget-setup.sh
+++ b/overlays/usr/local/bin/usb-gadget-setup.sh
@@ -195,18 +195,31 @@ start()
 
     # bind if not bound (also the reconnect path after a replug)
     if [ -z "$(cat $G/UDC 2>/dev/null)" ]; then
-        udc=$(ls /sys/class/udc 2>/dev/null | head -n1)
+        # Prefer a hardware UDC; skip virtual ones (e.g. usbip-vudc.0) that would
+        # "bind" fine but expose nothing on the physical Type-C port.
+        udc=$(ls /sys/class/udc 2>/dev/null | grep -v vudc | head -n1)
+        udc=${udc:-$(ls /sys/class/udc 2>/dev/null | head -n1)}
         [ -n "$udc" ] || { echo "No UDC available" >&2; exit 1; }
         # only one gadget can hold the single dwc3 UDC; refuse with a clear message
         for other in /sys/kernel/config/usb_gadget/*/UDC; do
             [ -e "$other" ] || continue
             [ "$other" = "$G/UDC" ] && continue
             if [ "$(cat "$other" 2>/dev/null)" = "$udc" ]; then
-                echo "UDC $udc is busy (held by $(basename "$(dirname "$other")")); stop it first, e.g. 'systemctl stop usb-ncm-gadget'" >&2
+                echo "UDC $udc is busy (held by $(basename "$(dirname "$other")")); stop that gadget first" >&2
                 exit 1
             fi
         done
-        echo "$udc" > $G/UDC
+        # Early in boot the dwc3 controller may not be ready yet: writing UDC fails
+        # with -19 (ENODEV) / EBUSY and leaves it empty, so the gadget never comes
+        # up on the port. Retry until the bind sticks (up to ~5s).
+        i=0
+        while :; do
+            echo "$udc" > "$G/UDC" 2>/dev/null
+            [ -n "$(cat $G/UDC 2>/dev/null)" ] && break
+            i=$((i + 1))
+            [ "$i" -ge 15 ] && { echo "UDC $udc not ready after 15s" >&2; break; }
+            sleep 1
+        done
     fi
 }
 


### PR DESCRIPTION
Makes the USB gadget bind reliable at boot. Touches only `usb-gadget-setup.sh`, so it applies to every preset and composite.

## Retry the UDC bind

Early in boot the dwc3 controller may not be ready when the gadget service runs: writing the UDC name returns `ENODEV`/`EBUSY` and leaves `UDC` empty, so the gadget silently never comes up on the Type-C port. The bind now retries the write until it actually sticks (re-reading `UDC` to confirm), instead of writing once and assuming success.

## Skip virtual UDCs

`ls /sys/class/udc | head -n1` could pick a virtual controller (e.g. `usbip-vudc.0`) over the real dwc3. Binding to a vudc "succeeds" but exposes nothing on the physical port. The helper now prefers a hardware UDC and only falls back to whatever is present if none other exists.

Also reworded the busy-UDC message to be gadget-name-agnostic.

Follows the USB gadget work already merged to `dev`; this is a standalone reliability fix on top.