### PR TITLE
btrfs-tools: -y/--yes and -d/--device for scripted and recovery use

### DIFF
--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -15,8 +15,13 @@ need_root()  { [ "$(id -u)" -eq 0 ] || die "Must run as root (use sudo)"; }
 need_btrfs() { command -v btrfs >/dev/null 2>&1 || die "Btrfs-progs not installed"; }
 need_cmd()   { command -v "$1" >/dev/null 2>&1 || die "Command not installed: $1${2:+ ($2)}"; }
 
-# Ask on stderr, read stdin; abort unless yes. $1 may span lines.
+# Non-interactive switch for confirm(): set to 1 by -y/--yes, or via the environment
+# (ASSUME_YES=1 <tool> ...) so the tools can run unattended from scripts.
+ASSUME_YES=${ASSUME_YES:-0}
+
+# Ask on stderr, read stdin; abort unless yes. $1 may span lines. -y/--yes auto-confirms.
 confirm() {
+    if [ "$ASSUME_YES" = 1 ]; then printf '%s [auto-yes]\n' "$1" >&2; return 0; fi
     printf '%s [y/N] ' "$1" >&2
     read -r _a || die "Aborted"
     case "$_a" in y|Y|yes|YES) return 0 ;; *) die "Aborted" ;; esac

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -15,6 +15,9 @@ need_root()  { [ "$(id -u)" -eq 0 ] || die "Must run as root (use sudo)"; }
 need_btrfs() { command -v btrfs >/dev/null 2>&1 || die "Btrfs-progs not installed"; }
 need_cmd()   { command -v "$1" >/dev/null 2>&1 || die "Command not installed: $1${2:+ ($2)}"; }
 
+# True if / is a btrfs mount (a normally booted system, not a RAM recovery root).
+root_is_btrfs() { [ "$(findmnt -no FSTYPE / 2>/dev/null)" = btrfs ]; }
+
 # Non-interactive switch for confirm(): set to 1 by -y/--yes, or via the environment
 # (ASSUME_YES=1 <tool> ...) so the tools can run unattended from scripts.
 ASSUME_YES=${ASSUME_YES:-0}
@@ -52,9 +55,12 @@ set_lock() {
 
 # Mount the btrfs top level (subvolid=5) at a temp dir and arrange teardown on EXIT.
 # Sets ROOTDEV and TOP. Extra temp files to remove: assign them to TOP_TMPFILES first.
+# ROOTDEV may be preset (by -d/--device) to run against a filesystem that is not the
+# booted root, e.g. from a RAM recovery boot where / is not the btrfs filesystem.
 mount_top() {
-    ROOTDEV=$(findmnt -no SOURCE / | sed 's/\[.*//')
-    [ -n "$ROOTDEV" ] || die "Cannot determine root device"
+    [ -n "${ROOTDEV:-}" ] || ROOTDEV=$(findmnt -no SOURCE / | sed 's/\[.*//')
+    [ -n "$ROOTDEV" ] || die "Cannot determine root device (use -d/--device)"
+    [ -b "$ROOTDEV" ] || die "Not a block device: $ROOTDEV"
     TOP=$(mktemp -d)
     trap 'top_cleanup' EXIT
     _err=$(mount -o subvolid=5 "$ROOTDEV" "$TOP" 2>&1) || die "Mount failed: $_err"

--- a/overlays/usr/local/sbin/btrfs-maintenance
+++ b/overlays/usr/local/sbin/btrfs-maintenance
@@ -24,17 +24,24 @@ Usage: btrfs-maintenance <check|fix|dedup|balance|all>
 EOF
 }
 
-do_scrub=0; scrub_ro=; dedup=0; balance=0; lock=1
-case "${1:-}" in
-    -h|--help) usage; exit 0 ;;
+do_scrub=0; scrub_ro=; dedup=0; balance=0; lock=1; cmd=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -y|--yes)    ASSUME_YES=1 ;;
+        -h|--help)   usage; exit 0 ;;
+        -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)           [ -z "$cmd" ] || { echo "Error: unexpected argument: $1" >&2; usage >&2; exit 1; }; cmd=$1 ;;
+    esac
+    shift
+done
+case "$cmd" in
     check)     do_scrub=1; scrub_ro=-r; lock=0 ;;
     fix)       do_scrub=1 ;;
     dedup)     dedup=1 ;;
     balance)   balance=1 ;;
     all)       do_scrub=1; scrub_ro=-r; dedup=1; balance=1 ;;
