### PR TITLE
btrfs tooling: shared helpers, migrate-profile hardening, and the defects device testing found

### DIFF
--- a/overlays/usr/lib/flipper-accountdb.awk
+++ b/overlays/usr/lib/flipper-accountdb.awk
@@ -1,0 +1,65 @@
+# flipper-accountdb.awk - per-entry 3-way merge of the account databases, run by
+# migrate-profile as: awk -v LF=<list-fields> -f this base ours theirs
+#
+# Account databases (passwd/shadow/group/gshadow + backups) are keyed by the first field, not by
+# line order, so a text merge conflicts on every epoch bump and could duplicate entries. Merge them
+# per entry instead: an account the user did not touch follows the new base (apt replay is the
+# authority for service accounts), an account the user added or changed rides along from src, and
+# group/gshadow memberships are set-merged. Deterministic, never conflicts.
+#
+# LF: comma-separated field numbers holding member lists (group=4, gshadow=3,4).
+BEGIN { FS=":"; nlf=split(LF,_l,","); for(i=1;i<=nlf;i++) islist[_l[i]+0]=1; fidx=0 }
+FNR==1 { fidx++ }
+{
+    if ($0=="") next
+    k=$1
+    if      (fidx==1) { Bl[k]=$0; hB[k]=1 }
+    else if (fidx==2) { Ol[k]=$0; hO[k]=1; if(!(k in os)){ os[k]=1; oord[++no]=k } }
+    else              { Tl[k]=$0; hT[k]=1; if(!(k in ts)){ ts[k]=1; tord[++nt]=k } }
+}
+END {
+    for (i=1;i<=no;i++) put(oord[i])
+    for (i=1;i<=nt;i++) if (!(tord[i] in os)) put(tord[i])
+}
+function put(k,   line) { line=decide(k); if (line!="") print line }
+function decide(k,   ib,io,it) {
+    ib=(k in hB); io=(k in hO); it=(k in hT)
+    if (!io && !it) return ""
+    if ( io && !it) { if (ib && Ol[k]==Bl[k]) return ""; return Ol[k] }
+    if (!io &&  it) { if (ib && Tl[k]==Bl[k]) return ""; return Tl[k] }
+    if (LF!="") return mergerec(k, ib)
+    if (Ol[k]==Tl[k]) return Ol[k]
+    if (!ib)          return Ol[k]
+    if (Tl[k]==Bl[k]) return Ol[k]
+    if (Ol[k]==Bl[k]) return Tl[k]
+    return Tl[k]
+}
+function mergerec(k, ib,   nb,no2,nt2,fb,fo,ft,fi,res) {
+    nb  = ib ? split(Bl[k], fb, ":") : 0
+    no2 =      split(Ol[k], fo, ":")
+    nt2 =      split(Tl[k], ft, ":")
+    for (fi=1; fi<=no2; fi++)
+        rf[fi] = (fi in islist) ? merge_members(fi, ib, fb, fo, ft, nb, no2, nt2) : fo[fi]
+    res=rf[1]; for(fi=2;fi<=no2;fi++) res=res ":" rf[fi]
+    delete rf
+    return res
+}
+function merge_members(fi, ib, fb, fo, ft, nb, no2, nt2,   i,m,res) {
+    delete inB; delete inO; delete inT; delete ordm; delete ordseen; nord=0
+    if (ib && nb >=fi) mark(fb[fi], inB)
+    if (      no2>=fi) mark(fo[fi], inO)
+    if (      nt2>=fi) mark(ft[fi], inT)
+    if (      no2>=fi) order(fo[fi])
+    if (      nt2>=fi) order(ft[fi])
+    if (ib && nb >=fi) order(fb[fi])
+    res=""
+    for (i=1;i<=nord;i++) {
+        m=ordm[i]
+        if ((m in inB) && !(m in inO)) continue
+        if ((m in inB) && !(m in inT)) continue
+        res = (res=="") ? m : res "," m
+    }
+    return res
+}
+function mark(s, arr,   n,a,i) { n=split(s,a,","); for(i=1;i<=n;i++) if(a[i]!="") arr[a[i]]=1 }
+function order(s,   n,a,i)     { n=split(s,a,","); for(i=1;i<=n;i++) if(a[i]!="" && !(a[i] in ordseen)){ ordseen[a[i]]=1; ordm[++nord]=a[i] } }

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -102,6 +102,9 @@ mount_top() {
     [ -b "$ROOTDEV" ] || die "Not a block device: $ROOTDEV"
     TOP=$(mktemp -d)
     trap 'top_cleanup' EXIT
+    # dash runs the EXIT trap on exit, not on a signal, so a plain kill would leave $TOP mounted;
+    # route the usual signals through exit so the cleanup happens once, in one place
+    trap 'exit 130' INT; trap 'exit 143' TERM; trap 'exit 129' HUP
     _err=$(mount -o subvolid=5 "$ROOTDEV" "$TOP" 2>&1) || die "Mount failed: $_err"
 }
 # True if the filesystem mount_top opened is the one we booted from, so the booted profile and its
