### PR TITLE
btrfs tools: do not compare against the booted profile on another filesystem

### DIFF
--- a/overlays/configs/kernel/install.d/90-loaderentry.install
+++ b/overlays/configs/kernel/install.d/90-loaderentry.install
@@ -40,7 +40,7 @@ set_dtb_dirs
 # content (version + rootflags=subvol=), so it never touches another profile's entries and
 # survives any purge/cleanup path. kernel-install itself removes this root's staged dir.
 if [ "$COMMAND" = "remove" ]; then
-    remove_entries "$(current_subvol)" "$KERNEL_VERSION"
+    remove_entries "$(booted_subvol)" "$KERNEL_VERSION"
     # kernel-install removed this version's staged dir; reap the now-empty per-token parent
     # ($BOOT_ROOT/$ENTRY_TOKEN) too. rmdir (not rm -rf) only succeeds if truly empty, so it
     # never touches a token dir that still has another version staged.
@@ -78,7 +78,7 @@ discover_devicetreedir
 
 # Write this root's entry. apt/dpkg only ever touch the booted root, so emit ONLY its entry: match
 # the booted root to a profile line for its title/overlays, else treat it as a clone (title = name).
-CUR_SUBVOL="$(current_subvol)"
+CUR_SUBVOL="$(booted_subvol)"
 [ -n "$CUR_SUBVOL" ] || die "cannot determine current root subvol (findmnt)"
 
 # kernel + initrd from this root's own /usr/lib/modules/<ver>/, else /boot (resolve_kernel_paths)