-    -?*)       echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
     "")        usage >&2; exit 1 ;;
-    *)         echo "Error: unknown command: $1" >&2; usage >&2; exit 1 ;;
+    *)         echo "Error: unknown command: $cmd" >&2; usage >&2; exit 1 ;;
 esac
 
 need_root

--- a/overlays/usr/local/sbin/btrfs-maintenance
+++ b/overlays/usr/local/sbin/btrfs-maintenance
@@ -15,18 +15,21 @@ set -eu
 
 usage() {
     cat <<EOF
-Usage: btrfs-maintenance <check|fix|dedup|balance|all>
+Usage: btrfs-maintenance [-d|--device DEV] <check|fix|dedup|balance|all>
   check     read-only scrub (verify checksums, no writes)
   fix       scrub with repair (only where a good copy exists)
   dedup     offline dedup via duperemove across all writable subvolumes
   balance   light filtered balance to reclaim partly-empty chunks
   all       check + dedup + balance
+  -d,--device  operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
 EOF
 }
 
 do_scrub=0; scrub_ro=; dedup=0; balance=0; lock=1; cmd=""
 while [ $# -gt 0 ]; do
     case "$1" in
+        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        --device=*)  ROOTDEV=${1#*=} ;;
         -y|--yes)    ASSUME_YES=1 ;;
         -h|--help)   usage; exit 0 ;;
         -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
@@ -46,7 +49,10 @@ esac
 
 need_root
 need_btrfs
+# On a booted system operate on / (scrub/balance are filesystem-wide). With -d/--device,
+# or a RAM recovery boot where / is not btrfs, mount the top level and act there instead.
 MNT=/
+if [ -n "${ROOTDEV:-}" ] || ! root_is_btrfs; then mount_top; MNT=$TOP; fi
 
 # Dedup across every profile/snapshot: duperemove must run on the btrfs TOP LEVEL (subvolid=5),
 # where all subvolumes appear as subdirectories. Run on / and it only sees the booted root.
@@ -55,7 +61,7 @@ MNT=/
 # would otherwise raise on each RO file.
 do_dedup() {
     need_cmd duperemove
-    mount_top
+    [ -n "${TOP:-}" ] || mount_top
     HASHFILE=$TOP/@var-cache/.duperemove_hashes.db
     _excl=""
     for _p in $(btrfs subvolume list -r "$TOP" | awk '{print $NF}'); do

--- a/overlays/usr/local/sbin/btrfs-show-space
+++ b/overlays/usr/local/sbin/btrfs-show-space
@@ -18,33 +18,40 @@ set -eu
 
 usage() {
     cat <<EOF
-Usage: btrfs-show-space [-q|--quick]
+Usage: btrfs-show-space [-q|--quick] [-d|--device DEV]
   Btrfs usage plus per-root-subvolume space (UNIQUE / REFERENCED / TOTAL).
   -q,--quick  skip the compsize REFERENCED column (one less extent-walk per subvol)
+  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
 EOF
 }
 
 quick=0
-case "${1:-}" in
-    -h|--help)  usage; exit 0 ;;
-    -q|--quick) quick=1; shift ;;
-    -?*)        echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
-esac
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -q|--quick)  quick=1 ;;
+        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        --device=*)  ROOTDEV=${1#*=} ;;
+        -h|--help)   usage; exit 0 ;;
+        -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)           echo "Error: unexpected argument: $1" >&2; usage >&2; exit 1 ;;
+    esac
+    shift
+done
 
 need_root
 need_btrfs
 have_cs=0
 if [ "$quick" = 0 ] && command -v compsize >/dev/null 2>&1; then have_cs=1; fi
 
