### PR TITLE
flipper-btrfs.sh: clean up on signals, early exits and stale lock lines

### DIFF
--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -98,7 +98,7 @@ remove_entries() {  # $1 = subvol  $2 = version
         [ "$(awk '$1=="version"{print $2; exit}' "$_c")" = "$2" ] || continue
         _es="$(awk '$1=="options"{for(i=2;i<=NF;i++) if($i ~ /^rootflags=subvol=/) s=$i}
                     END{sub(/^rootflags=subvol=/,"",s); print s}' "$_c")"
-        [ "$_es" = "$1" ] && rm -f "$_c"
+        [ "$_es" = "$1" ] && rm -f "$_c" || true
     done
     return 0   # a non-matching last entry must not fail the loop under set -e
 }

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -99,14 +99,16 @@ set_lock() {
 # ROOTDEV may be preset (by -d/--device) to run against a filesystem that is not the
 # booted root, e.g. from a RAM recovery boot where / is not the btrfs filesystem.
 mount_top() {
-    [ -n "${ROOTDEV:-}" ] || ROOTDEV=$(findmnt -no SOURCE / | sed 's/\[.*//')
-    [ -n "$ROOTDEV" ] || die "Cannot determine root device (use -d/--device)"
-    [ -b "$ROOTDEV" ] || die "Not a block device: $ROOTDEV"
-    TOP=$(mktemp -d)
+    # Arm cleanup FIRST: callers set TOP_TMPFILES before calling us, so a die on the checks below
+    # (a bad -d argument, no btrfs root) must still take their temp files with it.
     trap 'top_cleanup' EXIT
     # dash runs the EXIT trap on exit, not on a signal, so a plain kill would leave $TOP mounted;
     # route the usual signals through exit so the cleanup happens once, in one place
     trap 'exit 130' INT; trap 'exit 143' TERM; trap 'exit 129' HUP
+    [ -n "${ROOTDEV:-}" ] || ROOTDEV=$(findmnt -no SOURCE / | sed 's/\[.*//')
+    [ -n "$ROOTDEV" ] || die "Cannot determine root device (use -d/--device)"
+    [ -b "$ROOTDEV" ] || die "Not a block device: $ROOTDEV"
+    TOP=$(mktemp -d)
     _err=$(mount -o subvolid=5 "$ROOTDEV" "$TOP" 2>&1) || die "Mount failed: $_err"
 }
 top_cleanup() {

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -104,10 +104,22 @@ mount_top() {
     [ -b "$ROOTDEV" ] || die "Not a block device: $ROOTDEV"
     TOP=$(mktemp -d)
     trap 'top_cleanup' EXIT
+    # dash runs the EXIT trap on exit, not on a signal, so a plain kill would leave $TOP mounted;
+    # route the usual signals through exit so the cleanup happens once, in one place
+    trap 'exit 130' INT; trap 'exit 143' TERM; trap 'exit 129' HUP
     _err=$(mount -o subvolid=5 "$ROOTDEV" "$TOP" 2>&1) || die "Mount failed: $_err"
 }
 top_cleanup() {
-    [ -n "${TOP:-}" ] && { umount "$TOP" 2>/dev/null || true; rmdir "$TOP" 2>/dev/null || true; }
+    if [ -n "${TOP:-}" ]; then
+        for _i in 1 2 3 4 5; do
+            umount "$TOP" 2>/dev/null && break
+            # the callers run under set -e, where a failing detach would abort the trap and
+            # abandon the mount
+            [ "$_i" = 5 ] && umount -l "$TOP" 2>/dev/null || true
+            sleep 1
+        done
+        rmdir "$TOP" 2>/dev/null || true
+    fi
     [ -n "${TOP_TMPFILES:-}" ] && rm -f $TOP_TMPFILES
     return 0
 }

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -14,6 +14,10 @@ die() { echo "Error: $*" >&2; exit 1; }
 need_root()  { [ "$(id -u)" -eq 0 ] || die "Must run as root (use sudo)"; }
 need_btrfs() { command -v btrfs >/dev/null 2>&1 || die "Btrfs-progs not installed"; }
 need_cmd()   { command -v "$1" >/dev/null 2>&1 || die "Command not installed: $1${2:+ ($2)}"; }
+# Guard for the -d/--device value: fail (with the tool's usage) if the flag was the last token.
+# Call with the arg count remaining AFTER shifting the flag off:
+#   -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
+need_device_arg() { [ "$1" -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; }
 
 # True if / is a btrfs mount (a normally booted system, not a RAM recovery root).
 root_is_btrfs() { [ "$(findmnt -no FSTYPE / 2>/dev/null)" = btrfs ]; }

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -88,10 +88,17 @@ set_lock() {
     exec 9<>"$LOCK_FILE" || die "Cannot open lock $LOCK_FILE"   # <> = don't truncate the holder line
     if ! flock -w 0 9 2>/dev/null; then
         _h=$(cat "$LOCK_FILE" 2>/dev/null); [ -n "$_h" ] || _h="PID unknown"
+        # the line is written by whoever holds it; if that process is gone the line is stale
+        # leftovers from a crash, so do not present it as the reason we are waiting
+        _hp=${_h#PID }; _hp=${_hp%% *}
+        case "$_hp" in
+            [0-9]*) kill -0 "$_hp" 2>/dev/null || _h="$_h, which is no longer running; the line is stale" ;;
+        esac
         echo "Another flipper-btrfs operation is in progress ($_h); waiting for it to finish..." >&2
         flock 9 || die "Cannot acquire lock $LOCK_FILE"
     fi
     printf 'PID %s (%s)\n' "$$" "${0##*/}" >"$LOCK_FILE" || true
+    LOCK_HELD=1
 }
 
 # Mount the btrfs top level (subvolid=5) at a temp dir and arrange teardown on EXIT.
@@ -112,6 +119,9 @@ mount_top() {
     _err=$(mount -o subvolid=5 "$ROOTDEV" "$TOP" 2>&1) || die "Mount failed: $_err"
 }
 top_cleanup() {
+    # the holder line outlives the flock the kernel drops for us, so blank it: no waiter should read
+    # a pid gone for days
+    [ "${LOCK_HELD:-0}" = 1 ] && : > "$LOCK_FILE" 2>/dev/null
     if [ -n "${TOP:-}" ]; then
         for _i in 1 2 3 4 5; do
             umount "$TOP" 2>/dev/null && break

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -84,6 +84,18 @@ validate_profile_name() {
 # file so a blocked waiter can say who it is waiting on. Read-only tools do not take it, and it
 # does NOT guard against concurrent native `btrfs` commands, which honor no lock.
 LOCK_FILE=/run/flipper-btrfs.lock
+
+# True if we are the OPPOSITE end of a pipe from that pid (our stdout is its stdin, or the reverse).
+# Sharing the same end does not count: siblings from one shell inherit the same stdin. /proc names a
+# pipe as pipe:[<inode>], so the inode is the identity.
+pipe_shared_with() {  # $1 = pid
+    _out=$(readlink "/proc/$$/fd/1" 2>/dev/null || true)
+    _in=$(readlink "/proc/$$/fd/0" 2>/dev/null || true)
+    case "$_out" in pipe:*) [ "$_out" = "$(readlink "/proc/$1/fd/0" 2>/dev/null || true)" ] && return 0 ;; esac
+    case "$_in" in pipe:*) [ "$_in" = "$(readlink "/proc/$1/fd/1" 2>/dev/null || true)" ] && return 0 ;; esac
+    return 1
+}
+
 set_lock() {
     exec 9<>"$LOCK_FILE" || die "Cannot open lock $LOCK_FILE"   # <> = don't truncate the holder line
     if ! flock -w 0 9 2>/dev/null; then
@@ -94,11 +106,29 @@ set_lock() {
         case "$_hp" in
             [0-9]*) kill -0 "$_hp" 2>/dev/null || _h="$_h, which is no longer running; the line is stale" ;;
         esac
+        # A holder on the other end of our pipe can never release: it is blocked reading what we
+        # have not written. Waiting is then a deadlock, so say so. A holder that merely shares our
+        # process group (a sibling job from one script) is not that case and must be waited for.
+        case "$_hp" in
+            [0-9]*) if kill -0 "$_hp" 2>/dev/null && pipe_shared_with "$_hp"; then
+                        die "$_h holds the lock and is on the other end of our pipe, so waiting would deadlock. Piping one of our tools into another on the same machine cannot work: write the stream to a file and read it back, or run one side on another host"
+                    fi ;;
+        esac
         echo "Another flipper-btrfs operation is in progress ($_h); waiting for it to finish..." >&2
         flock 9 || die "Cannot acquire lock $LOCK_FILE"
     fi
     printf 'PID %s (%s)\n' "$$" "${0##*/}" >"$LOCK_FILE" || true
     LOCK_HELD=1
+}
+
+# Drop the lock before a long read-only phase, so a writer does not queue behind work that no
+# longer mutates anything. The kernel releases the flock when the last descriptor closes, and
+# children inherit fd 9, so this only takes effect for what we start afterwards.
+release_lock() {
+    [ "${LOCK_HELD:-0}" = 1 ] || return 0
+    ( : > "$LOCK_FILE" ) 2>/dev/null || true
+    exec 9>&-
+    LOCK_HELD=0
 }
 
 # Mount the btrfs top level (subvolid=5) at a temp dir and arrange teardown on EXIT.

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -115,7 +115,10 @@ mount_top() {
     [ -n "${ROOTDEV:-}" ] || ROOTDEV=$(findmnt -no SOURCE / | sed 's/\[.*//')
     [ -n "$ROOTDEV" ] || die "Cannot determine root device (use -d/--device)"
     [ -b "$ROOTDEV" ] || die "Not a block device: $ROOTDEV"
-    TOP=$(mktemp -d)
+    # NOT under /tmp: `rm -rf /tmp/tmp.*` while a tool holds its mount recurses through the whole
+    # filesystem, and rmdir removes an empty subvolume, so it deletes profiles, @home and boot.
+    # /run is tmpfs, root-only, and nobody sweeps it by glob.
+    TOP=$(mktemp -d /run/flipper-btrfs.mnt.XXXXXX 2>/dev/null || mktemp -d)
     _err=$(mount -o subvolid=5 "$ROOTDEV" "$TOP" 2>&1) || die "Mount failed: $_err"
 }
 top_cleanup() {

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -123,8 +123,9 @@ mount_top() {
 }
 top_cleanup() {
     # the holder line outlives the flock the kernel drops for us, so blank it: no waiter should read
-    # a pid gone for days
-    [ "${LOCK_HELD:-0}" = 1 ] && : > "$LOCK_FILE" 2>/dev/null
+    # a pid gone for days. Subshell: a failed '>' on the special builtin ':' exits the shell outright,
+    # too early for '|| true' to catch, and the unmount below still has to run
+    [ "${LOCK_HELD:-0}" = 1 ] && ( : > "$LOCK_FILE" ) 2>/dev/null || true
     if [ -n "${TOP:-}" ]; then
         for _i in 1 2 3 4 5; do
             umount "$TOP" 2>/dev/null && break
@@ -135,7 +136,7 @@ top_cleanup() {
         done
         rmdir "$TOP" 2>/dev/null || true
     fi
-    [ -n "${TOP_TMPFILES:-}" ] && rm -f $TOP_TMPFILES
+    [ -n "${TOP_TMPFILES:-}" ] && rm -f $TOP_TMPFILES || true
     return 0
 }
 

--- a/overlays/usr/local/sbin/btrfs-maintenance
+++ b/overlays/usr/local/sbin/btrfs-maintenance
@@ -21,14 +21,14 @@ Usage: btrfs-maintenance [-d|--device DEV] <check|fix|dedup|balance|all>
   dedup     offline dedup via duperemove across all writable subvolumes
   balance   light filtered balance to reclaim partly-empty chunks
   all       check + dedup + balance
-  -d,--device  operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
 EOF
 }
 
 do_scrub=0; scrub_ro=; dedup=0; balance=0; lock=1; cmd=""
 while [ $# -gt 0 ]; do
     case "$1" in
-        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -y|--yes)    ASSUME_YES=1 ;;
         -h|--help)   usage; exit 0 ;;

--- a/overlays/usr/local/sbin/btrfs-show-space
+++ b/overlays/usr/local/sbin/btrfs-show-space
@@ -21,7 +21,7 @@ usage() {
 Usage: btrfs-show-space [-q|--quick] [-d|--device DEV]
   Btrfs usage plus per-root-subvolume space (UNIQUE / REFERENCED / TOTAL).
   -q,--quick  skip the compsize REFERENCED column (one less extent-walk per subvol)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
 EOF
 }
 
@@ -29,7 +29,7 @@ quick=0
 while [ $# -gt 0 ]; do
     case "$1" in
         -q|--quick)  quick=1 ;;
-        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
         -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -27,8 +27,8 @@ usage() {
     cat <<EOF
 Usage: create-profile [-m|--move] [-y|--yes] [-d|--device DEV] <@source> [<@dest>|current]
   -m,--move   move <@source> into <@dest> (consume source, preserve parent_uuid)
-  -y,--yes    assume yes to prompts (non-interactive)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_YES
+$HELP_DEVICE
   <@source>   full path or bare name: @snapshots/<name>, @<profile>_<stamp>, @<profile>_stock
   <@dest>     profile to write (default: booted profile; or current|booted)
 EOF
@@ -39,7 +39,7 @@ while :; do
     case "${1:-}" in
         -m|--move)   move=1; shift ;;
         -y|--yes)    ASSUME_YES=1; shift ;;
-        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1; shift ;;
+        -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1; shift ;;
         --device=*)  ROOTDEV=${1#*=}; shift ;;
         -h|--help)   usage; exit 0 ;;
         -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -104,12 +104,12 @@ if [ "$existed" = 1 ]; then
 fi
 if [ "$move" = 1 ]; then
     if ! mv "$src" "$tgt"; then
