### PR TITLE
btrfs tools: share the helpers the twelve tools were repeating

### DIFF
--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -132,6 +132,19 @@ is_ro() {
     esac
 }
 
+# The timestamp every generated name uses (snapshots, aside copies, ro sends). One helper so
+# the names stay mutually parseable: list-profiles keys KIND=old off this exact shape.
+stamp() { date +%Y-%m-%d_%H-%M-%S; }
+
+# Top-relative path of the subvolume with this uuid, empty if none. $1 = top mount, $2 = uuid.
+path_of_uuid() {
+    case "$2" in ''|'-') return ;; esac
+    btrfs subvolume list -u "$1" 2>/dev/null | awk -v u="$2" '
+        { p=""; uu=""
+          for (i=1;i<=NF;i++) { if($i=="uuid")uu=$(i+1); else if($i=="path"){p=$(i+1);for(j=i+2;j<=NF;j++)p=p" "$j} }
+          if (uu==u){print p; exit} }'
+}
+
 human() { numfmt --to=iec-i --suffix=B --format='%.1f' "${1:-0}" 2>/dev/null || printf '%s' "${1:-0}"; }
 
 # uuid -> "id <tab> path" for every subvolume, so parents resolve by UUID. $1 = top, $2 = out file.

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -18,6 +18,28 @@ need_cmd()   { command -v "$1" >/dev/null 2>&1 || die "Command not installed: $1
 # True if / is a btrfs mount (a normally booted system, not a RAM recovery root).
 root_is_btrfs() { [ "$(findmnt -no FSTYPE / 2>/dev/null)" = btrfs ]; }
 
+# The subvolume mounted at / (e.g. @Desktop), empty if there is none. findmnt cannot answer inside a
+# chroot, so fall back to asking btrfs. flipper-bls.sh keeps its own copy: kernel-install hooks
+# source that file without this one.
+current_subvol() {
+    _cs=$(findmnt -nro FSROOT / 2>/dev/null | sed 's,^/,,')
+    [ -n "$_cs" ] || _cs=$(btrfs subvolume show / 2>/dev/null | sed -n '1{s,^/*,,;s,[[:space:]]*$,,;p}')
+    printf '%s' "$_cs"
+}
+
+# btrfs FS UUID of the mounted root, empty if unknown. Same reasoning as current_subvol.
+current_fsuuid() {
+    _fu=$(findmnt -nro UUID / 2>/dev/null)
+    [ -n "$_fu" ] || _fu=$(btrfs filesystem show / 2>/dev/null | sed -n 's/.*[[:space:]]uuid:[[:space:]]*//p' | head -1)
+    printf '%s' "$_fu"
+}
+
+# The two option help lines nearly every tool repeats verbatim in its usage(). Kept here so the
+# wording cannot drift between tools; interpolated inside their heredocs. migrate-profile spells
+# its own out, its -y means something more specific and its help column is wider.
+HELP_YES="  -y,--yes    assume yes to prompts (non-interactive)"
+HELP_DEVICE="  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)"
+
 # Non-interactive switch for confirm(): set to 1 by -y/--yes, or via the environment
 # (ASSUME_YES=1 <tool> ...) so the tools can run unattended from scripts.
 ASSUME_YES=${ASSUME_YES:-0}

--- a/overlays/usr/local/sbin/btrfs-maintenance
+++ b/overlays/usr/local/sbin/btrfs-maintenance
@@ -21,7 +21,7 @@ Usage: btrfs-maintenance [-d|--device DEV] <check|fix|dedup|balance|all>
   dedup     offline dedup via duperemove across all writable subvolumes
   balance   light filtered balance to reclaim partly-empty chunks
   all       check + dedup + balance
-  -d,--device  operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
 EOF
 }
 