-echo "== filesystem =="
-btrfs filesystem usage -T /
-echo
-
 rows=$(mktemp)
 list=$(mktemp)
 TOP_TMPFILES="$rows $list"
 mount_top
 cur_id=$(booted_id)
+
+echo "== filesystem =="
+btrfs filesystem usage -T "$TOP"
+echo
 
 row() {  # $1=display name  $2=fs path  -> append a TSV row
     line=$(btrfs filesystem du -s --raw "$2" 2>/dev/null | awk 'NR==2{print $1, $2}')

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -25,8 +25,9 @@ set -eu
 
 usage() {
     cat <<EOF
-Usage: create-profile [-m|--move] <@source> [<@dest>|current]
+Usage: create-profile [-m|--move] [-y|--yes] <@source> [<@dest>|current]
   -m,--move   move <@source> into <@dest> (consume source, preserve parent_uuid)
+  -y,--yes    assume yes to prompts (non-interactive)
   <@source>   full path or bare name: @snapshots/<name>, @<profile>_<stamp>, @<profile>_stock
   <@dest>     profile to write (default: booted profile; or current|booted)
 EOF
@@ -35,10 +36,11 @@ EOF
 move=0
 while :; do
     case "${1:-}" in
-        -m|--move)  move=1; shift ;;
-        -h|--help)  usage; exit 0 ;;
-        -?*)        echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
-        *)          break ;;
+        -m|--move)   move=1; shift ;;
+        -y|--yes)    ASSUME_YES=1; shift ;;
+        -h|--help)   usage; exit 0 ;;
+        -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)           break ;;
     esac
 done
 [ $# -ge 1 ] || { usage >&2; exit 1; }

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -99,9 +99,13 @@ if [ "$move" = 1 ]; then
     btrfs property set -f "$src" ro false || die "Could not clear ro on $src_name (needed to move it)"
 fi
 if [ "$existed" = 1 ]; then
+    # the stamp is per-second, so a second replace within the same second would land on an
+    # existing .old_<ts> and mv would nest the profile INSIDE it; take the next free name
     ts=$(date +%Y-%m-%d_%H-%M-%S)
     aside="$tgt.old_$ts"
-    mv "$tgt" "$aside"
+    n=1
+    while [ -e "$aside" ]; do aside="$tgt.old_${ts}_$n"; n=$((n + 1)); done
+    mv -T "$tgt" "$aside" || die "Could not move '$rel' aside; nothing changed"
 fi
 if [ "$move" = 1 ]; then
     if ! mv "$src" "$tgt"; then
@@ -134,9 +138,9 @@ fi
 
 if [ "$move" = 1 ]; then verb="moved"; else verb="created"; fi
 if [ "$existed" = 1 ]; then
-    echo "Profile '$rel' $verb from '$src_name' (writable); previous kept as ${rel}.old_$ts"
+    echo "Profile '$rel' $verb from '$src_name' (writable); previous kept as ${aside##*/}"
     echo "Reboot into '$rel' to use it; remove the old copy later with:"
-    echo "  sudo delete-profile ${rel}.old_$ts"
+    echo "  sudo delete-profile ${aside##*/}"
 else
     echo "Profile '$rel' $verb from '$src_name' (writable, boot entry added)"
     echo "Reboot and pick '$rel' from the boot menu to use it"

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -25,9 +25,10 @@ set -eu
 
 usage() {
     cat <<EOF
-Usage: create-profile [-m|--move] [-y|--yes] <@source> [<@dest>|current]
+Usage: create-profile [-m|--move] [-y|--yes] [-d|--device DEV] <@source> [<@dest>|current]
   -m,--move   move <@source> into <@dest> (consume source, preserve parent_uuid)
   -y,--yes    assume yes to prompts (non-interactive)
+  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
   <@source>   full path or bare name: @snapshots/<name>, @<profile>_<stamp>, @<profile>_stock
   <@dest>     profile to write (default: booted profile; or current|booted)
 EOF
@@ -38,6 +39,8 @@ while :; do
     case "${1:-}" in
         -m|--move)   move=1; shift ;;
         -y|--yes)    ASSUME_YES=1; shift ;;