-        [ -n "$aside" ] && mv "$aside" "$tgt"
+        [ -n "$aside" ] && mv "$aside" "$tgt" || true
         die "Move failed; ${aside:+previous $rel restored, }nothing changed"
     fi
 else
     if ! btrfs subvolume snapshot "$src" "$tgt" >/dev/null; then
-        [ -n "$aside" ] && mv "$aside" "$tgt"
+        [ -n "$aside" ] && mv "$aside" "$tgt" || true
         die "Snapshot failed; ${aside:+previous $rel restored, }nothing changed"
     fi
 fi

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -14,8 +14,8 @@ set -eu
 usage() {
     cat <<EOF
 Usage: delete-profile [-y|--yes] [-d|--device DEV] <@profile>
-  -y,--yes    assume yes to prompts (non-interactive)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_YES
+$HELP_DEVICE
   Delete a bootable profile at the btrfs top level (see list-profiles) and its boot
   entry: a profile root or an @<profile>.old_* leftover. For restore points and
   _stock golden bases use delete-snapshot.
@@ -25,7 +25,7 @@ EOF
 while [ $# -gt 0 ]; do
     case "$1" in
         -y|--yes)    ASSUME_YES=1 ;;
-        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
         --)          shift; break ;;

--- a/overlays/usr/local/sbin/delete-snapshot
+++ b/overlays/usr/local/sbin/delete-snapshot
@@ -14,8 +14,8 @@ set -eu
 usage() {
     cat <<EOF
 Usage: delete-snapshot [-y|--yes] [-d|--device DEV] <@snapshots/@name | @stock-snapshots/@X_stock | @X_stock>
-  -y,--yes    assume yes to prompts (non-interactive)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_YES
+$HELP_DEVICE
   Delete a restore-point snapshot under @snapshots or a _stock golden base under
   @stock-snapshots (see list-snapshots). For profiles or .old leftovers use delete-profile.
 EOF
@@ -24,7 +24,7 @@ EOF
 while [ $# -gt 0 ]; do
     case "$1" in
         -y|--yes)    ASSUME_YES=1 ;;
-        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
         --)          shift; break ;;

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -14,7 +14,7 @@ set -eu
 usage() {
     cat <<EOF
 Usage: list-profiles [-d|--device DEV]
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   List bootable profiles at the btrfs top level: profile roots and @<profile>.old_*
   leftovers. For _stock golden bases and restore points, see list-snapshots.
 EOF
@@ -22,7 +22,7 @@ EOF
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
         *)           echo "Error: unexpected argument: $1" >&2; usage >&2; exit 1 ;;