--- a/overlays/usr/local/sbin/btrfs-show-space
+++ b/overlays/usr/local/sbin/btrfs-show-space
@@ -21,7 +21,7 @@ usage() {
 Usage: btrfs-show-space [-q|--quick] [-d|--device DEV]
   Btrfs usage plus per-root-subvolume space (UNIQUE / REFERENCED / TOTAL).
   -q,--quick  skip the compsize REFERENCED column (one less extent-walk per subvol)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
 EOF
 }
 

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -27,8 +27,8 @@ usage() {
     cat <<EOF
 Usage: create-profile [-m|--move] [-y|--yes] [-d|--device DEV] <@source> [<@dest>|current]
   -m,--move   move <@source> into <@dest> (consume source, preserve parent_uuid)
-  -y,--yes    assume yes to prompts (non-interactive)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_YES
+$HELP_DEVICE
   <@source>   full path or bare name: @snapshots/<name>, @<profile>_<stamp>, @<profile>_stock
   <@dest>     profile to write (default: booted profile; or current|booted)
 EOF

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -96,7 +96,7 @@ fi
 if [ "$existed" = 1 ]; then
     # the stamp is per-second, so a second replace within the same second would land on an
     # existing .old_<ts> and mv would nest the profile INSIDE it; take the next free name
-    ts=$(date +%Y-%m-%d_%H-%M-%S)
+    ts=$(stamp)
     aside="$tgt.old_$ts"
     n=1
     while [ -e "$aside" ]; do aside="$tgt.old_${ts}_$n"; n=$((n + 1)); done

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -65,7 +65,7 @@ src="$TOP/$src_rel"
 # dest -> exact top-level name (default: booted root)
 case "$dest" in
     current|booted|"") root_is_btrfs || die "No booted profile to default <@dest> to; pass an explicit <@dest> (e.g. @Desktop-2)"
-                       rel=$(findmnt -no FSROOT / | sed 's,^/,,')
+                       rel=$(current_subvol)
                        [ -n "$rel" ] || die "Cannot determine booted subvolume" ;;
     *)                 rel=$dest; validate_profile_name "$rel" ;;
 esac
@@ -126,7 +126,7 @@ rm -f "$tgt/var/lib/dbus/machine-id" 2>/dev/null || true
 # entry uses; swap every occurrence for the live one.
 fst="$tgt/etc/fstab"
 if [ -f "$fst" ]; then
-    cur=$(findmnt -no UUID / 2>/dev/null)
+    cur=$(current_fsuuid)
     old=$(awk '$2=="/"{for(i=1;i<=NF;i++) if($i ~ /^UUID=/){sub(/^UUID=/,"",$i); print $i; exit}}' "$fst")
     [ -n "$cur" ] && [ -n "$old" ] && [ "$cur" != "$old" ] && { sed -i "s/$old/$cur/g" "$fst"; echo "fstab: rewrote fs UUID $old -> $cur"; }
 fi