+        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1; shift ;;
+        --device=*)  ROOTDEV=${1#*=}; shift ;;
         -h|--help)   usage; exit 0 ;;
         -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
         *)           break ;;
@@ -61,7 +64,8 @@ src="$TOP/$src_rel"
 
 # dest -> exact top-level name (default: booted root)
 case "$dest" in
-    current|booted|"") rel=$(findmnt -no FSROOT / | sed 's,^/,,')
+    current|booted|"") root_is_btrfs || die "No booted profile to default <@dest> to; pass an explicit <@dest> (e.g. @Desktop-2)"
+                       rel=$(findmnt -no FSROOT / | sed 's,^/,,')
                        [ -n "$rel" ] || die "Cannot determine booted subvolume" ;;
     *)                 case "$dest" in *..*|/*|*/*) die "Invalid dest: $dest (top-level name only, e.g. @Desktop-2)" ;; esac
                        rel=$dest ;;

--- a/overlays/usr/local/sbin/create-snapshot
+++ b/overlays/usr/local/sbin/create-snapshot
@@ -20,10 +20,16 @@ Usage: create-snapshot [tag...]
 EOF
 }
 
-case "${1:-}" in
-    -h|--help) usage; exit 0 ;;
-    -?*)       echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
-esac
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -y|--yes)  ASSUME_YES=1 ;;
+        -h|--help) usage; exit 0 ;;
+        --)        shift; break ;;
+        -?*)       echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)         break ;;
+    esac
+    shift
+done
 
 need_root
 need_btrfs

--- a/overlays/usr/local/sbin/create-snapshot
+++ b/overlays/usr/local/sbin/create-snapshot
@@ -33,6 +33,7 @@ done
 
 need_root
 need_btrfs
+root_is_btrfs || die "create-snapshot captures the running root; not available when / is not btrfs (e.g. RAM recovery)"
 
 tag=$*
 if [ -n "$tag" ]; then

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -13,17 +13,24 @@ set -eu
 
 usage() {
     cat <<EOF
-Usage: delete-profile <@profile>
+Usage: delete-profile [-y|--yes] <@profile>
+  -y,--yes    assume yes to prompts (non-interactive)
   Delete a bootable profile at the btrfs top level (see list-profiles) and its boot
   entry: a profile root or an @<profile>.old_* leftover. For restore points and
   _stock golden bases use delete-snapshot.
 EOF
 }
 