--- a/overlays/usr/local/sbin/list-snapshots
+++ b/overlays/usr/local/sbin/list-snapshots
@@ -13,7 +13,7 @@ set -eu
 usage() {
     cat <<EOF
 Usage: list-snapshots [-d|--device DEV]
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   List restore-point snapshots under @snapshots and _stock golden bases under
   @stock-snapshots. For bootable profiles, see list-profiles.
 EOF
@@ -21,7 +21,7 @@ EOF
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
         *)           echo "Error: unexpected argument: $1" >&2; usage >&2; exit 1 ;;

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -54,7 +54,7 @@ while :; do
         -v|--verbose)      verbose=1; shift ;;
         --show-noise)      show_noise=1; shift ;;
         --do-not-resolve)  no_resolve=1; shift ;;
-        -d|--device)       shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1; shift ;;
+        -d|--device)       shift; need_device_arg "$#"; ROOTDEV=$1; shift ;;
         --device=*)        ROOTDEV=${1#*=}; shift ;;
         -h|--help)       usage; exit 0 ;;
         -?*)             echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;

--- a/overlays/usr/local/sbin/receive-snapshot
+++ b/overlays/usr/local/sbin/receive-snapshot
@@ -15,7 +15,7 @@ set -eu
 usage() {
     cat <<EOF
 Usage: receive-snapshot [-d|--device DEV] <file|->
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   Receive a send-snapshot stream (a _stock base -> @stock-snapshots, else @snapshots). Put it onto a root
   with create-profile. Incremental streams need their parent to exist here first.
 EOF
@@ -24,7 +24,7 @@ EOF
 while [ $# -gt 0 ]; do
     case "$1" in
         -y|--yes)    ASSUME_YES=1 ;;
-        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
         --)          shift; break ;;