@@ -117,7 +120,16 @@ top_is_booted_fs() {
 # dying, so the first umount can lose the race with EBUSY and the top-level mount leaks for the rest
 # of the uptime. Retry briefly, then detach lazily so it goes away once the last reference does.
 top_cleanup() {
-    [ -n "${TOP:-}" ] && { umount "$TOP" 2>/dev/null || true; rmdir "$TOP" 2>/dev/null || true; }
+    if [ -n "${TOP:-}" ]; then
+        for _i in 1 2 3 4 5; do
+            umount "$TOP" 2>/dev/null && break
+            # no bare AND-list here: the callers run under set -e, where a false test would
+            # abort the trap and abandon the mount
+            if [ "$_i" = 5 ]; then umount -l "$TOP" 2>/dev/null || true; fi
+            sleep 1
+        done
+        rmdir "$TOP" 2>/dev/null || true
+    fi
     [ -n "${TOP_TMPFILES:-}" ] && rm -f $TOP_TMPFILES
     return 0
 }

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -86,10 +86,17 @@ set_lock() {
     exec 9<>"$LOCK_FILE" || die "Cannot open lock $LOCK_FILE"   # <> = don't truncate the holder line
     if ! flock -w 0 9 2>/dev/null; then
         _h=$(cat "$LOCK_FILE" 2>/dev/null); [ -n "$_h" ] || _h="PID unknown"
+        # the line is written by whoever holds it; if that process is gone the line is stale
+        # leftovers from a crash, so do not present it as the reason we are waiting
+        _hp=${_h#PID }; _hp=${_hp%% *}
+        case "$_hp" in
+            [0-9]*) kill -0 "$_hp" 2>/dev/null || _h="$_h, which is no longer running; the line is stale" ;;
+        esac
         echo "Another flipper-btrfs operation is in progress ($_h); waiting for it to finish..." >&2
         flock 9 || die "Cannot acquire lock $LOCK_FILE"
     fi
     printf 'PID %s (%s)\n' "$$" "${0##*/}" >"$LOCK_FILE" || true
+    LOCK_HELD=1
 }
 
 # Mount the btrfs top level (subvolid=5) at a temp dir and arrange teardown on EXIT.
@@ -122,6 +129,9 @@ top_is_booted_fs() {
 # dying, so the first umount can lose the race with EBUSY and the top-level mount leaks for the rest
 # of the uptime. Retry briefly, then detach lazily so it goes away once the last reference does.
 top_cleanup() {
+    # our holder line outlives the flock, which the kernel drops for us; blank it so the next
+    # waiter never reads a pid that has been gone for days
+    [ "${LOCK_HELD:-0}" = 1 ] && : > "$LOCK_FILE" 2>/dev/null
     if [ -n "${TOP:-}" ]; then
         for _i in 1 2 3 4 5; do
             umount "$TOP" 2>/dev/null && break

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -134,6 +134,19 @@ is_ro() {
     esac
 }
 
+# The timestamp every generated name uses (snapshots, aside copies, ro sends). One helper so
+# the names stay mutually parseable: list-profiles keys KIND=old off this exact shape.
+stamp() { date +%Y-%m-%d_%H-%M-%S; }
+
+# Top-relative path of the subvolume with this uuid, empty if none. $1 = top mount, $2 = uuid.
+path_of_uuid() {
+    case "$2" in ''|'-') return ;; esac
+    btrfs subvolume list -u "$1" 2>/dev/null | awk -v u="$2" '
+        { p=""; uu=""
+          for (i=1;i<=NF;i++) { if($i=="uuid")uu=$(i+1); else if($i=="path"){p=$(i+1);for(j=i+2;j<=NF;j++)p=p" "$j} }
+          if (uu==u){print p; exit} }'
+}
+
 human() { numfmt --to=iec-i --suffix=B --format='%.1f' "${1:-0}" 2>/dev/null || printf '%s' "${1:-0}"; }
 
 # uuid -> "id <tab> path" for every subvolume, so parents resolve by UUID. $1 = top, $2 = out file.

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -18,6 +18,30 @@ need_cmd()   { command -v "$1" >/dev/null 2>&1 || die "Command not installed: $1
 # True if / is a btrfs mount (a normally booted system, not a RAM recovery root).
 root_is_btrfs() { [ "$(findmnt -no FSTYPE / 2>/dev/null)" = btrfs ]; }
 
+# The subvolume mounted at / (e.g. @Desktop), empty if there is none. findmnt reads
+# /proc/self/mountinfo, which is authoritative on a booted system and needs no privileges; it
+# cannot answer inside a chroot, and it reports the path recorded at mount time, so fall back to
+# asking btrfs, which resolves the subvolume live. flipper-bls.sh keeps its own copy of this on
+# purpose: kernel-install hooks source that file without this one.
+current_subvol() {
+    _cs=$(findmnt -nro FSROOT / 2>/dev/null | sed 's,^/,,')
+    [ -n "$_cs" ] || _cs=$(btrfs subvolume show / 2>/dev/null | sed -n '1{s,^/*,,;s,[[:space:]]*$,,;p}')
+    printf '%s' "$_cs"
+}
+
+# btrfs FS UUID of the mounted root, empty if unknown. Same reasoning as current_subvol.
+current_fsuuid() {
+    _fu=$(findmnt -nro UUID / 2>/dev/null)
+    [ -n "$_fu" ] || _fu=$(btrfs filesystem show / 2>/dev/null | sed -n 's/.*[[:space:]]uuid:[[:space:]]*//p' | head -1)
+    printf '%s' "$_fu"
+}
+
+# The two option help lines nearly every tool repeats verbatim in its usage(). Kept here so the
+# wording cannot drift between tools; interpolated inside their heredocs. migrate-profile spells
+# its own out, its -y means something more specific and its help column is wider.
+HELP_YES="  -y,--yes    assume yes to prompts (non-interactive)"
+HELP_DEVICE="  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)"
+
 # Non-interactive switch for confirm(): set to 1 by -y/--yes, or via the environment
 # (ASSUME_YES=1 <tool> ...) so the tools can run unattended from scripts.
 ASSUME_YES=${ASSUME_YES:-0}

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -97,14 +97,16 @@ set_lock() {
 # ROOTDEV may be preset (by -d/--device) to run against a filesystem that is not the
 # booted root, e.g. from a RAM recovery boot where / is not the btrfs filesystem.
 mount_top() {
-    [ -n "${ROOTDEV:-}" ] || ROOTDEV=$(findmnt -no SOURCE / | sed 's/\[.*//')
-    [ -n "$ROOTDEV" ] || die "Cannot determine root device (use -d/--device)"
-    [ -b "$ROOTDEV" ] || die "Not a block device: $ROOTDEV"
-    TOP=$(mktemp -d)
+    # Arm cleanup FIRST: callers set TOP_TMPFILES before calling us, so a die on the checks below
+    # (a bad -d argument, no btrfs root) must still take their temp files with it.
     trap 'top_cleanup' EXIT
     # dash runs the EXIT trap on exit, not on a signal, so a plain kill would leave $TOP mounted;
     # route the usual signals through exit so the cleanup happens once, in one place
     trap 'exit 130' INT; trap 'exit 143' TERM; trap 'exit 129' HUP
+    [ -n "${ROOTDEV:-}" ] || ROOTDEV=$(findmnt -no SOURCE / | sed 's/\[.*//')
+    [ -n "$ROOTDEV" ] || die "Cannot determine root device (use -d/--device)"
+    [ -b "$ROOTDEV" ] || die "Not a block device: $ROOTDEV"
+    TOP=$(mktemp -d)
     _err=$(mount -o subvolid=5 "$ROOTDEV" "$TOP" 2>&1) || die "Mount failed: $_err"
 }
 # True if the filesystem mount_top opened is the one we booted from, so the booted profile and its

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -104,6 +104,18 @@ mount_top() {
     trap 'top_cleanup' EXIT
     _err=$(mount -o subvolid=5 "$ROOTDEV" "$TOP" 2>&1) || die "Mount failed: $_err"
 }
+# True if the filesystem mount_top opened is the one we booted from, so the booted profile and its
+# subvolume ids mean something here. Under -d/--device (recovery) the two filesystems are unrelated
+# and their ids collide by accident, which would mark or refuse the wrong subvolume. Needs ROOTDEV.
+top_is_booted_fs() {
+    root_is_btrfs || return 1
+    _tu=$(blkid -o value -s UUID "${ROOTDEV:-}" 2>/dev/null)
+    [ -n "$_tu" ] && [ "$_tu" = "$(current_fsuuid)" ]
+}
+
+# Best-effort was not good enough: on a signal the children (btrfs send/receive, zstd) are still
+# dying, so the first umount can lose the race with EBUSY and the top-level mount leaks for the rest
+# of the uptime. Retry briefly, then detach lazily so it goes away once the last reference does.
 top_cleanup() {
     [ -n "${TOP:-}" ] && { umount "$TOP" 2>/dev/null || true; rmdir "$TOP" 2>/dev/null || true; }
     [ -n "${TOP_TMPFILES:-}" ] && rm -f $TOP_TMPFILES

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -148,12 +148,10 @@ align_table() {
 }
 
 # Stamp a _stock's factory-origin marker (/etc/profile_origin) so migrate-profile can find a
-# profile's base after the btrfs parent chain is broken by deletions. Records the stock's own
-# name and its build id (BUILD_GIT from os-release). Profiles snapshotted from the stock inherit
-# the file; matching later is by name + BUILD_GIT, not by uuid (uuid is cleared by snapshots).
-# $1 = the stock's mounted dir, $2 = the stock's name (e.g. @Desktop_stock).
+# profile's base after the btrfs parent chain is broken by deletions. Profiles snapshotted from
+# the stock inherit the file; matching later is by name, not by uuid (a snapshot clears that).
+# The name carries the build id (@Desktop_744_stock), so it identifies the exact base on its own.
+# $1 = the stock's mounted dir, $2 = the stock's name (e.g. @Desktop_744_stock).
 stamp_stock_origin() {
-    _bg=$( . "$1/etc/os-release" >/dev/null 2>&1; printf '%s' "${BUILD_GIT:-}" ) || _bg=
-    [ -n "$_bg" ] || _bg=-
-    printf 'origin_stock_name=%s\norigin_base_build=%s\n' "$2" "$_bg" > "$1/etc/profile_origin"
+    printf 'origin_stock_name=%s\n' "$2" > "$1/etc/profile_origin"
 }

--- a/overlays/usr/local/sbin/btrfs-maintenance
+++ b/overlays/usr/local/sbin/btrfs-maintenance
@@ -62,7 +62,16 @@ if [ -n "${ROOTDEV:-}" ] || ! root_is_btrfs; then mount_top; MNT=$TOP; fi
 do_dedup() {
     need_cmd duperemove
     [ -n "${TOP:-}" ] || mount_top
-    HASHFILE=$TOP/@var-cache/.duperemove_hashes.db
+    # @var-cache is where the hashfile belongs, so it survives between runs and is not itself
+    # deduped. It is only there on filesystems our image built, and -d/--device exists precisely
+    # for the others, where duperemove would otherwise fail with an opaque "Error opening db".
+    if [ -d "$TOP/@var-cache" ]; then
+        HASHFILE=$TOP/@var-cache/.duperemove_hashes.db
+    else
+        HASHFILE=$(mktemp -u)
+        TOP_TMPFILES="${TOP_TMPFILES:-} $HASHFILE"
+        echo "No @var-cache on this filesystem; keeping duperemove's hash db in $HASHFILE for this run only" >&2
+    fi
     _excl=""
     for _p in $(btrfs subvolume list -r "$TOP" | awk '{print $NF}'); do
         _excl="$_excl --exclude=$TOP/$_p"
@@ -73,5 +82,18 @@ do_dedup() {
 [ "$lock" = 1 ]     && set_lock
 [ "$do_scrub" = 1 ] && btrfs scrub start -B $scrub_ro "$MNT"
 [ "$dedup" = 1 ]    && do_dedup
-[ "$balance" = 1 ]  && btrfs balance start -dusage=20 -musage=10 "$MNT"
+if [ "$balance" = 1 ]; then
+    # A balance needs somewhere to move chunks to. On a nearly full filesystem btrfs reports
+    # ENOSPC through the kernel log and leaves the caller with "try dmesg | tail", so say it here.
+    if ! _berr=$(btrfs balance start -dusage=20 -musage=10 "$MNT" 2>&1); then
+        printf '%s\n' "$_berr" >&2
+        case "$_berr" in
+            *"No space left"*|*ENOSPC*|*enospc*) die "Balance needs free space to move chunks into, and this filesystem has too little; free some and retry" ;;
+        esac
+        if dmesg 2>/dev/null | tail -40 | grep -qi 'enospc errors during balance'; then
+            die "Balance hit ENOSPC (kernel log): too little free space to move chunks; free some and retry"
+        fi
+        die "Balance failed"
+    fi
+fi
 exit 0

--- a/overlays/usr/local/sbin/btrfs-maintenance
+++ b/overlays/usr/local/sbin/btrfs-maintenance
@@ -21,7 +21,7 @@ Usage: btrfs-maintenance [-d|--device DEV] <check|fix|dedup|balance|all>
   dedup     offline dedup via duperemove across all writable subvolumes
   balance   light filtered balance to reclaim partly-empty chunks
   all       check + dedup + balance
-  -d,--device  operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
 EOF
 }
 

--- a/overlays/usr/local/sbin/btrfs-show-space
+++ b/overlays/usr/local/sbin/btrfs-show-space
@@ -1,7 +1,7 @@
 #!/bin/sh
 # btrfs-show-space [-q|--quick] - btrfs usage + per-root-subvolume space.
 # (-q/--quick skips the compsize REFERENCED column, one less extent-walk per subvol.)
-# Lists EVERY subvolume: profile roots and @.old_* leftovers, the snapshots under @snapshots,
+# Lists EVERY subvolume: profile roots and @_old_* leftovers, the snapshots under @snapshots,
 # the _stock bases under @stock-snapshots, and the shared @home / @var-* / boot.
 #   UNIQUE     - data only this subvolume holds; freed if you delete IT ALONE,
 #                others kept (btrfs fi du, exact, uncompressed)
@@ -70,7 +70,7 @@ row() {  # $1=display name  $2=fs path  -> append a TSV row
 }
 
 # collect EVERY subvolume (cheap), then measure with progress: each row walks extents (slow on
-# flash). btrfs subvolume list gives top-relative paths: profile roots + @.old_*, the nested
+# flash). btrfs subvolume list gives top-relative paths: profile roots + @_old_*, the nested
 # @snapshots/* and @stock-snapshots/* children, and the shared @home / @var-* / boot.
 btrfs subvolume list "$TOP" 2>/dev/null | sed -n 's/.* path //p' | sort | while read -r p; do
     printf '%s\t%s\n' "$p" "$TOP/$p" >> "$list"

--- a/overlays/usr/local/sbin/btrfs-show-space
+++ b/overlays/usr/local/sbin/btrfs-show-space
@@ -47,7 +47,7 @@ rows=$(mktemp)
 list=$(mktemp)
 TOP_TMPFILES="$rows $list"
 mount_top
-cur_id=$(booted_id)
+cur_id=""; top_is_booted_fs && cur_id=$(booted_id)
 
 echo "== filesystem =="
 btrfs filesystem usage -T "$TOP"

--- a/overlays/usr/local/sbin/btrfs-show-space
+++ b/overlays/usr/local/sbin/btrfs-show-space
@@ -21,7 +21,7 @@ usage() {
 Usage: btrfs-show-space [-q|--quick] [-d|--device DEV]
   Btrfs usage plus per-root-subvolume space (UNIQUE / REFERENCED / TOTAL).
   -q,--quick  skip the compsize REFERENCED column (one less extent-walk per subvol)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
 EOF
 }
 

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -27,8 +27,8 @@ usage() {
     cat <<EOF
 Usage: create-profile [-m|--move] [-y|--yes] [-d|--device DEV] <@source> [<@dest>|current]
   -m,--move   move <@source> into <@dest> (consume source, preserve parent_uuid)
-  -y,--yes    assume yes to prompts (non-interactive)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_YES
+$HELP_DEVICE
   <@source>   full path or bare name: @snapshots/<name>, @<profile>_<stamp>, @<profile>_stock
   <@dest>     profile to write (default: booted profile; or current|booted)
 EOF

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -13,7 +13,7 @@
 #             profile root while keeping its _stock parent.
 #
 # If <@dest> does not exist it is created and a BLS boot entry is generated for it. If it
-# already exists it is replaced and the previous copy kept as <@dest>.old_<ts> (recoverable;
+# already exists it is replaced and the previous copy kept as <@dest>_old_<ts> (recoverable;
 # its boot entry is refreshed in place, so no duplicate is left behind). The result is always
 # writable, even when <@source> is read-only.
 #
@@ -79,7 +79,7 @@ else
     how="with a writable copy of '$src_name'"
 fi
 if [ "$existed" = 1 ]; then
-    confirm "$(printf "Replace existing profile '%s' %s on %s?\nThe current '%s' is kept as %s.old_<ts>." \
+    confirm "$(printf "Replace existing profile '%s' %s on %s?\nThe current '%s' is kept as %s_old_<ts>." \
         "$rel" "$how" "$ROOTDEV" "$rel" "$rel")"
 else
     confirm "Create bootable profile '$rel' $how on $ROOTDEV?"
@@ -95,11 +95,11 @@ if [ "$move" = 1 ]; then
 fi
 if [ "$existed" = 1 ]; then
     # the stamp is per-second, so a second replace within the same second would land on an
-    # existing .old_<ts> and mv would nest the profile INSIDE it; take the next free name
+    # existing _old_<ts> and mv would nest the profile INSIDE it; take the next free name
     ts=$(date +%Y-%m-%d_%H-%M-%S)
-    aside="$tgt.old_$ts"
+    aside="${tgt}_old_$ts"
     n=1
-    while [ -e "$aside" ]; do aside="$tgt.old_${ts}_$n"; n=$((n + 1)); done
+    while [ -e "$aside" ]; do aside="${tgt}_old_${ts}_$n"; n=$((n + 1)); done
     mv -T "$tgt" "$aside" || die "Could not move '$rel' aside; nothing changed"
 fi
 if [ "$move" = 1 ]; then

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -96,7 +96,7 @@ fi
 if [ "$existed" = 1 ]; then
     # the stamp is per-second, so a second replace within the same second would land on an
     # existing _old_<ts> and mv would nest the profile INSIDE it; take the next free name
-    ts=$(date +%Y-%m-%d_%H-%M-%S)
+    ts=$(stamp)
     aside="${tgt}_old_$ts"
     n=1
     while [ -e "$aside" ]; do aside="${tgt}_old_${ts}_$n"; n=$((n + 1)); done

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -73,14 +73,20 @@ is_reserved_subvol "$rel" && die "Refusing to write reserved subvolume: $rel"
 [ "$rel" = "$src_rel" ] && die "Dest and source are the same subvolume"
 
 existed=0; [ -e "$TOP/$rel" ] && existed=1
+# Replacing the profile we are booted from is allowed on purpose (it is how a profile is reset to
+# a _stock), but the running system keeps using the copy moved aside until a reboot, so say so
+# before doing it and warn again afterwards.
+replacing_booted=0
+[ "$existed" = 1 ] && root_is_btrfs && [ "$(subvol_id "$TOP/$rel")" = "$(booted_id)" ] && replacing_booted=1
 if [ "$move" = 1 ]; then
     how="by MOVING '$src_name' into it (source consumed, parent preserved)"
 else
     how="with a writable copy of '$src_name'"
 fi
 if [ "$existed" = 1 ]; then
-    confirm "$(printf "Replace existing profile '%s' %s on %s?\nThe current '%s' is kept as %s_old_<ts>." \
-        "$rel" "$how" "$ROOTDEV" "$rel" "$rel")"
+    confirm "$(printf "Replace existing profile '%s' %s on %s?\nThe current '%s' is kept as %s_old_<ts>.%s" \
+        "$rel" "$how" "$ROOTDEV" "$rel" "$rel" \
+        "$([ "$replacing_booted" = 1 ] && printf "\nThis is the profile you are booted from: the running system stays on the copy moved aside until you reboot.")")"
 else
     confirm "Create bootable profile '$rel' $how on $ROOTDEV?"
 fi
@@ -145,7 +151,14 @@ fi
 if [ "$move" = 1 ]; then verb="moved"; else verb="created"; fi
 if [ "$existed" = 1 ]; then
     echo "Profile '$rel' $verb from '$src_name' (writable); previous kept as ${aside##*/}"
-    echo "Reboot into '$rel' to use it; remove the old copy later with:"
+    if [ "$replacing_booted" = 1 ]; then
+        echo "WARNING: REBOOT REQUIRED. '$rel' is the profile you are booted from, so the running" >&2
+        echo "         system is still the copy moved aside as ${aside##*/}; anything written" >&2
+        echo "         now lands there, not in the new '$rel'." >&2
+        echo "After rebooting, remove the old copy with:"
+    else
+        echo "Reboot into '$rel' to use it; remove the old copy later with:"
+    fi
     echo "  sudo delete-profile ${aside##*/}"
 else
     echo "Profile '$rel' $verb from '$src_name' (writable, boot entry added)"

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -65,7 +65,7 @@ src="$TOP/$src_rel"
 # dest -> exact top-level name (default: booted root)
 case "$dest" in
     current|booted|"") root_is_btrfs || die "No booted profile to default <@dest> to; pass an explicit <@dest> (e.g. @Desktop-2)"
-                       rel=$(findmnt -no FSROOT / | sed 's,^/,,')
+                       rel=$(current_subvol)
                        [ -n "$rel" ] || die "Cannot determine booted subvolume" ;;
     *)                 rel=$dest; validate_profile_name "$rel" ;;
 esac
@@ -126,7 +126,7 @@ rm -f "$tgt/var/lib/dbus/machine-id" 2>/dev/null || true
 # entry uses; swap every occurrence for the live one.
 fst="$tgt/etc/fstab"
 if [ -f "$fst" ]; then
-    cur=$(findmnt -no UUID / 2>/dev/null)
+    cur=$(current_fsuuid)
     old=$(awk '$2=="/"{for(i=1;i<=NF;i++) if($i ~ /^UUID=/){sub(/^UUID=/,"",$i); print $i; exit}}' "$fst")
     [ -n "$cur" ] && [ -n "$old" ] && [ "$cur" != "$old" ] && { sed -i "s/$old/$cur/g" "$fst"; echo "fstab: rewrote fs UUID $old -> $cur"; }
 fi

--- a/overlays/usr/local/sbin/create-snapshot
+++ b/overlays/usr/local/sbin/create-snapshot
@@ -43,7 +43,7 @@ fi
 # snapshot must not nest the new name under @snapshots/@snapshots/)
 src=$(current_subvol); src=${src##*/}
 [ -n "$src" ] || die "Cannot determine the source subvolume of /"
-name="${src}_$(date +%Y-%m-%d_%H-%M-%S)${tag:+_$tag}"
+name="${src}_$(stamp)${tag:+_$tag}"
 
 set_lock
 mount_top

--- a/overlays/usr/local/sbin/create-snapshot
+++ b/overlays/usr/local/sbin/create-snapshot
@@ -39,8 +39,9 @@ tag=$*
 if [ -n "$tag" ]; then
     tag=$(printf '%s' "$tag" | tr -c 'A-Za-z0-9._-' '-' | sed 's/-\{1,\}/-/g; s/^-//; s/-$//')
 fi
-# name after /'s source subvol, e.g. @Minimal_2026-06-29_19-52-31
-src=$(btrfs subvolume show / 2>/dev/null | head -n1); src=${src##*/}
+# name after /'s source subvol, e.g. @Minimal_2026-06-29_19-52-31 (leaf only: booting a
+# snapshot must not nest the new name under @snapshots/@snapshots/)
+src=$(current_subvol); src=${src##*/}
 [ -n "$src" ] || die "Cannot determine the source subvolume of /"
 name="${src}_$(date +%Y-%m-%d_%H-%M-%S)${tag:+_$tag}"
 

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -14,8 +14,8 @@ set -eu
 usage() {
     cat <<EOF
 Usage: delete-profile [-y|--yes] [-d|--device DEV] <@profile>
-  -y,--yes    assume yes to prompts (non-interactive)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_YES
+$HELP_DEVICE
   Delete a bootable profile at the btrfs top level (see list-profiles) and its boot
   entry: a profile root or an @<profile>_old_* leftover. For restore points and
   _stock golden bases use delete-snapshot.

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -1,6 +1,6 @@
 #!/bin/sh
 # delete-profile <@profile> - delete a bootable PROFILE at the btrfs top level (as listed by
-# list-profiles): a profile root (@Desktop, @Desktop-2, ...) or an @<profile>.old_* leftover. Also
+# list-profiles): a profile root (@Desktop, @Desktop-2, ...) or an @<profile>_old_* leftover. Also
 # removes its BLS boot entry. For @snapshots restore points and _stock golden bases (under
 # @stock-snapshots), use delete-snapshot.
 # Confirms once; AGAIN if the target is read-only. Refuses layout subvolumes and the currently
@@ -17,7 +17,7 @@ Usage: delete-profile [-y|--yes] [-d|--device DEV] <@profile>
   -y,--yes    assume yes to prompts (non-interactive)
   -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
   Delete a bootable profile at the btrfs top level (see list-profiles) and its boot
-  entry: a profile root or an @<profile>.old_* leftover. For restore points and
+  entry: a profile root or an @<profile>_old_* leftover. For restore points and
   _stock golden bases use delete-snapshot.
 EOF
 }

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -47,7 +47,7 @@ esac
 case "${arg##*/}" in *_stock) die "Top-level profiles only; for a golden base use: delete-snapshot $arg" ;; esac
 
 mount_top
-cur_id=$(booted_id)
+cur_id=""; top_is_booted_fs && cur_id=$(booted_id)
 [ -e "$TOP/$arg" ] || die "No such profile: $arg (see list-profiles)"
 rel=$arg
 is_reserved_subvol "$rel" && die "Refusing to delete reserved subvolume: $rel"

--- a/overlays/usr/local/sbin/delete-snapshot
+++ b/overlays/usr/local/sbin/delete-snapshot
@@ -14,8 +14,8 @@ set -eu
 usage() {
     cat <<EOF
 Usage: delete-snapshot [-y|--yes] [-d|--device DEV] <@snapshots/@name | @stock-snapshots/@X_stock | @X_stock>
-  -y,--yes    assume yes to prompts (non-interactive)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_YES
+$HELP_DEVICE
   Delete a restore-point snapshot under @snapshots or a _stock golden base under
   @stock-snapshots (see list-snapshots). For profiles or _old leftovers use delete-profile.
 EOF

--- a/overlays/usr/local/sbin/delete-snapshot
+++ b/overlays/usr/local/sbin/delete-snapshot
@@ -2,7 +2,7 @@
 # delete-snapshot <@snapshots/@name | @stock-snapshots/@X_stock | @X_stock> - delete a read-only
 # restore-point SNAPSHOT under @snapshots or a _stock GOLDEN BASE under @stock-snapshots (as listed
 # by list-snapshots); a bare _stock name resolves under @stock-snapshots. Confirms once, plus again
-# for a golden base. For bootable profiles or .old leftovers, use delete-profile. Works via a
+# for a golden base. For bootable profiles or _old leftovers, use delete-profile. Works via a
 # subvolid=5 (top-level) mount.
 #
 # Examples:
@@ -17,7 +17,7 @@ Usage: delete-snapshot [-y|--yes] [-d|--device DEV] <@snapshots/@name | @stock-s
   -y,--yes    assume yes to prompts (non-interactive)
   -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
   Delete a restore-point snapshot under @snapshots or a _stock golden base under
-  @stock-snapshots (see list-snapshots). For profiles or .old leftovers use delete-profile.
+  @stock-snapshots (see list-snapshots). For profiles or _old leftovers use delete-profile.
 EOF
 }
 

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -14,7 +14,7 @@ set -eu
 usage() {
     cat <<EOF
 Usage: list-profiles [-d|--device DEV]
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   List bootable profiles at the btrfs top level: profile roots and @<profile>_old_*
   leftovers. For _stock golden bases and restore points, see list-snapshots.
 EOF

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -39,10 +39,15 @@ TOP_TMPFILES="$map $rows"
 mount_top
 build_uuid_map "$TOP" "$map"
 
-cur=$(btrfs subvolume show / 2>/dev/null) || cur=
-cur_id=$(get "$cur" "Subvolume ID")
-cur_path=$(printf '%s\n' "$cur" | head -n1)
-[ -n "$cur_path" ] && echo "Currently booted profile: $cur_path (id ${cur_id:-?})"
+cur=""; cur_id=""; cur_path=""
+if top_is_booted_fs; then
+    cur=$(btrfs subvolume show / 2>/dev/null) || cur=
+    cur_id=$(get "$cur" "Subvolume ID")
+    cur_path=$(printf '%s\n' "$cur" | head -n1)
+    [ -n "$cur_path" ] && echo "Currently booted profile: $cur_path (id ${cur_id:-?})"
+else
+    echo "Listing $ROOTDEV, which is not the filesystem you booted from"
+fi
 echo
 
 emit() {  # $1=display name  $2=fs path

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -25,7 +25,8 @@ while [ $# -gt 0 ]; do
         -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
-        *)           echo "Error: unexpected argument: $1" >&2; usage >&2; exit 1 ;;
+        -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)           echo "Error: unexpected argument: $1 (this tool takes no arguments)" >&2; usage >&2; exit 1 ;;
     esac
     shift
 done

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -1,13 +1,13 @@
 #!/bin/sh
 # list-profiles - list the bootable PROFILES at the btrfs top level: the profile roots
-# (@Desktop, @Minimal, ...) and @<profile>.old_* leftovers from create-profile. KIND tags each
+# (@Desktop, @Minimal, ...) and @<profile>_old_* leftovers from create-profile. KIND tags each
 # (profile/old); PARENT is what it was snapshotted from (via Parent UUID). Names are top-level
 # paths (what create-profile/rename-profile/delete-profile take). The booted profile is marked
 # <- booted. For _stock golden bases and restore points, see list-snapshots.
 # Works via a subvolid=5 (top-level) mount.
 #
 # Example:
-#   list-profiles   # @SourceProfile / @DestinationProfile roots, _stock bases and .old leftovers
+#   list-profiles   # @SourceProfile / @DestinationProfile roots, _stock bases and _old leftovers
 set -eu
 . /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
 
@@ -15,7 +15,7 @@ usage() {
     cat <<EOF
 Usage: list-profiles [-d|--device DEV]
   -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
-  List bootable profiles at the btrfs top level: profile roots and @<profile>.old_*
+  List bootable profiles at the btrfs top level: profile roots and @<profile>_old_*
   leftovers. For _stock golden bases and restore points, see list-snapshots.
 EOF
 }
@@ -52,7 +52,9 @@ emit() {  # $1=display name  $2=fs path
     flags=$(get "$info" "Flags"); case "$flags" in *readonly*) flags=ro ;; *) flags=rw ;; esac
     parent=$(parent_of "$map" "$(get "$info" "Parent UUID")")
     case "$1" in
-        *.old_*) kind=old ;;
+        # _old_<ts> leftovers from create-profile; anchored on the stamp so a user-chosen
+        # name that merely contains "_old_" stays a profile ('.old_' is the legacy spelling)
+        *_old_[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_*|*.old_*) kind=old ;;
         *)       kind=profile ;;
     esac
     mark=""; [ -n "$cur_id" ] && [ "$id" = "$cur_id" ] && mark="<- booted"
@@ -60,7 +62,7 @@ emit() {  # $1=display name  $2=fs path
 }
 
 printf 'NAME\t\tKIND\tID\tCREATED\tRO\tPARENT\n' > "$rows"
-# top-level profile roots + @.old_* leftovers; skip shared/reserved subvols (@snapshots,
+# top-level profile roots + @_old_* leftovers; skip shared/reserved subvols (@snapshots,
 # @stock-snapshots, ...) so stocks (now nested under @stock-snapshots) are not listed here
 for d in "$TOP"/@*; do
     [ -e "$d" ] || continue

--- a/overlays/usr/local/sbin/list-snapshots
+++ b/overlays/usr/local/sbin/list-snapshots
@@ -24,7 +24,8 @@ while [ $# -gt 0 ]; do
         -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
-        *)           echo "Error: unexpected argument: $1" >&2; usage >&2; exit 1 ;;
+        -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)           echo "Error: unexpected argument: $1 (this tool takes no arguments)" >&2; usage >&2; exit 1 ;;
     esac
     shift
 done

--- a/overlays/usr/local/sbin/list-snapshots
+++ b/overlays/usr/local/sbin/list-snapshots
@@ -13,7 +13,7 @@ set -eu
 usage() {
     cat <<EOF
 Usage: list-snapshots [-d|--device DEV]
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   List restore-point snapshots under @snapshots and _stock golden bases under
   @stock-snapshots. For bootable profiles, see list-profiles.
 EOF

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -228,6 +228,7 @@ function is_noise(p) {
     if (p ~ /^var\/(cache|tmp|log)(\/|$)/) return 1
     if (p ~ /(^|\/)\.cache(\/|$)/) return 1
     if (p ~ /^usr\/local(\/|$)/) return 0
+    if (p ~ /^usr\/share\/keyrings(\/|$)/) return 0
     if (p ~ /^usr(\/|$)/) return 1
     if (p ~ /^var\/lib\/(dpkg|apt|ucf)(\/|$)/) return 1
     if (p=="var/.updated") return 1
@@ -478,6 +479,17 @@ btrfs subvolume snapshot -r "$TOP/$dst" "$TOP/$snap" >/dev/null \
 
 : > "$WORK/merged"; : > "$WORK/conflicts"
 
+# 0) apt's own configuration has to land before the replay below, or a package the user installed
+#    from a repository they added is not findable while dst still has the old sources, and gets
+#    reported as "install by hand" although its source is right here in src. Keyrings included,
+#    since a source without its key is no better. Step 2 re-merges these as a no-op.
+grep -E '^(etc/apt/|usr/share/keyrings/)' "$WORK/changed" > "$WORK/changed.apt" || :
+grep -vE '^(etc/apt/|usr/share/keyrings/)' "$WORK/changed" > "$WORK/changed.rest" || :
+if [ -s "$WORK/changed.apt" ]; then
+    echo "merging apt configuration first ($(cnt "$WORK/changed.apt") file(s))..."
+    while IFS= read -r f; do [ -n "$f" ] && merge_one "$f"; done < "$WORK/changed.apt"
+fi
+
 # 1) replay package intent FIRST (lays down package files + default conffiles), so the user's
 #    config edits in step 2 merge on top of them. Needs a working apt source / network.
 if [ -n "$added_pkgs" ] || { [ "$purge_removed" = 1 ] && [ -n "$removed_pkgs" ]; }; then
@@ -506,15 +518,15 @@ if [ -n "$added_pkgs" ] || { [ "$purge_removed" = 1 ] && [ -n "$removed_pkgs" ];
     for _m in dev/pts dev sys proc; do umount "$TOP/$dst/$_m" 2>/dev/null || true; done
 fi
 
-# 2) 3-way merge the user's changed files onto dst
-_total=$(wc -l < "$WORK/changed" 2>/dev/null | tr -d ' '); [ -n "$_total" ] || _total=0
+# 2) 3-way merge the rest of the user's changed files onto dst
+_total=$(cnt "$WORK/changed.rest")
 echo "merging your files onto $dst ($_total, via $merger)..."
 _n=0
 while IFS= read -r f; do
     [ -n "$f" ] || continue
     _n=$((_n+1)); printf '\r  merging %d/%d' "$_n" "$_total" >&2
     merge_one "$f"
-done < "$WORK/changed"
+done < "$WORK/changed.rest"
 [ "$_n" -gt 0 ] && printf '\r  merged %d/%d files \n' "$_n" "$_total" >&2
 
 # 3) apply the user's deletions, deepest-first (files before their dir) so empty dirs can rmdir

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -178,7 +178,7 @@ esac
 is_reserved_subvol "$src" && die "src is a reserved subvolume"
 is_reserved_subvol "$dst" && die "dst is a reserved subvolume"
 
-booted=$(current_subvol)
+booted=""; top_is_booted_fs && booted=$(current_subvol)
 if [ "$apply" = 1 ] && [ "$dst" = "$booted" ] && [ "$force" != 1 ]; then
     die "won't modify '$dst': it is the profile you are booted into.
 Boot into another profile and run this again, or pass --force to override."

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -510,7 +510,7 @@ fi
 # ================= APPLY =================
 confirm "Apply the above to '$dst'? A '$dst' snapshot is taken first."
 
-ts=$(date +%Y-%m-%d_%H-%M-%S)
+ts=$(stamp)
 snap="@snapshots/@${dst#@}_${ts}_before_migrate"
 if btrfs subvolume snapshot -r "$TOP/$dst" "$TOP/$snap" >/dev/null; then
     echo "snapshot: $snap"

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -85,7 +85,7 @@ ask_tty() {
 # --- interactive resolution of leftover sidecars ---------------------------------------------
 resolve_mode() {
     _p=$1
-    case "$_p" in current|booted|"") root_is_btrfs || die "no booted profile to default to; name the profile explicitly"; _p=$(findmnt -no FSROOT / | sed 's,^/,,') ;; esac
+    case "$_p" in current|booted|"") root_is_btrfs || die "no booted profile to default to; name the profile explicitly"; _p=$(current_subvol) ;; esac
     case "$_p" in *..*|/*|*/*) die "Invalid profile: $_p" ;; esac
     [ -d "$TOP/$_p" ] || die "No such profile: $_p"
     _root="$TOP/$_p"; _dstname=$_p; _srcname=${2:-}
@@ -170,7 +170,7 @@ esac
 
 [ -d "$TOP/$src" ] || die "No such profile: $src"
 case "$dst" in
-    current|booted|"") root_is_btrfs || die "no booted profile to default <@dst> to; pass an explicit <@dst>"; dst=$(findmnt -no FSROOT / | sed 's,^/,,'); [ -n "$dst" ] || die "cannot determine booted profile" ;;
+    current|booted|"") root_is_btrfs || die "no booted profile to default <@dst> to; pass an explicit <@dst>"; dst=$(current_subvol); [ -n "$dst" ] || die "cannot determine booted profile" ;;
     *)                 case "$dst" in *..*|/*|*/*) die "Invalid dst: $dst (top-level name)" ;; esac ;;
 esac
 [ -d "$TOP/$dst" ] || die "No such profile: $dst"
@@ -178,7 +178,7 @@ esac
 is_reserved_subvol "$src" && die "src is a reserved subvolume"
 is_reserved_subvol "$dst" && die "dst is a reserved subvolume"
 
-booted=$(findmnt -no FSROOT / | sed 's,^/,,')
+booted=$(current_subvol)
 if [ "$apply" = 1 ] && [ "$dst" = "$booted" ] && [ "$force" != 1 ]; then
     die "won't modify '$dst': it is the profile you are booted into.
 Boot into another profile and run this again, or pass --force to override."

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -512,8 +512,11 @@ confirm "Apply the above to '$dst'? A '$dst' snapshot is taken first."
 
 ts=$(date +%Y-%m-%d_%H-%M-%S)
 snap="@snapshots/@${dst#@}_${ts}_before_migrate"
-btrfs subvolume snapshot -r "$TOP/$dst" "$TOP/$snap" >/dev/null \
-    && echo "snapshot: $snap" || die "could not snapshot $dst; aborting before any change"
+if btrfs subvolume snapshot -r "$TOP/$dst" "$TOP/$snap" >/dev/null; then
+    echo "snapshot: $snap"
+else
+    die "could not snapshot $dst; aborting before any change"
+fi
 
 : > "$WORK/merged"; : > "$WORK/conflicts"
 

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -68,6 +68,7 @@ need_root
 need_btrfs
 
 WORK=$(mktemp -d)
+ACCOUNTDB_AWK=/usr/lib/flipper-accountdb.awk
 SRCSNAP=""
 mig_cleanup() {
     [ -n "$SRCSNAP" ] && btrfs subvolume delete "$SRCSNAP" >/dev/null 2>&1 || true
@@ -308,69 +309,6 @@ mergiraf_lang() {
 
 
 
-# Account databases (passwd/shadow/group/gshadow + backups) are keyed by the first field, not by
-# line order, so a text merge conflicts on every epoch bump and could duplicate entries. Merge them
-# per entry instead: an account the user did not touch follows the new base (apt replay is the
-# authority for service accounts), an account the user added or changed rides along from src, and
-# group/gshadow memberships are set-merged. Deterministic, never conflicts.
-cat > "$WORK/accountdb.awk" <<'AWK'
-BEGIN { FS=":"; nlf=split(LF,_l,","); for(i=1;i<=nlf;i++) islist[_l[i]+0]=1; fidx=0 }
-FNR==1 { fidx++ }
-{
-    if ($0=="") next
-    k=$1
-    if      (fidx==1) { Bl[k]=$0; hB[k]=1 }
-    else if (fidx==2) { Ol[k]=$0; hO[k]=1; if(!(k in os)){ os[k]=1; oord[++no]=k } }
-    else              { Tl[k]=$0; hT[k]=1; if(!(k in ts)){ ts[k]=1; tord[++nt]=k } }
-}
-END {
-    for (i=1;i<=no;i++) put(oord[i])
-    for (i=1;i<=nt;i++) if (!(tord[i] in os)) put(tord[i])
-}
-function put(k,   line) { line=decide(k); if (line!="") print line }
-function decide(k,   ib,io,it) {
-    ib=(k in hB); io=(k in hO); it=(k in hT)
-    if (!io && !it) return ""
-    if ( io && !it) { if (ib && Ol[k]==Bl[k]) return ""; return Ol[k] }
-    if (!io &&  it) { if (ib && Tl[k]==Bl[k]) return ""; return Tl[k] }
-    if (LF!="") return mergerec(k, ib)
-    if (Ol[k]==Tl[k]) return Ol[k]
-    if (!ib)          return Ol[k]
-    if (Tl[k]==Bl[k]) return Ol[k]
-    if (Ol[k]==Bl[k]) return Tl[k]
-    return Tl[k]
-}
-function mergerec(k, ib,   nb,no2,nt2,fb,fo,ft,fi,res) {
-    nb  = ib ? split(Bl[k], fb, ":") : 0
-    no2 =      split(Ol[k], fo, ":")
-    nt2 =      split(Tl[k], ft, ":")
-    for (fi=1; fi<=no2; fi++)
-        rf[fi] = (fi in islist) ? merge_members(fi, ib, fb, fo, ft, nb, no2, nt2) : fo[fi]
-    res=rf[1]; for(fi=2;fi<=no2;fi++) res=res ":" rf[fi]
-    delete rf
-    return res
-}
-function merge_members(fi, ib, fb, fo, ft, nb, no2, nt2,   i,m,res) {
-    delete inB; delete inO; delete inT; delete ordm; delete ordseen; nord=0
-    if (ib && nb >=fi) mark(fb[fi], inB)
-    if (      no2>=fi) mark(fo[fi], inO)
-    if (      nt2>=fi) mark(ft[fi], inT)
-    if (      no2>=fi) order(fo[fi])
-    if (      nt2>=fi) order(ft[fi])
-    if (ib && nb >=fi) order(fb[fi])
-    res=""
-    for (i=1;i<=nord;i++) {
-        m=ordm[i]
-        if ((m in inB) && !(m in inO)) continue
-        if ((m in inB) && !(m in inT)) continue
-        res = (res=="") ? m : res "," m
-    }
-    return res
-}
-function mark(s, arr,   n,a,i) { n=split(s,a,","); for(i=1;i<=n;i++) if(a[i]!="") arr[a[i]]=1 }
-function order(s,   n,a,i)     { n=split(s,a,","); for(i=1;i<=n;i++) if(a[i]!="" && !(a[i] in ordseen)){ ordseen[a[i]]=1; ordm[++nord]=a[i] } }
-AWK
-
 merge_accountdb() {  # $1 = etc/<db>: per-entry 3-way merge into dst (deterministic, no sidecar)
     _f=$1; _S="$TOP/$src/$_f"; _O="$TOP/$dst/$_f"; _B="$TOP/$base_rel/$_f"
     _mb="$EMPTY"; [ -f "$_B" ] && _mb="$_B"
@@ -390,7 +328,9 @@ merge_accountdb() {  # $1 = etc/<db>: per-entry 3-way merge into dst (determinis
     # These files decide whether the profile can be logged into, so the merged result has to
     # look like an account database before it replaces one: every db here has a root entry, and
     # a duplicate key is the corruption a text merge would have produced.
-    if ! awk -v LF="$_lf" -f "$WORK/accountdb.awk" "$_mb" "$_O" "$_S" > "$WORK/adb" 2>/dev/null; then
+    if [ ! -r "$ACCOUNTDB_AWK" ]; then
+        _why="$ACCOUNTDB_AWK not installed"
+    elif ! awk -v LF="$_lf" -f "$ACCOUNTDB_AWK" "$_mb" "$_O" "$_S" > "$WORK/adb" 2>/dev/null; then
         _why="merge failed"
     elif [ ! -s "$WORK/adb" ]; then
         _why="empty result"

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -17,8 +17,9 @@
 # text: user-added or user-changed accounts and group memberships are carried while service
 # accounts follow the new base. Everything the user changed is migrated EXCEPT a denylist of noise: package
 # files (replayed via apt instead), caches, regenerated runtime state, and generated/per-device
-# identity files (machine-id, ld.so.cache, and the like). SSH host keys ARE carried, so the
-# migrated profile keeps the device's ssh identity (no host-key-changed warnings).
+# identity files (machine-id, ld.so.cache, and the like). SSH host keys are carried explicitly,
+# by policy rather than by delta, so the migrated profile keeps the device's ssh identity even
+# though the build bakes the same keys into every image (no host-key-changed warnings).
 #
 # Default is a DRY RUN. -a/--apply performs it (snapshots <@dst> to @snapshots/<dst>_<ts>_before_
 # migrate first) and then, if any conflicts remain, drops straight into interactive resolution
@@ -476,6 +477,21 @@ while IFS= read -r f; do
     else echo "$f" >> "$WORK/overlap"; fi
 done < "$WORK/changed"
 
+# The ssh host keys ARE the device's identity, so they follow the device rather than the base.
+# They cannot ride along with the file merge: the keys are baked into the image, so src's copy
+# equals the ancestor's, the delta never mentions them, and dst would keep the keys of whatever
+# build it came from. Every migration would then change the device's ssh identity and greet the
+# user with a host-key warning. Carry them by policy, not by delta. Prints the src files dst does
+# not already have, so the preview and the apply always agree on the count.
+ssh_identity_files() {
+    [ -d "$TOP/$src/etc/ssh" ] || return 0
+    for _k in "$TOP/$src"/etc/ssh/ssh_host_*; do
+        [ -f "$_k" ] || continue
+        cmp -s "$_k" "$TOP/$dst/etc/ssh/${_k##*/}" && continue
+        printf '%s\n' "$_k"
+    done
+}
+
 # --- report ---
 cnt() { _c=$(wc -l < "$1" 2>/dev/null | tr -d ' '); printf '%s' "${_c:-0}"; }
 _na=$(printf '%s' "$added_pkgs" | wc -w | tr -d ' ')
@@ -486,6 +502,8 @@ echo
 echo "== migration preview: $src -> $dst =="
 printf '  packages:  +%s added   -%s removed\n' "$_na" "$_nr"
 printf '  files:     %s carried   %s changed by both sides   %s deleted   %s skipped as noise\n' "$_nc" "$_no" "$_nd" "$_noise"
+_nid=$(ssh_identity_files | wc -l | tr -d ' ')
+[ "${_nid:-0}" -gt 0 ] && printf '  identity:  %s ssh host key file(s), carried so %s keeps this device identity\n' "$_nid" "$dst"
 echo
 echo "  Carried, deleted and account databases apply automatically. The $_no changed-by-both"
 echo "  file(s) are 3-way merged on apply; only those that cannot merge cleanly will ask you to"
@@ -597,7 +615,16 @@ if [ -s "$WORK/deleted" ]; then
     while IFS= read -r f; do [ -n "$f" ] && delete_one "$f"; done < "$WORK/deleted.rev"
 fi
 
-# 4) merge_accountdb handles each database on its own, so nothing above guarantees they still
+# 4) Carry the ssh host keys, listed by ssh_identity_files above.
+_idn=0; _idfail=0
+for _k in $(ssh_identity_files); do
+    if rsync -aHAX "$_k" "$TOP/$dst/etc/ssh/${_k##*/}"; then _idn=$((_idn+1))
+    else _idfail=$((_idfail+1)); echo "Warning: could not carry ${_k##*/}" >&2; fi
+done
+[ "$_idn" -gt 0 ] && echo "carried $_idn ssh host key file(s), so '$dst' keeps this device's identity"
+[ "$_idfail" -gt 0 ] && echo "WARNING: $_idfail ssh host key file(s) could not be carried; '$dst' will present a different ssh identity and clients will report a changed host key" >&2
+
+# 5) merge_accountdb handles each database on its own, so nothing above guarantees they still
 # agree with each other: a passwd entry with no shadow entry is an account that cannot
 # authenticate, and group drifting from gshadow is what grpck exists to complain about.
 if grep -qE '^etc/(passwd|shadow|group|gshadow)-?$' "$WORK/changed" 2>/dev/null; then

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -280,6 +280,39 @@ manual_set() {  # $1 = subvol rel -> sorted list of manually-installed packages
     else : > "$WORK/auto"; fi
     comm -23 "$WORK/inst" "$WORK/auto"
 }
+
+# The version src has installed, so a recovered .deb can be matched against it. $1 = package.
+installed_ver() {
+    awk -v p="$1" 'BEGIN{RS="";FS="\n"} { n=""; v="";
+        for(i=1;i<=NF;i++){ if($i ~ /^Package: /) n=substr($i,10); else if($i ~ /^Version: /) v=substr($i,10) }
+        if(n==p){ print v; exit } }' "$TOP/$src/var/lib/dpkg/status" 2>/dev/null
+}
+
+# A package in no repository (a hand-installed .deb) can often still be found as a file: apt-get
+# leftovers in src's cache, or wherever the user downloaded it. @home and @root are shared
+# subvolumes, so a .deb sitting there is already reachable from dst. Collected in one traversal
+# with no depth limit, since a .deb below an arbitrary cutoff would be reported as missing.
+collect_debs() {
+    : > "$WORK/debs"
+    for _dir in "$TOP/$src/var/cache/apt/archives" "$TOP/@root" "$TOP/@home"; do
+        [ -d "$_dir" ] && find "$_dir" -type f -name '*.deb' >> "$WORK/debs" 2>/dev/null
+    done
+    return 0
+}
+
+# Print a .deb whose control says it really is this package, preferring the version src had.
+# $1 = package, $2 = wanted version, $3 = dpkg architecture.
+find_deb() {
+    _fallback=""
+    while IFS= read -r _cand; do
+        [ "$(dpkg-deb -f "$_cand" Package 2>/dev/null)" = "$1" ] || continue
+        case "$(dpkg-deb -f "$_cand" Architecture 2>/dev/null)" in "$3"|all) ;; *) continue ;; esac
+        [ "$(dpkg-deb -f "$_cand" Version 2>/dev/null)" = "$2" ] && { printf '%s' "$_cand"; return 0; }
+        [ -n "$_fallback" ] || _fallback=$_cand
+    done < "$WORK/debs"
+    [ -n "$_fallback" ] || return 1
+    printf '%s' "$_fallback"
+}
 manual_set "$base_rel" > "$WORK/pkg.base"
 manual_set "$src"  > "$WORK/pkg.src"
 added_pkgs=$(comm -13 "$WORK/pkg.base" "$WORK/pkg.src" | tr '\n' ' ')
@@ -514,7 +547,27 @@ if [ -n "$added_pkgs" ] || { [ "$purge_removed" = 1 ] && [ -n "$removed_pkgs" ];
             if chroot "$TOP/$dst" apt-get install -y --dry-run "$_p" >/dev/null 2>&1; then _ok="$_ok $_p"; else _miss="$_miss $_p"; fi
         done
         [ -n "$_ok" ] && { echo "  installing:$_ok"; chroot "$TOP/$dst" apt-get install -y $_ok || echo "WARN: apt install failed; packages not installed:$_ok" >&2; }
-        [ -n "$_miss" ] && echo "NOTE: could not reinstall (not in a repo; install by hand):$_miss" >&2
+        if [ -n "$_miss" ]; then
+            # nothing in a repo provides these, so look for the .deb itself before giving up
+            echo "  looking for a local .deb for:$_miss"
+            collect_debs
+            _debarch=$(dpkg --print-architecture 2>/dev/null || echo all)
+            _recovered=""; _stillmiss=""
+            for _p in $_miss; do
+                _debfile=$(find_deb "$_p" "$(installed_ver "$_p")" "$_debarch") || _debfile=""
+                if [ -z "$_debfile" ]; then _stillmiss="$_stillmiss $_p"; continue; fi
+                mkdir -p "$TOP/$dst/var/cache/apt/archives"
+                cp -f "$_debfile" "$TOP/$dst/var/cache/apt/archives/" 2>/dev/null || true
+                if chroot "$TOP/$dst" apt-get install -y "/var/cache/apt/archives/${_debfile##*/}" >/dev/null 2>&1; then
+                    _recovered="$_recovered $_p($(dpkg-deb -f "$_debfile" Version 2>/dev/null))"
+                else
+                    _stillmiss="$_stillmiss $_p"
+                    echo "WARN: found ${_debfile#"$TOP"/} for $_p but installing it failed (dependencies?)" >&2
+                fi
+            done
+            [ -n "$_recovered" ] && echo "  installed from a local .deb:$_recovered"
+            [ -n "$_stillmiss" ] && echo "NOTE: could not reinstall (not in a repo, no .deb found; install by hand):$_stillmiss" >&2
+        fi
     fi
     [ "$purge_removed" = 1 ] && [ -n "$removed_pkgs" ] && { echo "  purging removed:$removed_pkgs"; chroot "$TOP/$dst" apt-get purge -y $removed_pkgs || true; }
     rm -f "$_rc"; [ -n "$_rcbak" ] && mv "$_rcbak" "$_rc"   # restore dst's original resolv.conf

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -7,8 +7,8 @@
 # and data.
 #
 # <@src>'s factory base (the _stock it was built from) is read from /etc/profile_origin
-# (origin_stock_name); if that stock is present and its build (os-release BUILD_GIT) matches
-# <@src>'s, it is the merge ancestor. The delta ancestor -> src is computed with `btrfs send
+# (origin_stock_name), whose name carries the build id, so it names the exact base. If that stock
+# is present it is the merge ancestor. The delta ancestor -> src is computed with `btrfs send
 # --no-data` (adds/mods/deletes/renames). Packages are replayed by intent (apt); files are 3-way
 # merged (base=ancestor, ours=dst, theirs=src; syntax-aware via mergiraf when installed, else git
 # merge-file): non-overlapping changes auto-merge into dst, a real
@@ -183,30 +183,23 @@ if [ "$apply" = 1 ] && [ "$dst" = "$booted" ] && [ "$force" != 1 ]; then
 Boot into another profile and run this again, or pass --force to override."
 fi
 
-# --- resolve the merge ancestor: src's factory base, present and same build ---
-build_of() { sed -n 's/^BUILD_GIT=//p' "$TOP/$1/etc/os-release" 2>/dev/null | tr -d '"'; }
-
+# --- resolve the merge ancestor: the _stock src was built from, by name ---
+# The stock name carries the build id, so the name alone pins the exact base. btrfs send -p
+# below refuses a parent that is not a real ancestor, so there is nothing further to verify.
 marker="$TOP/$src/etc/profile_origin"
 [ -f "$marker" ] || die "$src has no /etc/profile_origin marker; cannot determine its base"
 base=$(sed -n 's/^origin_stock_name=//p' "$marker")
 [ -n "$base" ] || die "$src marker has no origin_stock_name"
-src_build=$(build_of "$src")
 
 # the marker records the stock by bare name; it now lives under @stock-snapshots (resolve_rel)
 base_rel=$(resolve_rel "$base")
 [ -n "$base_rel" ] || die "You must have the '$base' _stock image on disk to migrate $src.
 migrate compares $src against the _stock it was built from to work out what you changed, but
-'$base' (build ${src_build:-unknown}) is not on this device. Receive that _stock and retry:
+'$base' is not on this device. Receive that _stock and retry:
   receive-snapshot <path-to-${base#@}_pack.zst>"
-base_build=$(build_of "$base_rel")
-[ "$base_build" = "$src_build" ] || die "You must have the exact '$base' _stock $src was built from on disk.
-The '$base' on disk is a different build than $src:
-  on disk:    build ${base_build:-?}
-  $src needs: build ${src_build:-?}
-Receive the matching _stock and retry:  receive-snapshot <path-to-${base#@}_pack.zst>"
 
 echo "migrate: $src -> $dst"
-echo "  ancestor: $base (build ${src_build:-unknown})"
+echo "  ancestor: $base"
 echo "  merge engine: $merger"
 [ "$apply" = 1 ] && echo "  mode: APPLY" || echo "  mode: dry run"
 
@@ -313,6 +306,8 @@ mergiraf_lang() {
     esac
 }
 
+
+
 # Account databases (passwd/shadow/group/gshadow + backups) are keyed by the first field, not by
 # line order, so a text merge conflicts on every epoch bump and could duplicate entries. Merge them
 # per entry instead: an account the user did not touch follows the new base (apt replay is the
@@ -379,17 +374,53 @@ AWK
 merge_accountdb() {  # $1 = etc/<db>: per-entry 3-way merge into dst (deterministic, no sidecar)
     _f=$1; _S="$TOP/$src/$_f"; _O="$TOP/$dst/$_f"; _B="$TOP/$base_rel/$_f"
     _mb="$EMPTY"; [ -f "$_B" ] && _mb="$_B"
+    # _lf: fields holding comma-separated member lists, set-merged instead of taken whole.
+    # _nf: how many colon-separated fields a record has, so a truncated result is rejected below.
     case "${_f##*/}" in
-        group|group-)     _lf=4 ;;
-        gshadow|gshadow-) _lf=3,4 ;;
-        *)                _lf="" ;;
+        group|group-)     _lf=4;   _nf=4 ;;
+        gshadow|gshadow-) _lf=3,4; _nf=4 ;;
+        shadow|shadow-)   _lf="";  _nf=9 ;;
+        *)                _lf="";  _nf=7 ;;
     esac