-case "${1:-}" in
-    -h|--help) usage; exit 0 ;;
-    -?*)       echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
-esac
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -y|--yes)    ASSUME_YES=1 ;;
+        -h|--help)   usage; exit 0 ;;
+        --)          shift; break ;;
+        -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)           break ;;
+    esac
+    shift
+done
 [ $# -ge 1 ] || { usage >&2; exit 1; }
 
 need_root

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -13,8 +13,9 @@ set -eu
 
 usage() {
     cat <<EOF
-Usage: delete-profile [-y|--yes] <@profile>
+Usage: delete-profile [-y|--yes] [-d|--device DEV] <@profile>
   -y,--yes    assume yes to prompts (non-interactive)
+  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
   Delete a bootable profile at the btrfs top level (see list-profiles) and its boot
   entry: a profile root or an @<profile>.old_* leftover. For restore points and
   _stock golden bases use delete-snapshot.
@@ -24,6 +25,8 @@ EOF
 while [ $# -gt 0 ]; do
     case "$1" in
         -y|--yes)    ASSUME_YES=1 ;;
+        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
         --)          shift; break ;;
         -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;

--- a/overlays/usr/local/sbin/delete-snapshot
+++ b/overlays/usr/local/sbin/delete-snapshot
@@ -13,8 +13,9 @@ set -eu
 
 usage() {
     cat <<EOF
-Usage: delete-snapshot [-y|--yes] <@snapshots/@name | @stock-snapshots/@X_stock | @X_stock>
+Usage: delete-snapshot [-y|--yes] [-d|--device DEV] <@snapshots/@name | @stock-snapshots/@X_stock | @X_stock>
   -y,--yes    assume yes to prompts (non-interactive)
+  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
   Delete a restore-point snapshot under @snapshots or a _stock golden base under
   @stock-snapshots (see list-snapshots). For profiles or .old leftovers use delete-profile.
 EOF
@@ -23,6 +24,8 @@ EOF
 while [ $# -gt 0 ]; do
     case "$1" in
         -y|--yes)    ASSUME_YES=1 ;;
+        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
         --)          shift; break ;;
         -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;

--- a/overlays/usr/local/sbin/delete-snapshot
+++ b/overlays/usr/local/sbin/delete-snapshot
@@ -13,16 +13,23 @@ set -eu
 
 usage() {
     cat <<EOF
-Usage: delete-snapshot <@snapshots/@name | @stock-snapshots/@X_stock | @X_stock>
+Usage: delete-snapshot [-y|--yes] <@snapshots/@name | @stock-snapshots/@X_stock | @X_stock>
+  -y,--yes    assume yes to prompts (non-interactive)
   Delete a restore-point snapshot under @snapshots or a _stock golden base under
   @stock-snapshots (see list-snapshots). For profiles or .old leftovers use delete-profile.
 EOF
 }
 
-case "${1:-}" in
-    -h|--help) usage; exit 0 ;;
-    -?*)       echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
-esac
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -y|--yes)    ASSUME_YES=1 ;;
+        -h|--help)   usage; exit 0 ;;
+        --)          shift; break ;;
+        -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)           break ;;
+    esac
+    shift
+done
 [ $# -ge 1 ] || { usage >&2; exit 1; }
 
 need_root

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -13,16 +13,22 @@ set -eu
 
 usage() {
     cat <<EOF
-Usage: list-profiles
+Usage: list-profiles [-d|--device DEV]
+  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
   List bootable profiles at the btrfs top level: profile roots and @<profile>.old_*
   leftovers. For _stock golden bases and restore points, see list-snapshots.
 EOF
 }
 
-case "${1:-}" in
-    -h|--help) usage; exit 0 ;;
-    ?*)        echo "Error: unexpected argument: $1" >&2; usage >&2; exit 1 ;;
-esac
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        --device=*)  ROOTDEV=${1#*=} ;;
+        -h|--help)   usage; exit 0 ;;
+        *)           echo "Error: unexpected argument: $1" >&2; usage >&2; exit 1 ;;
+    esac
+    shift
+done
 
 need_root
 need_btrfs

--- a/overlays/usr/local/sbin/list-snapshots
+++ b/overlays/usr/local/sbin/list-snapshots
@@ -12,16 +12,22 @@ set -eu
 
 usage() {
     cat <<EOF
-Usage: list-snapshots
+Usage: list-snapshots [-d|--device DEV]
+  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
   List restore-point snapshots under @snapshots and _stock golden bases under
   @stock-snapshots. For bootable profiles, see list-profiles.
 EOF
 }
 
-case "${1:-}" in
-    -h|--help) usage; exit 0 ;;
-    ?*)        echo "Error: unexpected argument: $1" >&2; usage >&2; exit 1 ;;
-esac
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        --device=*)  ROOTDEV=${1#*=} ;;
+        -h|--help)   usage; exit 0 ;;
+        *)           echo "Error: unexpected argument: $1" >&2; usage >&2; exit 1 ;;
+    esac
+    shift
+done
 
 need_root
 need_btrfs