--- a/overlays/usr/local/sbin/receive-snapshot
+++ b/overlays/usr/local/sbin/receive-snapshot
@@ -53,6 +53,11 @@ if [ "$src" != "-" ]; then
     case "$name" in ?*_stock) target="$TOP/@stock-snapshots" ;; esac
 fi
 [ -d "$target" ] || die "${target##*/} not found at top level"
+# btrfs receive refuses to replace an existing subvolume, and it says so only once the stream has
+# been transferred. Where the name was read up front, answer it here instead.
+if [ -n "${name:-}" ] && [ -e "$target/$name" ]; then
+    die "Already present: ${target##*/}/$name (btrfs receive cannot replace it); delete-snapshot ${target##*/}/$name first"
+fi
 
 before=$(btrfs subvolume list -o "$target" 2>/dev/null | wc -l)
 
@@ -66,6 +71,23 @@ else                                               zstd -dc               | btrf
 fi
 rc=$?
 set -e
-[ "$rc" = 0 ] || die "Receive failed (rc=$rc); check the stream and that any parent snapshot exists here"
+if [ "$rc" != 0 ]; then
+    # btrfs turns the subvolume read-only only once the whole stream is in, so a failure leaves a
+    # writable partial behind. Left there, it is what the retry collides with.
+    if [ -n "${name:-}" ] && [ -e "$target/$name" ]; then
+        # ours only while it is still writable: btrfs sets ro on success, and our lock cannot stop
+        # a hand-run btrfs command from taking the name while we streamed
+        if is_ro "$target/$name"; then
+            echo "Warning: ${target##*/}/$name is read-only, so it is not our partial; left alone" >&2
+        elif btrfs subvolume delete "$target/$name" >/dev/null 2>&1; then
+            echo "Removed the incomplete ${target##*/}/$name" >&2
+        else
+            echo "Warning: could not remove the incomplete ${target##*/}/$name; delete it before retrying" >&2
+        fi
+    elif [ "$(btrfs subvolume list -o "$target" 2>/dev/null | wc -l)" != "$before" ]; then
+        echo "Warning: an incomplete subvolume may be left in ${target##*/}/; delete it before retrying" >&2
+    fi
+    die "Receive failed (rc=$rc); check the stream and that any parent snapshot exists here"
+fi
 
 echo "Received into ${target##*/}/ (now $(btrfs subvolume list -o "$target" 2>/dev/null | wc -l) entries, was $before)"