-    if [ -f "$_O" ] && awk -v LF="$_lf" -f "$WORK/accountdb.awk" "$_mb" "$_O" "$_S" > "$WORK/adb" 2>/dev/null; then
-        cat "$WORK/adb" > "$_O"; sync_meta "$_S" "$_O" "$_B"
-    else
+    if [ ! -f "$_O" ]; then
         rsync -aHAX "$_S" "$_O"          # dst lacks the db -> take the user's copy verbatim
+        echo x >> "$WORK/merged"
+        return 0
     fi
+    # These files decide whether the profile can be logged into, so the merged result has to
+    # look like an account database before it replaces one: every db here has a root entry, and
+    # a duplicate key is the corruption a text merge would have produced.
+    if ! awk -v LF="$_lf" -f "$WORK/accountdb.awk" "$_mb" "$_O" "$_S" > "$WORK/adb" 2>/dev/null; then
+        _why="merge failed"
+    elif [ ! -s "$WORK/adb" ]; then
+        _why="empty result"
+    elif ! grep -q '^root:' "$WORK/adb"; then
+        _why="no root entry"
+    elif ! awk -F: -v n="$_nf" 'NF != n { exit 1 }' "$WORK/adb"; then
+        _why="malformed record"
+    elif [ -n "$(cut -d: -f1 "$WORK/adb" | sort | uniq -d | head -n1)" ]; then
+        _why="duplicate entries"
+    else
+        _why=""
+    fi
+    if [ -n "$_why" ]; then
+        rsync -aHAX "$_S" "$_O.migrate-theirs"
+        printf '%s (account merge rejected: %s; %s kept)\n' "$_f" "$_why" "$dst" >> "$WORK/conflicts"
+        return 0
+    fi
+    cat "$WORK/adb" > "$_O"; sync_meta "$_S" "$_O" "$_B"
     echo x >> "$WORK/merged"