--- a/overlays/usr/local/sbin/receive-snapshot
+++ b/overlays/usr/local/sbin/receive-snapshot
@@ -14,7 +14,8 @@ set -eu
 
 usage() {
     cat <<EOF
-Usage: receive-snapshot <file|->
+Usage: receive-snapshot [-d|--device DEV] <file|->
+  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
   Receive a send-snapshot stream (a _stock base -> @stock-snapshots, else @snapshots). Put it onto a root
   with create-profile. Incremental streams need their parent to exist here first.
 EOF
@@ -23,6 +24,8 @@ EOF
 while [ $# -gt 0 ]; do
     case "$1" in
         -y|--yes)    ASSUME_YES=1 ;;
+        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
         --)          shift; break ;;
         -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;

--- a/overlays/usr/local/sbin/receive-snapshot
+++ b/overlays/usr/local/sbin/receive-snapshot
@@ -20,10 +20,16 @@ Usage: receive-snapshot <file|->
 EOF
 }
 
-case "${1:-}" in
-    -h|--help) usage; exit 0 ;;
-    -?*)       echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
-esac
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -y|--yes)    ASSUME_YES=1 ;;
+        -h|--help)   usage; exit 0 ;;
+        --)          shift; break ;;
+        -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)           break ;;
+    esac
+    shift
+done
 [ $# -ge 1 ] || { usage >&2; exit 1; }
 src=$1
 

--- a/overlays/usr/local/sbin/rename-profile
+++ b/overlays/usr/local/sbin/rename-profile
@@ -12,7 +12,8 @@ set -eu
 
 usage() {
     cat <<EOF
-Usage: rename-profile <@old> <@new>
+Usage: rename-profile [-d|--device DEV] <@old> <@new>
+  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
   Rename a bootable profile at the btrfs top level (see list-profiles) and reissue
   its boot entry. Both are top-level names. Cannot rename the booted profile.
 EOF
@@ -21,6 +22,8 @@ EOF
 while [ $# -gt 0 ]; do
     case "$1" in
         -y|--yes)    ASSUME_YES=1 ;;
+        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
         --)          shift; break ;;
         -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;

--- a/overlays/usr/local/sbin/rename-profile
+++ b/overlays/usr/local/sbin/rename-profile
@@ -18,10 +18,16 @@ Usage: rename-profile <@old> <@new>
 EOF
 }
 
-case "${1:-}" in
-    -h|--help) usage; exit 0 ;;
-    -?*)       echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
-esac
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -y|--yes)    ASSUME_YES=1 ;;
+        -h|--help)   usage; exit 0 ;;
+        --)          shift; break ;;
+        -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)           break ;;
+    esac
+    shift
+done
 [ $# -ge 2 ] || { usage >&2; exit 1; }
 old=$1; new=$2
 

--- a/overlays/usr/local/sbin/send-snapshot
+++ b/overlays/usr/local/sbin/send-snapshot
@@ -34,11 +34,12 @@ EOF
 parent=""; incremental=0
 while :; do
     case "${1:-}" in
-        -p)        [ $# -ge 2 ] || die "-p requires a PARENT snapshot"; parent=$2; shift 2 ;;
-        -i)        incremental=1; shift ;;
-        -h|--help) usage; exit 0 ;;
-        -?*)       echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
-        *)         break ;;
+        -p)          [ $# -ge 2 ] || die "-p requires a PARENT snapshot"; parent=$2; shift 2 ;;
+        -i)          incremental=1; shift ;;
+        -y|--yes)    ASSUME_YES=1; shift ;;
+        -h|--help)   usage; exit 0 ;;
+        -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)           break ;;
     esac
 done
 [ $# -ge 2 ] || { usage >&2; exit 1; }

--- a/overlays/usr/local/sbin/send-snapshot
+++ b/overlays/usr/local/sbin/send-snapshot
@@ -23,9 +23,10 @@ set -eu
 
 usage() {
     cat <<EOF
-Usage: send-snapshot [-p PARENT | -i] <@snapshot> <file|dir|->
+Usage: send-snapshot [-p PARENT | -i] [-d|--device DEV] <@snapshot> <file|dir|->
   -p PARENT   incremental: send only changes since PARENT (ro, must exist on receiver)
   -i          incremental vs the source's _stock parent (else a full send)
+  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
   <@snapshot> full path or bare name, e.g. @snapshots/<name> (rw source auto-snapshotted ro)
   <file|dir>  output file, a directory (writes <leaf>_pack.zst), or - for stdout
 EOF
@@ -37,6 +38,8 @@ while :; do
         -p)          [ $# -ge 2 ] || die "-p requires a PARENT snapshot"; parent=$2; shift 2 ;;
         -i)          incremental=1; shift ;;
         -y|--yes)    ASSUME_YES=1; shift ;;