--- a/overlays/usr/local/sbin/rename-profile
+++ b/overlays/usr/local/sbin/rename-profile
@@ -13,7 +13,7 @@ set -eu
 usage() {
     cat <<EOF
 Usage: rename-profile [-d|--device DEV] <@old> <@new>
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   Rename a bootable profile at the btrfs top level (see list-profiles) and reissue
   its boot entry. Both are top-level names. Cannot rename the booted profile.
 EOF
@@ -22,7 +22,7 @@ EOF
 while [ $# -gt 0 ]; do
     case "$1" in
         -y|--yes)    ASSUME_YES=1 ;;
-        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
         --)          shift; break ;;

--- a/overlays/usr/local/sbin/send-snapshot
+++ b/overlays/usr/local/sbin/send-snapshot
@@ -140,10 +140,15 @@ echo "Sending $srel${parentpath:+ (incremental from $prel)}${dest:+ -> $dest}" >
 # no pipefail: run under set +e and check both ends (send via $send_stat, and compress);
 # discard partial output on any failure so a bad send never looks like a complete backup
 set +e
+# 9>&- : children inherit the lock descriptor, and the flock lives on the open file description, so
+# a child that outlives us keeps the lock held with no owner. A killed send used to leave zstd, pv
+# or a waiting flock holding it, and every writer tool would block until the next reboot.
+{
 if   [ "$have_pv" = 1 ] && [ "$sz" -gt 0 ]; then do_send | pv -pterb -s "$sz" | emit
 elif [ "$have_pv" = 1 ];                    then do_send | pv -btr | emit
 else                                              do_send | emit
 fi
+} 9>&-
 emit_rc=$?
 set -e
 send_rc=$(cat "$send_stat" 2>/dev/null || echo 1)