--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -243,7 +243,8 @@ compute_base_opts() {
     BASE_OPTS="$(trim "$BASE_OPTS")"
     # rewrite the shipped cmdline's build-time root=UUID to the fs we install onto, so a _stock
     # received onto a device with a different btrfs UUID still boots.
-    _fsuuid="$(booted_fsuuid)"
+    # the filesystem the entry will boot from, which under -d is not the one we are running
+    _fsuuid="${TARGET_FSUUID:-$(booted_fsuuid)}"
     [ -n "$_fsuuid" ] && BASE_OPTS="$(printf '%s' " $BASE_OPTS " | sed "s/ root=UUID=[^ ]*/ root=UUID=$_fsuuid/")"
     BASE_OPTS="$(trim "$BASE_OPTS")"
     # Pin systemd.machine_id= only when entries are named after the machine-id (no-op otherwise).

--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -28,8 +28,15 @@ has_config() { [ -f "$KCONFIG" ] && grep -q "^CONFIG_$1=[ym]" "$KCONFIG"; }
 # Last rootflags=subvol= value in a cmdline/options string (empty if none).
 subvol_of() { printf '%s' "$1" | tr ' ' '\n' | sed -n 's/^rootflags=subvol=//p' | tail -n1; }
 
-# BLS sort-key from os-release (IMAGE_ID, else ID); empty if no os-release.
-os_sort_key() { [ -r /etc/os-release ] && ( . /etc/os-release; printf '%s' "${IMAGE_ID:-$ID}" ) || :; }
+# BLS sort-key from os-release (IMAGE_ID, else ID); empty if the root has no os-release.
+# $1 = mounted root to describe (default /). Reads the TARGET's os-release and nothing else: under
+# -d the running root is a different image entirely, and in a recovery boot its ID is the recovery
+# system's, so borrowing it would put the wrong name on the entry rather than no name at all.
+os_sort_key() {
+    _osr="${1:-}/etc/os-release"
+    [ -r "$_osr" ] || { log "no os-release in ${1:-/}, entry gets no sort-key"; return 0; }
+    ( . "$_osr"; printf '%s' "${IMAGE_ID:-$ID}" ) || :
+}
 
 # Set DTB_DIR + DTB_DIRS (primary dir + modules fallback) for the current $KERNEL_VERSION.
 set_dtb_dirs() { DTB_DIR="/usr/lib/linux-image-$KERNEL_VERSION"; DTB_DIRS="$DTB_DIR /usr/lib/modules/$KERNEL_VERSION/dtb"; }
@@ -122,6 +129,14 @@ remove_root_entries() {  # $1 = subvol
 }
 
 # Base menu slot (900,800,700,... by flipper-profiles position) for the profile $1 belongs to.
+# Which profile list to read bands from: the target's own copy when it has one, else the running
+# root's. flipper_write_entry can be pointed at a filesystem we did not boot from, whose bands are
+# defined by its own list.
+target_profiles() {
+    if [ -f "${1:-}/etc/kernel/flipper-profiles" ]; then printf '%s' "$1/etc/kernel/flipper-profiles"
+    else printf '%s' "${PROFILES:-/etc/kernel/flipper-profiles}"; fi
+}
+
 # $1 is a btrfs-PARENT name. It anchors on an ACTUAL profile: the exact name (@Desktop) or its
 # golden base / snapshot (@Desktop_stock, @Desktop_<stamp>: profile name followed by '_'). A
 # hyphen-suffixed clone (@Desktop-2) must NOT match here, so origin_base_depth can walk THROUGH
@@ -333,14 +348,23 @@ flipper_write_entry() {
     _name="$1"; _snap="$2"; _origin="${3:-}"
     { [ -n "$_name" ] && [ -d "$_snap" ]; } || { echo "flipper-bls: usage: flipper_write_entry <name> <mounted-path>" >&2; return 1; }
     ENTRIES="${ENTRIES:-/boot/loader/entries}"
-    CONF_ROOT="${KERNEL_INSTALL_CONF_ROOT:-/etc/kernel}"
+    # The base cmdline (root=UUID and policy) belongs to the root being written, not to whatever
+    # is running. kernel-install still wins when it sets its own conf root. Without this, an entry
+    # written from a recovery boot came out with no root= at all, and so could not boot.
+    if [ -n "${KERNEL_INSTALL_CONF_ROOT:-}" ]; then CONF_ROOT="$KERNEL_INSTALL_CONF_ROOT"
+    elif [ -f "$_snap/etc/kernel/cmdline" ]; then CONF_ROOT="$_snap/etc/kernel"
+    else CONF_ROOT=/etc/kernel; fi
     MACHINE_ID=""; DEVICETREE=""; DEVICETREE_ENTRY=""
     # version from the target's OWN tree, so modules + dtbs are self-consistent
     KERNEL_VERSION="$(ls -1d "$_snap"/usr/lib/linux-image-* 2>/dev/null | sed 's,.*/linux-image-,,' | sort -V | tail -n1)"
     [ -n "$KERNEL_VERSION" ] || { echo "flipper-bls: no /usr/lib/linux-image-* inside $_name" >&2; return 1; }
     resolve_kconfig "$_snap"
     set_dtb_dirs
-    SORT_KEY="$(os_sort_key)"
+    SORT_KEY="$(os_sort_key "$_snap")"
+    # The band comes from the profile list, which lives INSIDE a profile, not in the /etc of
+    # whatever is running. Under -d the running root may have no list at all (recovery), and an
+    # empty band silently drops the sort prefix from the entry filename.
+    PROFILES="${PROFILES:-$(target_profiles "$_snap")}"
     ENTRY_TOKEN="$(make_token "$(clone_slot "$_snap" "$_origin")" "$_name")"
     mkdir -p "$ENTRIES" || { echo "flipper-bls: cannot create $ENTRIES" >&2; return 1; }
     compute_base_opts

--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -73,20 +73,18 @@ fdt_prefix() {  # $1 = options string -> "/<rootflags-subvol>" (or $FDT_SUBVOL_P
     return 0
 }
 
-# btrfs subvol of the current root (e.g. @Desktop); empty if not one. findmnt answers on a booted
-# system; in a chroot it can't, so fall back to the mount-agnostic btrfs subvolume show.
-current_subvol() {
+# Copies of flipper-btrfs.sh's booted_subvol/booted_fsuuid, kept byte-identical: kernel-install
+# sources this file without that one, so it needs its own. Keep the bodies in sync with it.
+booted_subvol() {
     _cs=$(findmnt -nro FSROOT / 2>/dev/null | sed 's,^/,,')
     [ -n "$_cs" ] || _cs=$(btrfs subvolume show / 2>/dev/null | sed -n '1{s,^/*,,;s,[[:space:]]*$,,;p}')
-    printf '%s\n' "$_cs"
+    printf '%s' "$_cs"
 }
 
-# btrfs FS UUID of the current root; empty if unknown. findmnt on a booted system, btrfs filesystem
-# show as the chroot-safe fallback (like current_subvol).
-current_fsuuid() {
+booted_fsuuid() {
     _fu=$(findmnt -nro UUID / 2>/dev/null)
     [ -n "$_fu" ] || _fu=$(btrfs filesystem show / 2>/dev/null | sed -n 's/.*[[:space:]]uuid:[[:space:]]*//p' | head -1)
-    printf '%s\n' "$_fu"
+    printf '%s' "$_fu"
 }
 
 # Remove loader entries whose options select SUBVOL and whose version == VERSION. Content-based
@@ -245,7 +243,7 @@ compute_base_opts() {
     BASE_OPTS="$(trim "$BASE_OPTS")"
     # rewrite the shipped cmdline's build-time root=UUID to the fs we install onto, so a _stock
     # received onto a device with a different btrfs UUID still boots.
-    _fsuuid="$(current_fsuuid)"
+    _fsuuid="$(booted_fsuuid)"
     [ -n "$_fsuuid" ] && BASE_OPTS="$(printf '%s' " $BASE_OPTS " | sed "s/ root=UUID=[^ ]*/ root=UUID=$_fsuuid/")"
     BASE_OPTS="$(trim "$BASE_OPTS")"
     # Pin systemd.machine_id= only when entries are named after the machine-id (no-op otherwise).

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -25,14 +25,14 @@ root_is_btrfs() { [ "$(findmnt -no FSTYPE / 2>/dev/null)" = btrfs ]; }
 # The subvolume mounted at / (e.g. @Desktop), empty if there is none. findmnt cannot answer inside a
 # chroot, so fall back to asking btrfs. flipper-bls.sh keeps its own copy: kernel-install hooks
 # source that file without this one.
-current_subvol() {
+booted_subvol() {
     _cs=$(findmnt -nro FSROOT / 2>/dev/null | sed 's,^/,,')
     [ -n "$_cs" ] || _cs=$(btrfs subvolume show / 2>/dev/null | sed -n '1{s,^/*,,;s,[[:space:]]*$,,;p}')
     printf '%s' "$_cs"
 }
 
-# btrfs FS UUID of the mounted root, empty if unknown. Same reasoning as current_subvol.
-current_fsuuid() {
+# btrfs FS UUID of the mounted root, empty if unknown. Same reasoning as booted_subvol.
+booted_fsuuid() {
     _fu=$(findmnt -nro UUID / 2>/dev/null)
     [ -n "$_fu" ] || _fu=$(btrfs filesystem show / 2>/dev/null | sed -n 's/.*[[:space:]]uuid:[[:space:]]*//p' | head -1)
     printf '%s' "$_fu"
@@ -43,6 +43,12 @@ current_fsuuid() {
 # its own out, its -y means something more specific and its help column is wider.
 HELP_YES="  -y,--yes    assume yes to prompts (non-interactive)"
 HELP_DEVICE="  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)"
+
+# UUID of the filesystem being operated on, empty if blkid cannot say. Never falls back to the
+# booted root's: under -d that is a different filesystem, so a fallback would hand every caller the
+# wrong UUID exactly when it cannot check. Callers that want the booted root when this is empty say
+# so themselves (flipper-bls.sh does, for the cmdline root=UUID).
+target_fsuuid() { blkid -o value -s UUID "${ROOTDEV:-}" 2>/dev/null; }
 
 # Non-interactive switch for confirm(): set to 1 by -y/--yes, or via the environment
 # (ASSUME_YES=1 <tool> ...) so the tools can run unattended from scripts.
@@ -151,6 +157,10 @@ mount_top() {
     TOP=$(mktemp -d /run/flipper-btrfs.mnt.XXXXXX 2>/dev/null || mktemp -d)
     _err=$(mount -o subvolid=5 "$ROOTDEV" "$TOP" 2>&1) || die "Mount failed: $_err"
 }
+
+# Best-effort was not good enough: on a signal the children (btrfs send/receive, zstd) are still
+# dying, so the first umount can lose the race with EBUSY and the top-level mount leaks for the rest
+# of the uptime. Retry briefly, then detach lazily so it goes away once the last reference does.
 top_cleanup() {
     # the holder line outlives the flock the kernel drops for us, so blank it: no waiter should read
     # a pid gone for days. Subshell: a failed '>' on the special builtin ':' exits the shell outright,
@@ -185,7 +195,26 @@ resolve_rel() {
 get() { printf '%s\n' "$1" | awk -v k="$2" -F':[[:space:]]+' 'index($0,k){print $2; exit}'; }
 
 subvol_id() { get "$(btrfs subvolume show "$1" 2>/dev/null)" "Subvolume ID"; }
-booted_id() { subvol_id /; }
+
+# True only when the filesystem being operated on is PROVEN to be another one than we booted from.
+# Unprovable counts as the same: a probe that cannot answer must not disarm the refusals below.
+target_fs_differs() {  # needs ROOTDEV
+    root_is_btrfs || return 0
+    _bu=$(booted_fsuuid); _tu=$(target_fsuuid)
+    [ -n "$_bu" ] && [ -n "$_tu" ] && [ "$_bu" != "$_tu" ]
+}
+
+# The profile running from the filesystem being operated on, empty when nothing runs from it: ids
+# and names repeat across filesystems, so a match there would be coincidence.
+target_running_id()     { target_fs_differs && return 0; subvol_id / ; }
+target_running_subvol() { target_fs_differs && return 0; booted_subvol ; }
+
+# True if subvolume id $1 is the running profile's $2 (from target_running_id). An empty running id
+# never matches: it means another filesystem, where '=' alone would pair it with any lookup that also
+# came back empty, such as a path that is not a subvolume at all.
+is_running_id() {  # $1 = candidate id  $2 = target_running_id
+    [ -n "$2" ] && [ "$1" = "$2" ]
+}
 
 # True if the subvolume at $1 is read-only.
 is_ro() {

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -273,6 +273,21 @@ align_table() {
     }' "$1"
 }
 
+# Run a flipper-bls.sh function against the filesystem being operated on: its entries directory and
+# its UUID for the cmdline, not the running root's under -d. Subshell so the library's die cannot
+# abort us; a failure warns and returns, as the boot entry is never the point of the operation.
+with_bls() {  # $1 = what fails, for the warning; rest = function and arguments. Needs TOP
+    _what=$1; shift
+    _lib=/usr/lib/flipper-bls.sh
+    if [ -r "$_lib" ]; then
+        ( ENTRIES="$TOP/boot/loader/entries"; TARGET_FSUUID="$(target_fsuuid)"; . "$_lib"; "$@" ) \
+            || echo "Warning: $_what" >&2
+    else
+        echo "Warning: $_lib not found; $_what" >&2
+    fi
+    return 0
+}
+
 # Stamp a _stock's factory-origin marker (/etc/profile_origin) so migrate-profile can find a
 # profile's base after the btrfs parent chain is broken by deletions. Records the stock's own
 # name and its build id (BUILD_GIT from os-release). Profiles snapshotted from the stock inherit

--- a/overlays/usr/local/sbin/btrfs-show-space
+++ b/overlays/usr/local/sbin/btrfs-show-space
@@ -47,7 +47,7 @@ rows=$(mktemp)
 list=$(mktemp)
 TOP_TMPFILES="$rows $list"
 mount_top
-cur_id=$(booted_id)
+cur_id=$(target_running_id)
 
 echo "== filesystem =="
 btrfs filesystem usage -T "$TOP"
@@ -65,7 +65,7 @@ row() {  # $1=display name  $2=fs path  -> append a TSV row
         ref_h="-"
     fi
     id=$(subvol_id "$2")
-    mark=""; [ -n "$cur_id" ] && [ "$id" = "$cur_id" ] && mark="<- booted"
+    mark=""; is_running_id "$id" "$cur_id" && mark="<- booted"
     printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$mark" "$(human "$exc")" "$ref_h" "$(human "$tot")" >> "$rows"
 }
 

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -128,21 +128,14 @@ rm -f "$tgt/var/lib/dbus/machine-id" 2>/dev/null || true
 # entry uses; swap every occurrence for the live one.
 fst="$tgt/etc/fstab"
 if [ -f "$fst" ]; then
-    cur=$(current_fsuuid)
+    cur=$(target_fsuuid)
     old=$(awk '$2=="/"{for(i=1;i<=NF;i++) if($i ~ /^UUID=/){sub(/^UUID=/,"",$i); print $i; exit}}' "$fst")
     [ -n "$cur" ] && [ -n "$old" ] && [ "$cur" != "$old" ] && { sed -i "s/$old/$cur/g" "$fst"; echo "fstab: rewrote fs UUID $old -> $cur"; }
 fi
 
-# BLS entry + /etc/kernel/entry-token via flipper-bls.sh, in a subshell so its die can't abort
-# us. Pass the SOURCE as origin hint so the root lands in that profile's band if parent_uuid is
-# left dangling.
-lib=/usr/lib/flipper-bls.sh
-if [ -r "$lib" ]; then
-    ( . "$lib"; flipper_write_entry "$rel" "$tgt" "$src_rel" ) \
-        || echo "Warning: Boot entry not created for $rel" >&2
-else
-    echo "Warning: $lib not found; no boot entry created for $rel" >&2
-fi
+# BLS entry + /etc/kernel/entry-token. Pass the SOURCE as origin hint so the root lands in that
+# profile's band if parent_uuid is left dangling.
+with_bls "boot entry not created for $rel" flipper_write_entry "$rel" "$tgt" "$src_rel"
 
 if [ "$move" = 1 ]; then verb="moved"; else verb="created"; fi
 if [ "$existed" = 1 ]; then

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -64,9 +64,11 @@ src="$TOP/$src_rel"
 
 # dest -> exact top-level name (default: booted root)
 case "$dest" in
-    current|booted|"") root_is_btrfs || die "No booted profile to default <@dest> to; pass an explicit <@dest> (e.g. @Desktop-2)"
-                       rel=$(current_subvol)
-                       [ -n "$rel" ] || die "Cannot determine booted subvolume" ;;
+    # 'current' means the profile we booted from, which does not exist on another filesystem.
+    # Resolving it there would take its NAME and replace whatever happens to be called that on the
+    # target, moving the user's profile aside.
+    current|booted|"") rel=$(target_running_subvol)
+                       [ -n "$rel" ] || die "No booted profile on $ROOTDEV to default <@dest> to; pass an explicit <@dest> (e.g. @Desktop-2)" ;;
     *)                 rel=$dest; validate_profile_name "$rel" ;;
 esac
 is_reserved_subvol "$rel" && die "Refusing to write reserved subvolume: $rel"

--- a/overlays/usr/local/sbin/create-snapshot
+++ b/overlays/usr/local/sbin/create-snapshot
@@ -41,7 +41,7 @@ if [ -n "$tag" ]; then
 fi
 # name after /'s source subvol, e.g. @Minimal_2026-06-29_19-52-31 (leaf only: booting a
 # snapshot must not nest the new name under @snapshots/@snapshots/)
-src=$(current_subvol); src=${src##*/}
+src=$(booted_subvol); src=${src##*/}
 [ -n "$src" ] || die "Cannot determine the source subvolume of /"
 name="${src}_$(stamp)${tag:+_$tag}"
 

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -66,9 +66,4 @@ btrfs subvolume delete "$TOP/$rel" >/dev/null
 echo "Deleted '$rel'"
 
 # drop this profile's BLS entries + /boot/<token>/ staging
-lib=/usr/lib/flipper-bls.sh
-if [ -r "$lib" ]; then
-    ( . "$lib"; remove_root_entries "$rel" ) || echo "Warning: Entries/staging not fully removed for $rel" >&2
-else
-    echo "Warning: $lib not found; boot entry/staging not removed for $rel" >&2
-fi
+with_bls "entries/staging not fully removed for $rel" remove_root_entries "$rel"

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -47,13 +47,13 @@ esac
 case "${arg##*/}" in *_stock) die "Top-level profiles only; for a golden base use: delete-snapshot $arg" ;; esac
 
 mount_top
-cur_id=$(booted_id)
+cur_id=$(target_running_id)
 [ -e "$TOP/$arg" ] || die "No such profile: $arg (see list-profiles)"
 rel=$arg
 is_reserved_subvol "$rel" && die "Refusing to delete reserved subvolume: $rel"
 info=$(btrfs subvolume show "$TOP/$rel" 2>/dev/null) || die "Not a profile: $rel"
 tgt_id=$(get "$info" "Subvolume ID")
-[ -n "$cur_id" ] && [ "$tgt_id" = "$cur_id" ] && die "Refusing to delete the currently booted profile ($rel)"
+is_running_id "$tgt_id" "$cur_id" && die "Refusing to delete the currently booted profile ($rel)"
 
 is_ro=0; case "$(get "$info" "Flags")" in *readonly*) is_ro=1 ;; esac
 

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -39,10 +39,12 @@ TOP_TMPFILES="$map $rows"
 mount_top
 build_uuid_map "$TOP" "$map"
 
-cur=$(btrfs subvolume show / 2>/dev/null) || cur=
-cur_id=$(get "$cur" "Subvolume ID")
-cur_path=$(printf '%s\n' "$cur" | head -n1)
-[ -n "$cur_path" ] && echo "Currently booted profile: $cur_path (id ${cur_id:-?})"
+cur_id=$(target_running_id); cur_subvol=$(target_running_subvol)
+if [ -n "$cur_id" ]; then
+    echo "Currently booted profile: ${cur_subvol:-?} (id $cur_id)"
+else
+    echo "Listing $ROOTDEV, which is not the filesystem you booted from"
+fi
 echo
 
 emit() {  # $1=display name  $2=fs path
@@ -55,7 +57,7 @@ emit() {  # $1=display name  $2=fs path
         *.old_*) kind=old ;;
         *)       kind=profile ;;
     esac
-    mark=""; [ -n "$cur_id" ] && [ "$id" = "$cur_id" ] && mark="<- booted"
+    mark=""; is_running_id "$id" "$cur_id" && mark="<- booted"
     printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$mark" "$kind" "${id:-?}" "${otime:-?}" "$flags" "$parent" >> "$rows"
 }
 

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -84,7 +84,8 @@ ask_tty() {
 # --- interactive resolution of leftover sidecars ---------------------------------------------
 resolve_mode() {
     _p=$1
-    case "$_p" in current|booted|"") root_is_btrfs || die "no booted profile to default to; name the profile explicitly"; _p=$(current_subvol) ;; esac
+    case "$_p" in current|booted|"") _p=$(target_running_subvol)
+        [ -n "$_p" ] || die "no booted profile on $ROOTDEV to default to; name the profile explicitly" ;; esac
     case "$_p" in *..*|/*|*/*) die "Invalid profile: $_p" ;; esac
     [ -d "$TOP/$_p" ] || die "No such profile: $_p"
     _root="$TOP/$_p"; _dstname=$_p; _srcname=${2:-}
@@ -169,7 +170,9 @@ esac
 
 [ -d "$TOP/$src" ] || die "No such profile: $src"
 case "$dst" in
-    current|booted|"") root_is_btrfs || die "no booted profile to default <@dst> to; pass an explicit <@dst>"; dst=$(current_subvol); [ -n "$dst" ] || die "cannot determine booted profile" ;;
+    # the booted profile's NAME on another filesystem is whatever happens to be called that there
+    current|booted|"") dst=$(target_running_subvol)
+                       [ -n "$dst" ] || die "no booted profile on $ROOTDEV to default <@dst> to; pass an explicit <@dst>" ;;
     *)                 case "$dst" in *..*|/*|*/*) die "Invalid dst: $dst (top-level name)" ;; esac ;;
 esac
 [ -d "$TOP/$dst" ] || die "No such profile: $dst"
@@ -177,8 +180,8 @@ esac
 is_reserved_subvol "$src" && die "src is a reserved subvolume"
 is_reserved_subvol "$dst" && die "dst is a reserved subvolume"
 
-booted=$(current_subvol)
-if [ "$apply" = 1 ] && [ "$dst" = "$booted" ] && [ "$force" != 1 ]; then
+cur_subvol=$(target_running_subvol)
+if [ "$apply" = 1 ] && [ "$dst" = "$cur_subvol" ] && [ "$force" != 1 ]; then
     die "won't modify '$dst': it is the profile you are booted into.
 Boot into another profile and run this again, or pass --force to override."
 fi

--- a/overlays/usr/local/sbin/receive-snapshot
+++ b/overlays/usr/local/sbin/receive-snapshot
@@ -44,14 +44,34 @@ have_pv=0; command -v pv >/dev/null 2>&1 && have_pv=1
 
 set_lock
 mount_top
+# the same figure bounds the compressed prefix we keep and the decompressed prefix we read out of
+# it: zstd never expands, so this many bytes in yield at least this many bytes out. The name is a
+# few hundred bytes in, in the stream's first command, so this is already far more than we need.
+PEEK_BYTES=262144
+stream_name() {
+    zstd -dc "$1" 2>/dev/null | head -c "$PEEK_BYTES" | btrfs receive --dump 2>/dev/null \
+        | awk '/^(subvol|snapshot)[[:space:]]/ { n=$2; sub(/^\.\//,"",n); print n; exit }'
+}
+
 # route a _stock golden base into @stock-snapshots; every other snapshot into @snapshots. The stream
-# carries the subvol name; peek it from a file (a pipe cannot be peeked, so it stays in @snapshots).
+# carries the subvol name; peek it from a file. A pipe cannot be peeked, so a stream arriving on
+# stdin lands in @snapshots first and is moved afterwards, once the name is on disk to read.
 target="$TOP/@snapshots"
+PEEK=""
 if [ "$src" != "-" ]; then
-    name=$(zstd -dc "$src" 2>/dev/null | head -c 262144 | btrfs receive --dump 2>/dev/null \
-           | awk '/^(subvol|snapshot)[[:space:]]/ { n=$2; sub(/^\.\//,"",n); print n; exit }')
-    case "$name" in ?*_stock) target="$TOP/@stock-snapshots" ;; esac
+    name=$(stream_name "$src")
+else
+    # A pipe cannot be rewound, so keep the first chunk and replay it ahead of the rest. Fixing
+    # it afterwards is not an option: clearing ro to move a received subvolume drops
+    # received_uuid, which is what btrfs matches a later incremental against.
+    PEEK=$(mktemp); TOP_TMPFILES="${TOP_TMPFILES:-} $PEEK"
+    # 9>&-: this blocks until the peer sends the chunk or closes, and it inherits the lock
+    # descriptor, so a kill while it waits would leave it holding the lock with no owner
+    head -c "$PEEK_BYTES" > "$PEEK" 9>&-
+    name=$(stream_name "$PEEK")
 fi
+case "$name" in ?*_stock) target="$TOP/@stock-snapshots" ;; esac
+[ -n "$name" ] && echo "Stream carries $name" >&2
 [ -d "$target" ] || die "${target##*/} not found at top level"
 # btrfs receive refuses to replace an existing subvolume, and it says so only once the stream has
 # been transferred. Where the name was read up front, answer it here instead.