--- a/overlays/usr/local/sbin/create-snapshot
+++ b/overlays/usr/local/sbin/create-snapshot
@@ -43,7 +43,7 @@ fi
 # snapshot must not nest the new name under @snapshots/@snapshots/)
 src=$(current_subvol); src=${src##*/}
 [ -n "$src" ] || die "Cannot determine the source subvolume of /"
-name="${src}_$(date +%Y-%m-%d_%H-%M-%S)${tag:+_$tag}"
+name="${src}_$(stamp)${tag:+_$tag}"
 
 set_lock
 mount_top

--- a/overlays/usr/local/sbin/create-snapshot
+++ b/overlays/usr/local/sbin/create-snapshot
@@ -39,8 +39,9 @@ tag=$*
 if [ -n "$tag" ]; then
     tag=$(printf '%s' "$tag" | tr -c 'A-Za-z0-9._-' '-' | sed 's/-\{1,\}/-/g; s/^-//; s/-$//')
 fi
-# name after /'s source subvol, e.g. @Minimal_2026-06-29_19-52-31
-src=$(btrfs subvolume show / 2>/dev/null | head -n1); src=${src##*/}
+# name after /'s source subvol, e.g. @Minimal_2026-06-29_19-52-31 (leaf only: booting a
+# snapshot must not nest the new name under @snapshots/@snapshots/)
+src=$(current_subvol); src=${src##*/}
 [ -n "$src" ] || die "Cannot determine the source subvolume of /"
 name="${src}_$(date +%Y-%m-%d_%H-%M-%S)${tag:+_$tag}"
 

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -14,8 +14,8 @@ set -eu
 usage() {
     cat <<EOF
 Usage: delete-profile [-y|--yes] [-d|--device DEV] <@profile>
-  -y,--yes    assume yes to prompts (non-interactive)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_YES
+$HELP_DEVICE
   Delete a bootable profile at the btrfs top level (see list-profiles) and its boot
   entry: a profile root or an @<profile>.old_* leftover. For restore points and
   _stock golden bases use delete-snapshot.

--- a/overlays/usr/local/sbin/delete-snapshot
+++ b/overlays/usr/local/sbin/delete-snapshot
@@ -14,8 +14,8 @@ set -eu
 usage() {
     cat <<EOF
 Usage: delete-snapshot [-y|--yes] [-d|--device DEV] <@snapshots/@name | @stock-snapshots/@X_stock | @X_stock>
-  -y,--yes    assume yes to prompts (non-interactive)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_YES
+$HELP_DEVICE
   Delete a restore-point snapshot under @snapshots or a _stock golden base under
   @stock-snapshots (see list-snapshots). For profiles or .old leftovers use delete-profile.
 EOF

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -14,7 +14,7 @@ set -eu
 usage() {
     cat <<EOF
 Usage: list-profiles [-d|--device DEV]
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   List bootable profiles at the btrfs top level: profile roots and @<profile>.old_*
   leftovers. For _stock golden bases and restore points, see list-snapshots.
 EOF

--- a/overlays/usr/local/sbin/list-snapshots
+++ b/overlays/usr/local/sbin/list-snapshots
@@ -13,7 +13,7 @@ set -eu
 usage() {
     cat <<EOF
 Usage: list-snapshots [-d|--device DEV]
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   List restore-point snapshots under @snapshots and _stock golden bases under
   @stock-snapshots. For bootable profiles, see list-profiles.
 EOF

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -84,7 +84,7 @@ ask_tty() {
 # --- interactive resolution of leftover sidecars ---------------------------------------------
 resolve_mode() {
     _p=$1
-    case "$_p" in current|booted|"") root_is_btrfs || die "no booted profile to default to; name the profile explicitly"; _p=$(findmnt -no FSROOT / | sed 's,^/,,') ;; esac
+    case "$_p" in current|booted|"") root_is_btrfs || die "no booted profile to default to; name the profile explicitly"; _p=$(current_subvol) ;; esac
     case "$_p" in *..*|/*|*/*) die "Invalid profile: $_p" ;; esac
     [ -d "$TOP/$_p" ] || die "No such profile: $_p"
     _root="$TOP/$_p"; _dstname=$_p; _srcname=${2:-}
@@ -169,7 +169,7 @@ esac
 
 [ -d "$TOP/$src" ] || die "No such profile: $src"
 case "$dst" in
-    current|booted|"") root_is_btrfs || die "no booted profile to default <@dst> to; pass an explicit <@dst>"; dst=$(findmnt -no FSROOT / | sed 's,^/,,'); [ -n "$dst" ] || die "cannot determine booted profile" ;;
+    current|booted|"") root_is_btrfs || die "no booted profile to default <@dst> to; pass an explicit <@dst>"; dst=$(current_subvol); [ -n "$dst" ] || die "cannot determine booted profile" ;;
     *)                 case "$dst" in *..*|/*|*/*) die "Invalid dst: $dst (top-level name)" ;; esac ;;
 esac
 [ -d "$TOP/$dst" ] || die "No such profile: $dst"
@@ -177,7 +177,7 @@ esac
 is_reserved_subvol "$src" && die "src is a reserved subvolume"
 is_reserved_subvol "$dst" && die "dst is a reserved subvolume"
 
-booted=$(findmnt -no FSROOT / | sed 's,^/,,')
+booted=$(current_subvol)
 if [ "$apply" = 1 ] && [ "$dst" = "$booted" ] && [ "$force" != 1 ]; then
     die "won't modify '$dst': it is the profile you are booted into.
 Boot into another profile and run this again, or pass --force to override."

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -500,7 +500,7 @@ fi
 # ================= APPLY =================
 confirm "Apply the above to '$dst'? A '$dst' snapshot is taken first."
 
-ts=$(date +%Y-%m-%d_%H-%M-%S)
+ts=$(stamp)
 snap="@snapshots/@${dst#@}_${ts}_before_migrate"
 btrfs subvolume snapshot -r "$TOP/$dst" "$TOP/$snap" >/dev/null \
     && echo "snapshot: $snap" || die "could not snapshot $dst; aborting before any change"

--- a/overlays/usr/local/sbin/receive-snapshot
+++ b/overlays/usr/local/sbin/receive-snapshot
@@ -15,7 +15,7 @@ set -eu
 usage() {
     cat <<EOF
 Usage: receive-snapshot [-d|--device DEV] <file|->
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   Receive a send-snapshot stream (a _stock base -> @stock-snapshots, else @snapshots). Put it onto a root
   with create-profile. Incremental streams need their parent to exist here first.
 EOF

--- a/overlays/usr/local/sbin/rename-profile
+++ b/overlays/usr/local/sbin/rename-profile
@@ -13,7 +13,7 @@ set -eu
 usage() {
     cat <<EOF
 Usage: rename-profile [-d|--device DEV] <@old> <@new>
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   Rename a bootable profile at the btrfs top level (see list-profiles) and reissue
   its boot entry. Both are top-level names. Cannot rename the booted profile.
 EOF

--- a/overlays/usr/local/sbin/send-snapshot
+++ b/overlays/usr/local/sbin/send-snapshot
@@ -27,7 +27,7 @@ usage() {
 Usage: send-snapshot [-p PARENT | -i] [-d|--device DEV] <@snapshot> <file|dir|->
   -p PARENT   incremental: send only changes since PARENT (ro, must exist on receiver)
   -i          incremental vs the source's _stock parent (else a full send)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   <@snapshot> full path or bare name, e.g. @snapshots/<name> (rw source auto-snapshotted ro)
   <file|dir>  output file, a directory (writes <leaf>_pack.zst), or - for stdout
 EOF

--- a/overlays/usr/local/sbin/send-snapshot
+++ b/overlays/usr/local/sbin/send-snapshot
@@ -65,12 +65,7 @@ set_lock
 mount_top
 
 parent_path_of() {  # $1 = fs path -> top-relative path of its parent subvol (empty if none)
-    pu=$(btrfs subvolume show "$1" 2>/dev/null | awk -F':[[:space:]]+' '/Parent UUID/{print $2; exit}')
-    case "$pu" in ''|'-') return ;; esac
-    btrfs subvolume list -u "$TOP" 2>/dev/null | awk -v u="$pu" '
-        { p=""; uu=""
-          for (i=1;i<=NF;i++) { if($i=="uuid")uu=$(i+1); else if($i=="path"){p=$(i+1);for(j=i+2;j<=NF;j++)p=p" "$j} }
-          if (uu==u){print p; exit} }'
+    path_of_uuid "$TOP" "$(get "$(btrfs subvolume show "$1" 2>/dev/null)" "Parent UUID")"
 }
 
 srel=$(resolve_rel "$src_name"); [ -n "$srel" ] || die "No such snapshot: $src_name"
@@ -95,7 +90,7 @@ case "${srel##*/}" in
             # btrfs send needs a ro source; snapshot the rw one ro into @snapshots (kept as a
             # restore point) and send that. Each send captures current state, so re-sends never collide.
             [ -d "$TOP/@snapshots" ] || die "@snapshots not found at top level (needed for a ro snapshot)"
-            rosnap="@snapshots/${src_name##*/}_$(date +%Y-%m-%d_%H-%M-%S)"
+            rosnap="@snapshots/${src_name##*/}_$(stamp)"
             [ -e "$TOP/$rosnap" ] && die "Snapshot already exists: $rosnap"
             btrfs subvolume snapshot -r "$srcpath" "$TOP/$rosnap" >/dev/null || die "Failed to make a ro snapshot of $src_name"
             echo "Source is read-write; made ro snapshot $rosnap (kept) and sending it" >&2


### PR DESCRIPTION
Three small DRY passes over the twelve btrfs tools, no behaviour change intended.

- `current_subvol()` / `current_fsuuid()` replace bare `findmnt -nro FSROOT /` and `findmnt -nro UUID /`
  calls. findmnt stays the first source, since it needs no privileges and is authoritative on a booted
  system, but it cannot answer inside a chroot and reports the path recorded at mount time, so the
  helpers fall back to asking btrfs. `flipper-bls.sh` keeps its own copy on purpose, because
  kernel-install hooks source it without this lib.
- `stamp()` replaces the four copies of `date +%Y-%m-%d_%H-%M-%S` that name snapshots, aside copies and
  ro sends. `list-profiles` classifies `KIND=old` by matching that exact shape, so the format needs one
  definition rather than four. `path_of_uuid()` takes over `send-snapshot`'s private uuid-to-path scan.
- `HELP_YES` / `HELP_DEVICE` hold the two option lines that ten tools repeated verbatim, so the wording
  cannot drift. `migrate-profile` spells its own out, since its `-y` also decides what happens to
  conflicts.
as one branch on hardware across five builds; splitting preserved the final tree byte for byte.

Split out of the closed #141. Only the combined final state was run on hardware; each
commit parses and defines the helpers it uses, and the stack tip is byte-identical to what
was tested.