--- a/overlays/usr/local/sbin/send-snapshot
+++ b/overlays/usr/local/sbin/send-snapshot
@@ -27,7 +27,7 @@ usage() {
 Usage: send-snapshot [-p PARENT | -i] [-d|--device DEV] <@snapshot> <file|dir|->
   -p PARENT   incremental: send only changes since PARENT (ro, must exist on receiver)
   -i          incremental vs the source's _stock parent (else a full send)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   <@snapshot> full path or bare name, e.g. @snapshots/<name> (rw source auto-snapshotted ro)
   <file|dir>  output file, a directory (writes <leaf>_pack.zst), or - for stdout
 EOF

--- a/overlays/usr/local/sbin/send-snapshot
+++ b/overlays/usr/local/sbin/send-snapshot
@@ -61,7 +61,9 @@ fi
 
 send_stat=$(mktemp)
 TOP_TMPFILES="$send_stat"
-set_lock
+# No lock yet: a send only reads. Only the ro snapshot of a read-write source mutates, and it takes
+# the lock just for that. Holding it across the stream blocks every writer for the whole send, and
+# deadlocks a local 'send-snapshot - | receive-snapshot -'.
 mount_top
 
 parent_path_of() {  # $1 = fs path -> top-relative path of its parent subvol (empty if none)
@@ -90,9 +92,11 @@ case "${srel##*/}" in
             # btrfs send needs a ro source; snapshot the rw one ro into @snapshots (kept as a
             # restore point) and send that. Each send captures current state, so re-sends never collide.
             [ -d "$TOP/@snapshots" ] || die "@snapshots not found at top level (needed for a ro snapshot)"
+            set_lock
             rosnap="@snapshots/${src_name##*/}_$(stamp)"
             [ -e "$TOP/$rosnap" ] && die "Snapshot already exists: $rosnap"
             btrfs subvolume snapshot -r "$srcpath" "$TOP/$rosnap" >/dev/null || die "Failed to make a ro snapshot of $src_name"
+            release_lock
             echo "Source is read-write; made ro snapshot $rosnap (kept) and sending it" >&2
             srel=$rosnap; srcpath="$TOP/$rosnap"
         fi ;;


### PR DESCRIPTION
Four defects in how the shared lib manages its mount and its lock. The first matters most.

- **The mount sat in the directory everybody sweeps.** `mount_top` used a bare `mktemp -d`, so the
  filesystem lived at `/tmp/tmp.XXXX`. Any `rm -rf /tmp/tmp.*` while a tool held its mount recursed
  through the whole filesystem, and because `rmdir` removes an empty subvolume, it emptied and then
  deleted profiles, `@home` and `boot`, leaving only the read-only `_stock` bases. The mount now
  lives at `/run/flipper-btrfs.mnt.XXXXXX`, which no glob sweeps, with a fallback if `/run` is not
  writable.
- **A signal left the mount behind for the rest of the uptime**, because the cleanup hung off a
  plain `trap ... EXIT`, which dash runs on exit but not on a signal. `INT`, `TERM` and `HUP` now
  route through `exit`. The first `umount` also raced the dying children and failed silently, so it
  retries and then detaches lazily.
- **`mount_top` armed cleanup after its own checks**, so dying on a bad `-d` left the caller's temp
  files behind: one leak per invocation in a recovery boot.
- **The lock file kept a dead holder's pid line.** The flock was never stale, only the label was, so
  a waiter could name a long-gone pid. It is checked with `kill -0` now and blanked on exit. The file
  is truncated rather than unlinked, since deleting it lets two processes lock different inodes.

Split out of the closed #141. Only the combined final state ran on hardware. The mountpoint fix has
a regression test that runs the glob against a sandbox and asserts nothing changed.