@@ -64,11 +84,15 @@ before=$(btrfs subvolume list -o "$target" 2>/dev/null | wc -l)
 # file src -> pv shows %/ETA; silence zstd so the two don't collide on one line.
 # No pipefail in POSIX sh, so the pipeline's status is btrfs receive's (the meaningful end).
 set +e
+# 9>&- for the same reason as the peek above: nothing in this pipeline needs the lock descriptor,
+# and anything that survives us must not keep the lock alive
+{
 if   [ "$have_pv" = 1 ] && [ "$src" != "-" ]; then pv "$src" | zstd -dc --no-progress | btrfs receive "$target"
-elif [ "$have_pv" = 1 ];                      then zstd -dc --no-progress | pv -btr   | btrfs receive "$target"
 elif [ "$src" != "-" ];                       then zstd -dc "$src"        | btrfs receive "$target"
-else                                               zstd -dc               | btrfs receive "$target"
+elif [ "$have_pv" = 1 ];                      then { cat "$PEEK"; cat; } | zstd -dc --no-progress | pv -btr | btrfs receive "$target"
+else                                               { cat "$PEEK"; cat; } | zstd -dc | btrfs receive "$target"
 fi
+} 9>&-
 rc=$?
 set -e
 if [ "$rc" != 0 ]; then