+        -d|--device) [ $# -ge 2 ] || die "--device requires an argument"; ROOTDEV=$2; shift 2 ;;
+        --device=*)  ROOTDEV=${1#*=}; shift ;;
         -h|--help)   usage; exit 0 ;;
         -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
         *)           break ;;


### PR DESCRIPTION
Make the btrfs profile/snapshot tools usable from scripts and from a recovery boot.

## `-y/--yes` (non-interactive)

`confirm()` now honors `ASSUME_YES`, set by `-y/--yes` or via the environment
(`ASSUME_YES=1 delete-profile @Foo`). When set it prints the question with
`[auto-yes]` and never reads stdin, so the tools can run unattended.

Real effect on the three tools that prompt (`create-profile`, `delete-profile`,
`delete-snapshot`); accepted as a no-op on the other writers so scripts can pass
the flag uniformly.

## `-d/--device DEV` (operate on a non-booted filesystem)

Previously every tool found the filesystem the same way: `findmnt -no SOURCE /`,
i.e. the device behind `/`, then mounted `subvolid=5`. That only works on a
normally booted system. From a recovery Linux running fully in RAM, `/` is a
tmpfs/overlay, so the lookup returned the wrong device and every tool failed.

`mount_top()` now uses a preset `ROOTDEV` when given, so `-d/--device` can target
any btrfs filesystem:

```
list-profiles -d /dev/mmcblk0p3
delete-profile -y -d /dev/mmcblk0p3 @Broken
```

There is deliberately no auto-discovery: without `-d` the behavior is unchanged
(booted root), and `-d` is the explicit override.

Also in this commit:

- new `root_is_btrfs()` helper; operations that assume a booted btrfs root now
  fail with a clear message instead of a bogus default:
  - `create-snapshot` snapshots the running `/`, so it is booted-only and says so
  - `create-profile`'s default `<@dest>` (the booted profile) asks for an explicit
    dest when there is no booted btrfs root
- `btrfs-show-space` and `btrfs-maintenance` run `btrfs filesystem usage` /
  `scrub` / `balance` against the mounted top level under `--device` (the booted
  path still acts on `/`)
- `mount_top()` gained a block-device sanity check and a `use -d/--device` hint
- read-only tools (`list-profiles`, `list-snapshots`, `btrfs-show-space`) take
  `-d` too, so a filesystem can be inspected from recovery

## Testing

- `sh -n` clean on all 12 files
- `--help` works on every tool; unknown options still rejected; `-y`/`-d` parse in
  any position ahead of positionals
- `--device` with no value gives a clear error; `send-snapshot`'s `--device`
  correctly consumes its value
- `confirm()`: auto-yes skips stdin; default still accepts `y` and aborts on
  empty/EOF

Not yet exercised against a real recovery boot on device.

## Note

`migration-tool` is stacked on this branch (`migrate-profile` gets the same two
flags there) and depends on the shared-lib changes here, so this should merge
first.