+}
+
+# Report accounts present in a database but missing from its shadow companion, either way round.
+# Names only: the entries themselves are merged per file above, this checks the sets line up.
+check_db_pair() {  # $1 = passwd/group, $2 = its shadow/gshadow companion
+    [ -f "$TOP/$dst/$1" ] && [ -f "$TOP/$dst/$2" ] || return 0
+    cut -d: -f1 "$TOP/$dst/$1" | sort -u > "$WORK/k1"
+    cut -d: -f1 "$TOP/$dst/$2" | sort -u > "$WORK/k2"
+    _d=$(comm -3 "$WORK/k1" "$WORK/k2" | tr -d '\t' | tr '\n' ' ')
+    [ -n "$_d" ] && printf '%s and %s disagree on: %s\n' "$1" "$2" "$_d" >> "$WORK/conflicts"
+    return 0
 }
 
 # Merge one changed file onto dst. Clean auto-merges are written to dst; a conflict leaves dst's
@@ -414,11 +445,11 @@ merge_one() {
         if [ "$merger" = mergiraf ]; then
             _lang=$(mergiraf_lang "$_f" "$_S")
             mergiraf merge "$_mb" "$_O" "$_S" -o "$WORK/m" -p "$_f" --allow-parse-errors ${_lang:+-L "$_lang"} \
-                -s "factory base (${src_build:-unknown})" -x "new base ($dst)" -y "your changes ($src)" 2>/dev/null
+                -s "factory base ($base)" -x "new base ($dst)" -y "your changes ($src)" 2>/dev/null
             _rc=$?
         else
             git merge-file -p --diff3 \
-                -L "new base ($dst)" -L "factory base (${src_build:-unknown})" -L "your changes ($src)" \
+                -L "new base ($dst)" -L "factory base ($base)" -L "your changes ($src)" \
                 "$_O" "$_mb" "$_S" > "$WORK/m" 2>/dev/null
             _rc=$?
         fi
@@ -551,6 +582,15 @@ if [ -s "$WORK/deleted" ]; then
     echo "applying your deletions..."
     sort -r "$WORK/deleted" > "$WORK/deleted.rev"
     while IFS= read -r f; do [ -n "$f" ] && delete_one "$f"; done < "$WORK/deleted.rev"
+fi
+
+# 4) merge_accountdb handles each database on its own, so nothing above guarantees they still
+# agree with each other: a passwd entry with no shadow entry is an account that cannot
+# authenticate, and group drifting from gshadow is what grpck exists to complain about.
+if grep -qE '^etc/(passwd|shadow|group|gshadow)-?$' "$WORK/changed" 2>/dev/null; then
+    echo "checking the account databases agree..."
+    check_db_pair etc/passwd etc/shadow
+    check_db_pair etc/group etc/gshadow
 fi
 
 _nmerged=$(cnt "$WORK/merged"); _nconf=$(cnt "$WORK/conflicts")

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -397,7 +397,7 @@ check_db_pair() {  # $1 = passwd/group, $2 = its shadow/gshadow companion
     cut -d: -f1 "$TOP/$dst/$1" | sort -u > "$WORK/k1"
     cut -d: -f1 "$TOP/$dst/$2" | sort -u > "$WORK/k2"
     _d=$(comm -3 "$WORK/k1" "$WORK/k2" | tr -d '\t' | tr '\n' ' ')
-    [ -n "$_d" ] && printf '%s and %s disagree on: %s\n' "$1" "$2" "$_d" >> "$WORK/conflicts"
+    [ -n "$_d" ] && printf '%s and %s disagree on: %s\n' "$1" "$2" "$_d" >> "$WORK/notices"
     return 0
 }
 
@@ -454,11 +454,11 @@ delete_one() {
     _f=$1; _O="$TOP/$dst/$_f"; _B="$TOP/$base_rel/$_f"
     { [ -e "$_O" ] || [ -L "$_O" ]; } || return 0
     if [ -d "$_O" ] && [ ! -L "$_O" ]; then
-        rmdir "$_O" 2>/dev/null || printf '%s/ (you deleted this dir; new base still has files in it -> kept)\n' "$_f" >> "$WORK/conflicts"
+        rmdir "$_O" 2>/dev/null || printf '%s/ (you deleted this dir; new base still has files in it -> kept)\n' "$_f" >> "$WORK/notices"
         return 0
     fi
     if [ -f "$_O" ] && [ ! -L "$_O" ] && [ -f "$_B" ] && ! cmp -s "$_O" "$_B"; then
-        printf '%s (you deleted it; new base changed it -> kept new version)\n' "$_f" >> "$WORK/conflicts"
+        printf '%s (you deleted it; new base changed it -> kept new version)\n' "$_f" >> "$WORK/notices"
         return 0
     fi
     rm -f "$_O"
@@ -536,7 +536,7 @@ else
     die "could not snapshot $dst; aborting before any change"
 fi
 
-: > "$WORK/merged"; : > "$WORK/conflicts"
+: > "$WORK/merged"; : > "$WORK/conflicts"; : > "$WORK/notices"
 
 # 0) apt's own configuration has to land before the replay below, or a package the user installed
 #    from a repository they added is not findable while dst still has the old sources, and gets
@@ -633,7 +633,7 @@ if grep -qE '^etc/(passwd|shadow|group|gshadow)-?$' "$WORK/changed" 2>/dev/null;
     check_db_pair etc/group etc/gshadow
 fi
 
-_nmerged=$(cnt "$WORK/merged"); _nconf=$(cnt "$WORK/conflicts")
+_nmerged=$(cnt "$WORK/merged"); _nconf=$(cnt "$WORK/conflicts"); _nnote=$(cnt "$WORK/notices")
 echo
 echo "== migration summary: $src -> $dst =="
 printf '  packages:  +%s added   -%s removed\n' "$_na" "$_nr"
@@ -643,7 +643,11 @@ if [ "$_nconf" -gt 0 ]; then
 else
     echo "  everything merged cleanly; nothing to decide"
 fi
+# Settled by policy, so --resolve has nothing to offer for these: counted apart from the
+# decisions, or the summary would promise sidecars that do not exist.
+[ "$_nnote" -gt 0 ] && printf '  %s file(s) settled for you (no sidecar, nothing to resolve)\n' "$_nnote"
 [ "$verbose" = 1 ] && [ -s "$WORK/conflicts" ] && { echo; echo "-- files needing a decision --"; sed 's,^,  ,' "$WORK/conflicts"; }
+[ "$verbose" = 1 ] && [ -s "$WORK/notices" ]   && { echo; echo "-- settled for you --";        sed 's,^,  ,' "$WORK/notices"; }
 
 if [ -s "$WORK/conflicts" ]; then
     if [ "$no_resolve" = 1 ] || [ "$ASSUME_YES" = 1 ]; then

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -468,7 +468,9 @@ delete_one() {
 while IFS= read -r f; do
     [ -n "$f" ] || continue
     _O="$TOP/$dst/$f"; _B="$TOP/$base_rel/$f"; _S="$TOP/$src/$f"
-    if [ -d "$_S" ] && [ ! -L "$_S" ]; then echo "$f" >> "$WORK/clean"; continue; fi   # dir: created + metadata
+    # merge_one takes anything that is not a regular file wholesale (dirs are created, symlinks
+    # and specials are rsynced), so it is never a both-sides merge, whatever the base looks like
+    if [ ! -f "$_S" ] || [ -L "$_S" ]; then echo "$f" >> "$WORK/clean"; continue; fi
     if [ ! -e "$_O" ] || { [ -f "$_B" ] && cmp -s "$_B" "$_O"; }; then echo "$f" >> "$WORK/clean"
     elif [ -f "$_S" ] && cmp -s "$_S" "$_O"; then :
     else echo "$f" >> "$WORK/overlap"; fi

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -223,6 +223,9 @@ awk -v snap="$snapname" '
 function strip(p,  s){ s="./" snap "/"; if (index(p,s)==1) return substr(p, length(s)+1); return "" }
 # Denylist: migrate everything the user changed EXCEPT known-useless paths. 1 = noise, 0 = migrate.
 function is_noise(p) {
+    # our own leftovers: an unresolved sidecar would otherwise count as a user change and be
+    # carried into the next migration, and .migrate-bak is the resolv.conf we move aside for apt
+    if (p ~ /\.migrate-(conflict|theirs|bak)$/) return 1
     if (p ~ /^(proc|sys|dev|run|tmp|mnt|media|home|boot)(\/|$)/) return 1
     if (p ~ /^flipperone-testing(\/|$)/) return 1
     if (p ~ /^var\/(cache|tmp|log)(\/|$)/) return 1

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -68,13 +68,13 @@ done
 need_root
 need_btrfs
 
-WORK=$(mktemp -d)
 ACCOUNTDB_AWK=/usr/lib/flipper-accountdb.awk
 SRCSNAP=""
 mig_cleanup() {
     [ -n "$SRCSNAP" ] && btrfs subvolume delete "$SRCSNAP" >/dev/null 2>&1 || true
     top_cleanup
-    rm -rf "$WORK"
+    [ -n "${WORK:-}" ] && rm -rf "$WORK"
+    return 0
 }
 
 ask_tty() {
@@ -154,6 +154,10 @@ resolve_mode() {
 
 mount_top
 trap mig_cleanup EXIT
+# Created only once mig_cleanup owns the EXIT trap. mount_top installs its own trap and would
+# clobber ours, so anything made before this line is leaked when mount_top itself dies, which is
+# what a recovery boot does on every invocation that forgets -d.
+WORK=$(mktemp -d)
 
 if [ "$resolve" = 1 ]; then resolve_mode "$1"; exit 0; fi
 

--- a/overlays/usr/local/sbin/receive-snapshot
+++ b/overlays/usr/local/sbin/receive-snapshot
@@ -15,7 +15,7 @@ set -eu
 usage() {
     cat <<EOF
 Usage: receive-snapshot [-d|--device DEV] <file|->
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   Receive a send-snapshot stream (a _stock base -> @stock-snapshots, else @snapshots). Put it onto a root
   with create-profile. Incremental streams need their parent to exist here first.
 EOF

--- a/overlays/usr/local/sbin/rename-profile
+++ b/overlays/usr/local/sbin/rename-profile
@@ -43,7 +43,7 @@ is_reserved_subvol "$new" && die "Refusing to use reserved name: $new"
 
 set_lock
 mount_top
-cur_id=$(booted_id)
+cur_id=""; top_is_booted_fs && cur_id=$(booted_id)
 [ -e "$TOP/$old" ] || die "No such profile: $old (see list-profiles)"
 [ -e "$TOP/$new" ] && die "Target already exists: $new"
 is_reserved_subvol "$old" && die "Refusing to rename reserved subvolume: $old"

--- a/overlays/usr/local/sbin/rename-profile
+++ b/overlays/usr/local/sbin/rename-profile
@@ -13,7 +13,7 @@ set -eu
 usage() {
     cat <<EOF
 Usage: rename-profile [-d|--device DEV] <@old> <@new>
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   Rename a bootable profile at the btrfs top level (see list-profiles) and reissue
   its boot entry. Both are top-level names. Cannot rename the booted profile.
 EOF

--- a/overlays/usr/local/sbin/send-snapshot
+++ b/overlays/usr/local/sbin/send-snapshot
@@ -27,7 +27,7 @@ usage() {
 Usage: send-snapshot [-p PARENT | -i] [-d|--device DEV] <@snapshot> <file|dir|->
   -p PARENT   incremental: send only changes since PARENT (ro, must exist on receiver)
   -i          incremental vs the source's _stock parent (else a full send)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   <@snapshot> full path or bare name, e.g. @snapshots/<name> (rw source auto-snapshotted ro)
   <file|dir>  output file, a directory (writes <leaf>_pack.zst), or - for stdout
 EOF

--- a/overlays/usr/local/sbin/send-snapshot
+++ b/overlays/usr/local/sbin/send-snapshot
@@ -65,12 +65,7 @@ set_lock
 mount_top
 
 parent_path_of() {  # $1 = fs path -> top-relative path of its parent subvol (empty if none)
-    pu=$(btrfs subvolume show "$1" 2>/dev/null | awk -F':[[:space:]]+' '/Parent UUID/{print $2; exit}')
-    case "$pu" in ''|'-') return ;; esac
-    btrfs subvolume list -u "$TOP" 2>/dev/null | awk -v u="$pu" '
-        { p=""; uu=""
-          for (i=1;i<=NF;i++) { if($i=="uuid")uu=$(i+1); else if($i=="path"){p=$(i+1);for(j=i+2;j<=NF;j++)p=p" "$j} }
-          if (uu==u){print p; exit} }'
+    path_of_uuid "$TOP" "$(get "$(btrfs subvolume show "$1" 2>/dev/null)" "Parent UUID")"
 }
 
 srel=$(resolve_rel "$src_name"); [ -n "$srel" ] || die "No such snapshot: $src_name"
@@ -95,7 +90,7 @@ case "${srel##*/}" in
             # btrfs send needs a ro source; snapshot the rw one ro into @snapshots (kept as a
             # restore point) and send that. Each send captures current state, so re-sends never collide.
             [ -d "$TOP/@snapshots" ] || die "@snapshots not found at top level (needed for a ro snapshot)"
-            rosnap="@snapshots/${src_name##*/}_$(date +%Y-%m-%d_%H-%M-%S)"
+            rosnap="@snapshots/${src_name##*/}_$(stamp)"
             [ -e "$TOP/$rosnap" ] && die "Snapshot already exists: $rosnap"
             btrfs subvolume snapshot -r "$srcpath" "$TOP/$rosnap" >/dev/null || die "Failed to make a ro snapshot of $src_name"
             echo "Source is read-write; made ro snapshot $rosnap (kept) and sending it" >&2


### PR DESCRIPTION
Hardening and shared-helper cleanup for the btrfs profile tooling, plus eleven defects found by
testing all of it on hardware.

## What is in here

**migrate-profile hardening** (the first seven commits): account databases validated before a merge
is accepted, the per-entry merge moved out to `/usr/lib/flipper-accountdb.awk`, apt configuration
merged before packages are replayed, our own leftover sidecars treated as noise, a missing package
recovered from a local `.deb`, aside copies named `_old_<ts>` instead of `.old_<ts>`, and
non-regular files no longer counted as changed by both sides.

**Shared helpers**, so the twelve tools stop repeating themselves: `current_subvol()` /
`current_fsuuid()` with a btrfs fallback for when findmnt cannot answer, one `stamp()` for the
timestamp format that `list-profiles` parses, one uuid to path lookup, and one copy of the
`-y`/`-d` help text.

**Defects found while testing on the device.** Each was reproduced before fixing and verified after:

- Five tools compared subvolume ids with the booted profile even under `-d`, where the two
  filesystems hand out ids from the same range. Proven by creating profiles on a loop filesystem
  until one hit the booted id, at which point `delete-profile -d` refused to delete it.
- A signal left the `subvolid=5` mount behind for the rest of the uptime, because dash runs an EXIT
  trap on exit but not on a signal. One test run accumulated seventeen leftovers.
- `mount_top` armed its cleanup only after its own checks, so a rejected `-d` leaked the caller's
  temp files. Invisible normally, one leak per invocation in a recovery boot.
- `migrate-profile` leaked its work directory whenever `mount_top` died, for the same reason.
- SSH host keys were not carried, despite the header promising the device keeps its identity. The
  build bakes the keys in, so the source's copy equals its ancestor's and the delta never mentions
  them. A migration therefore changed the device's ssh identity.
- The conflict count promised sidecars that did not exist: cases settled by policy were counted as
  needing a decision, so the summary said four while three sidecars existed.
- `btrfs-maintenance` reported someone else's error instead of the cause, for both a missing
  `@var-cache` (duperemove's opaque `rc=14`) and a full filesystem (`try dmesg | tail`).
- `list-profiles` and `list-snapshots` said `unexpected argument` where the other ten say
  `unknown option`, and could not tell a typo'd flag from a stray positional.
- The lock file kept a dead holder's pid line, so a waiter could name a process gone for days.

`create-profile` also gained a `REBOOT REQUIRED` warning when it replaces the profile you are
booted from, which is allowed on purpose (it is how a profile is reset to its `_stock`) but leaves
the running system on the copy moved aside until a reboot.

## Testing

All on one device, never on a dev host, since its `/bin/sh` and `awk` differ from the device's
(dash and mawk 1.3.4, and bash in recoveryOS). Roughly 520 assertions across five runs on builds
768, 772, 774, 775 and 777:

- Full suite: argument and safety surface, snapshot and profile lifecycle including BLS entries and
  the `devicetreedir` subvolume prefix, send and receive with incremental parents, missing parents
  and truncated streams, the migrate matrix, every `--resolve` menu key, locking, maintenance, and
  a leak audit against a baseline.
- Cross-build migration between two real builds from different commits, so every case had somewhere
  to go. The load-bearing one: a package installed from a repository that exists only on the source
  profile, which the destination can only resolve if apt configuration was merged before the
  replay.
- Recovery boot, where `/` is a RAM `rootfs` and the profiles sit on an unmounted partition. This is
  what `-d` exists for and could not be reached earlier.
- The migrated profile booted, and a client holding the pre-migration host keys connected under
  `StrictHostKeyChecking=yes` with no warning. A user account added before the migration logs in
  with its carried password hash.

Two behaviours worth a reviewer's attention, both deliberate:

- Re-running a migration is stable but not silent: the delta is recomputed each time, so the same
  paths are reported again. Convergence is what holds, verified by comparing manifests across
  consecutive applies.
- Replacing a profile from its own `_stock` at runtime re-tokens its boot entry into the clone band
  (`901-` rather than the build's `900-`), because the slot is derived from the btrfs parent chain.
  No duplicate entry is left and the default boot entry is unchanged.

## Related

The image bakes one ssh host key set into every build, so every device flashed from it shares a
host identity and reflashing changes it. This branch compensates inside `migrate-profile`, but the
root cause is in the build. #140 covers the wider question of how credentials reach every profile.