--- a/overlays/usr/local/sbin/rename-profile
+++ b/overlays/usr/local/sbin/rename-profile
@@ -57,12 +57,7 @@ mv "$TOP/$old" "$TOP/$new"
 echo "Renamed profile '$old' -> '$new'"
 
 # drop old name's BLS entry + staging, reissue for <@new>; parent chain intact -> right band
-lib=/usr/lib/flipper-bls.sh
-if [ -r "$lib" ]; then
-    ( . "$lib"; remove_root_entries "$old"; flipper_write_entry "$new" "$TOP/$new" ) \
-        || echo "Warning: Boot entry not updated for $new" >&2
-else
-    echo "Warning: $lib not found; boot entry not updated for $new" >&2
-fi
+with_bls "old boot entry not removed for $old" remove_root_entries "$old"
+with_bls "boot entry not created for $new" flipper_write_entry "$new" "$TOP/$new"
 
 echo "Reboot and pick '$new' from the boot menu to use it"

--- a/overlays/usr/local/sbin/rename-profile
+++ b/overlays/usr/local/sbin/rename-profile
@@ -43,13 +43,13 @@ is_reserved_subvol "$new" && die "Refusing to use reserved name: $new"
 
 set_lock
 mount_top
-cur_id=$(booted_id)
+cur_id=$(target_running_id)
 [ -e "$TOP/$old" ] || die "No such profile: $old (see list-profiles)"
 [ -e "$TOP/$new" ] && die "Target already exists: $new"
 is_reserved_subvol "$old" && die "Refusing to rename reserved subvolume: $old"
 info=$(btrfs subvolume show "$TOP/$old" 2>/dev/null) || die "Not a profile: $old"
 old_id=$(get "$info" "Subvolume ID")
-[ -n "$cur_id" ] && [ "$old_id" = "$cur_id" ] \
+is_running_id "$old_id" "$cur_id" \
     && die "Refusing to rename the currently booted profile ($old); boot into another profile first"
 
 # top-level dir entry: mv keeps UUID + btrfs parent


### PR DESCRIPTION
Under `-d/--device` the tools operate on a filesystem we did not boot
from, and in six different places they consulted the running root for a fact that belongs to the
target. A recovery boot is the only environment where those two diverge enough to notice, which is
why none of this surfaced earlier.

**Subvolume ids.** Five tools compared ids, or names, with the booted profile's. The two
filesystems hand out 256, 257 and so on, so a collision is a matter of time. Demonstrated by
creating profiles on a loop filesystem until one landed on the booted profile's id 265, at which
point `delete-profile -d` refused to delete it, reporting it as the profile you are booted into.
`target_running_id()`/`target_running_subvol()` now answer the question once, comparing the target's filesystem UUID with the
booted root's, and only a proven mismatch empties it, so a probe that cannot answer leaves the
refusals armed. The booted root's own helpers are renamed `booted_*` so they cannot be mistaken
for the target's.

**The entries directory.** `flipper-bls.sh` defaults to the absolute `/boot/loader/entries`, right
on a booted system and wrong under `-d`. In recovery `/boot` is an empty directory on the RAM
rootfs, so a profile created there got its entry written to RAM and was left unbootable after the
next reboot, while a profile deleted there kept its real entry on disk. The three tools that mount
the top level now state where the entries live, through one `with_bls()` helper rather than three
copies of the same block; the lib default is untouched for the kernel-install hooks.

**The menu band.** `profile_base_nn` reads the profile list, which lives inside a profile rather
than in the running system's `/etc`. Recovery has none, so every name resolved to an empty band and
the token silently lost its sort prefix: `flipperos-Desktop` where the build wrote
`900-flipperos-Desktop`, which also reorders the menu, since a leading letter sorts above a digit.

**The sort key.** `os_sort_key` read the running `/etc/os-release`, so an entry written from
recovery described the recovery system. It now reads the target's, which reproduces what the build
writes for every entry.

**The filesystem UUID.** `create-profile` rewrites a profile's fstab, and `flipper-bls` rewrites the
cmdline's `root=UUID`, so a root built elsewhere still boots here. Both read `current_fsuuid()`,
which answers for the booted root, so both silently did nothing under `-d`. Landing the 775 build's
packs on a 777 filesystem from recovery showed the cost: the restored profile kept the build
machine's UUID in all five fstab entries, and its entry had no `root=` at all.

**The base cmdline.** `compute_base_opts` read `$CONF_ROOT/cmdline` from the running root, absent in
recovery, so `BASE_OPTS` came out empty: no `root=`, no `audit=0`, no console policy. It now prefers
the target's own copy, with `KERNEL_INSTALL_CONF_ROOT` still winning for the hooks.

Plus one usability fix in the same area: **a piped golden base is now routed like a file.** The
destination was chosen by peeking the subvolume name out of the stream, which only worked for a
file, so a `_stock` arriving over ssh (the form this tool's own examples show) was filed as an
ordinary restore point, where `migrate-profile` never looks for an ancestor. Buffering the head of
stdin makes the name readable and the buffer is replayed ahead of the rest. Relocating afterwards is
not possible: a received subvolume is read-only, `mv` refuses, and clearing `ro` to force it drops
`received_uuid`, which is what btrfs matches a later incremental's parent on.

## Testing

All on hardware, in a recovery boot, since that is the only place these paths differ: 97 checks
across four suites, plus a dedicated run that lands the real 775 build's packs on a 777 filesystem
and checks the restored profile end to end. After the fixes that run reports the stream routed to
`@stock-snapshots`, the incremental following its parent, the fstab rewritten across every entry,
and an entry reading `root=UUID=<this filesystem> audit=0 console=tty1 ... rootflags=subvol=@Desktop-775`.

Also covered here for the first time: `create-profile -m/--move`, proven to preserve `parent_uuid`
with a control showing a plain copy re-parents instead, and the full send-out, receive-back, promote
cycle.



