### PR TITLE
btrfs tools: clearer aside names, warnings and errors

### DIFF
--- a/overlays/usr/local/sbin/btrfs-maintenance
+++ b/overlays/usr/local/sbin/btrfs-maintenance
@@ -62,16 +62,60 @@ if [ -n "${ROOTDEV:-}" ] || ! root_is_btrfs; then mount_top; MNT=$TOP; fi
 do_dedup() {
     need_cmd duperemove
     [ -n "${TOP:-}" ] || mount_top
-    HASHFILE=$TOP/@var-cache/.duperemove_hashes.db
+    # @var-cache is where the hashfile belongs, so it survives between runs and is not itself
+    # deduped. It is only there on filesystems our image built, and -d/--device exists precisely
+    # for the others, where duperemove would otherwise fail with an opaque "Error opening db".
+    if [ -d "$TOP/@var-cache" ]; then
+        HASHFILE=$TOP/@var-cache/.duperemove_hashes.db
+    else
+        HASHFILE=$(mktemp -u)
+        TOP_TMPFILES="${TOP_TMPFILES:-} $HASHFILE"
+        echo "No @var-cache on this filesystem; keeping duperemove's hash db in $HASHFILE for this run only" >&2
+    fi
     _excl=""
     for _p in $(btrfs subvolume list -r "$TOP" | awk '{print $NF}'); do
         _excl="$_excl --exclude=$TOP/$_p"
     done
-    duperemove -dhr --hashfile="$HASHFILE" --exclude="$HASHFILE*" $_excl "$TOP" || die "Duperemove failed (rc=$?)"
+    # duperemove exits 22 with "No dedupe candidates found" when there is nothing to do, which is
+    # not a failure. Keep the output live and read the status separately, since a pipeline reports
+    # only the last command's.
+    _dlog=$(mktemp); _drc=$(mktemp)
+    TOP_TMPFILES="${TOP_TMPFILES:-} $_dlog $_drc"
+    { duperemove -dhr --hashfile="$HASHFILE" --exclude="$HASHFILE*" $_excl "$TOP" 2>&1 || echo $? > "$_drc"; } | tee "$_dlog"
+    _rc=0
+    if [ -s "$_drc" ]; then _rc=$(cat "$_drc"); fi
+    if [ "$_rc" != 0 ]; then
+        if [ "$_rc" = 22 ] && grep -q 'No dedupe candidates found' "$_dlog"; then
+            echo "Nothing to dedup here: duperemove found no candidates, so no space was reclaimed"
+        else
+            die "Duperemove failed (rc=$_rc)"
+        fi
+    fi
 }
 
 [ "$lock" = 1 ]     && set_lock
-[ "$do_scrub" = 1 ] && btrfs scrub start -B $scrub_ro "$MNT"
+# A scrub that reports errors ended the run here with nothing said, so 'all' silently did no dedup
+# and no balance. Stopping is right, since both rewrite extents and that is not what a filesystem
+# with unfixed errors needs, but it has to be stated.
+if [ "$do_scrub" = 1 ] && ! btrfs scrub start -B $scrub_ro "$MNT"; then
+    if [ "$dedup" = 1 ] || [ "$balance" = 1 ]; then
+        die "Scrub failed or reported errors, so dedup and balance were not run: both rewrite extents, which a filesystem with unfixed errors does not need. Try 'btrfs-maintenance fix', then run this again"
+    fi
+    die "Scrub failed or reported errors on $MNT"
+fi
 [ "$dedup" = 1 ]    && do_dedup
-[ "$balance" = 1 ]  && btrfs balance start -dusage=20 -musage=10 "$MNT"
+if [ "$balance" = 1 ]; then
+    # A balance needs somewhere to move chunks to. On a nearly full filesystem btrfs reports
+    # ENOSPC through the kernel log and leaves the caller with "try dmesg | tail", so say it here.
+    if ! _berr=$(btrfs balance start -dusage=20 -musage=10 "$MNT" 2>&1); then
+        printf '%s\n' "$_berr" >&2
+        case "$_berr" in
+            *"No space left"*|*ENOSPC*|*enospc*) die "Balance needs free space to move chunks into, and this filesystem has too little; free some and retry" ;;
+        esac
+        if dmesg 2>/dev/null | tail -40 | grep -qi 'enospc errors during balance'; then
+            die "Balance hit ENOSPC (kernel log): too little free space to move chunks; free some and retry"
+        fi
+        die "Balance failed"
+    fi
+fi
 exit 0

--- a/overlays/usr/local/sbin/btrfs-show-space
+++ b/overlays/usr/local/sbin/btrfs-show-space
@@ -1,7 +1,7 @@
 #!/bin/sh
 # btrfs-show-space [-q|--quick] - btrfs usage + per-root-subvolume space.
 # (-q/--quick skips the compsize REFERENCED column, one less extent-walk per subvol.)
-# Lists EVERY subvolume: profile roots and @.old_* leftovers, the snapshots under @snapshots,
+# Lists EVERY subvolume: profile roots and @_old_* leftovers, the snapshots under @snapshots,
 # the _stock bases under @stock-snapshots, and the shared @home / @var-* / boot.
 #   UNIQUE     - data only this subvolume holds; freed if you delete IT ALONE,
 #                others kept (btrfs fi du, exact, uncompressed)
@@ -70,7 +70,7 @@ row() {  # $1=display name  $2=fs path  -> append a TSV row
 }
 
 # collect EVERY subvolume (cheap), then measure with progress: each row walks extents (slow on
-# flash). btrfs subvolume list gives top-relative paths: profile roots + @.old_*, the nested
+# flash). btrfs subvolume list gives top-relative paths: profile roots + @_old_*, the nested
 # @snapshots/* and @stock-snapshots/* children, and the shared @home / @var-* / boot.
 btrfs subvolume list "$TOP" 2>/dev/null | sed -n 's/.* path //p' | sort | while read -r p; do
     printf '%s\t%s\n' "$p" "$TOP/$p" >> "$list"

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -75,14 +75,25 @@ is_reserved_subvol "$rel" && die "Refusing to write reserved subvolume: $rel"
 [ "$rel" = "$src_rel" ] && die "Dest and source are the same subvolume"
 
 existed=0; [ -e "$TOP/$rel" ] && existed=1
+# Replacing the profile we are booted from is allowed on purpose (it is how a profile is reset to
+# a _stock), but the running system keeps using the copy moved aside until a reboot, so say so
+# before doing it and warn again afterwards.
+replacing_booted=0
+# ids are per-filesystem, so 265 here and 265 on a target reached through -d are unrelated, and
+# comparing them claims a reboot is needed for a profile the running system never used.
+cur_id=$(target_running_id)
+if [ "$existed" = 1 ] && is_running_id "$(subvol_id "$TOP/$rel")" "$cur_id"; then
+    replacing_booted=1
+fi
 if [ "$move" = 1 ]; then
     how="by MOVING '$src_name' into it (source consumed, parent preserved)"
 else
     how="with a writable copy of '$src_name'"
 fi
 if [ "$existed" = 1 ]; then
-    confirm "$(printf "Replace existing profile '%s' %s on %s?\nThe current '%s' is kept as %s_old_<ts>." \
-        "$rel" "$how" "$ROOTDEV" "$rel" "$rel")"
+    confirm "$(printf "Replace existing profile '%s' %s on %s?\nThe current '%s' is kept as %s_old_<ts>.%s" \
+        "$rel" "$how" "$ROOTDEV" "$rel" "$rel" \
+        "$([ "$replacing_booted" = 1 ] && printf "\nThis is the profile you are booted from: the running system stays on the copy moved aside until you reboot.")")"
 else
     confirm "Create bootable profile '$rel' $how on $ROOTDEV?"
 fi
@@ -140,7 +151,14 @@ with_bls "boot entry not created for $rel" flipper_write_entry "$rel" "$tgt" "$s
 if [ "$move" = 1 ]; then verb="moved"; else verb="created"; fi
 if [ "$existed" = 1 ]; then
     echo "Profile '$rel' $verb from '$src_name' (writable); previous kept as ${aside##*/}"
-    echo "Reboot into '$rel' to use it; remove the old copy later with:"
+    if [ "$replacing_booted" = 1 ]; then
+        echo "WARNING: REBOOT REQUIRED. '$rel' is the profile you are booted from, so the running" >&2
+        echo "         system is still the copy moved aside as ${aside##*/}; anything written" >&2
+        echo "         now lands there, not in the new '$rel'." >&2
+        echo "After rebooting, remove the old copy with:"
+    else
+        echo "Reboot into '$rel' to use it; remove the old copy later with:"
+    fi
     echo "  sudo delete-profile ${aside##*/}"
 else
     echo "Profile '$rel' $verb from '$src_name' (writable, boot entry added)"

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -13,7 +13,7 @@
 #             profile root while keeping its _stock parent.
 #
 # If <@dest> does not exist it is created and a BLS boot entry is generated for it. If it
-# already exists it is replaced and the previous copy kept as <@dest>.old_<ts> (recoverable;
+# already exists it is replaced and the previous copy kept as <@dest>_old_<ts> (recoverable;
 # its boot entry is refreshed in place, so no duplicate is left behind). The result is always
 # writable, even when <@source> is read-only.
 #
@@ -81,7 +81,7 @@ else
     how="with a writable copy of '$src_name'"
 fi
 if [ "$existed" = 1 ]; then
-    confirm "$(printf "Replace existing profile '%s' %s on %s?\nThe current '%s' is kept as %s.old_<ts>." \
+    confirm "$(printf "Replace existing profile '%s' %s on %s?\nThe current '%s' is kept as %s_old_<ts>." \
         "$rel" "$how" "$ROOTDEV" "$rel" "$rel")"
 else
     confirm "Create bootable profile '$rel' $how on $ROOTDEV?"
@@ -97,11 +97,11 @@ if [ "$move" = 1 ]; then
 fi
 if [ "$existed" = 1 ]; then
     # the stamp is per-second, so a second replace within the same second would land on an
-    # existing .old_<ts> and mv would nest the profile INSIDE it; take the next free name
+    # existing _old_<ts> and mv would nest the profile INSIDE it; take the next free name
     ts=$(stamp)
-    aside="$tgt.old_$ts"
+    aside="${tgt}_old_$ts"
     n=1
-    while [ -e "$aside" ]; do aside="$tgt.old_${ts}_$n"; n=$((n + 1)); done
+    while [ -e "$aside" ]; do aside="${tgt}_old_${ts}_$n"; n=$((n + 1)); done
     mv -T "$tgt" "$aside" || die "Could not move '$rel' aside; nothing changed"
 fi
 if [ "$move" = 1 ]; then

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -1,6 +1,6 @@
 #!/bin/sh
 # delete-profile <@profile> - delete a bootable PROFILE at the btrfs top level (as listed by
-# list-profiles): a profile root (@Desktop, @Desktop-2, ...) or an @<profile>.old_* leftover. Also
+# list-profiles): a profile root (@Desktop, @Desktop-2, ...) or an @<profile>_old_* leftover. Also
 # removes its BLS boot entry. For @snapshots restore points and _stock golden bases (under
 # @stock-snapshots), use delete-snapshot.
 # Confirms once; AGAIN if the target is read-only. Refuses layout subvolumes and the currently
@@ -17,7 +17,7 @@ Usage: delete-profile [-y|--yes] [-d|--device DEV] <@profile>
 $HELP_YES
 $HELP_DEVICE
   Delete a bootable profile at the btrfs top level (see list-profiles) and its boot
-  entry: a profile root or an @<profile>.old_* leftover. For restore points and
+  entry: a profile root or an @<profile>_old_* leftover. For restore points and
   _stock golden bases use delete-snapshot.
 EOF
 }

--- a/overlays/usr/local/sbin/delete-snapshot
+++ b/overlays/usr/local/sbin/delete-snapshot
@@ -2,7 +2,7 @@
 # delete-snapshot <@snapshots/@name | @stock-snapshots/@X_stock | @X_stock> - delete a read-only
 # restore-point SNAPSHOT under @snapshots or a _stock GOLDEN BASE under @stock-snapshots (as listed
 # by list-snapshots); a bare _stock name resolves under @stock-snapshots. Confirms once, plus again
-# for a golden base. For bootable profiles or .old leftovers, use delete-profile. Works via a
+# for a golden base. For bootable profiles or _old leftovers, use delete-profile. Works via a
 # subvolid=5 (top-level) mount.
 #
 # Examples:
@@ -17,7 +17,7 @@ Usage: delete-snapshot [-y|--yes] [-d|--device DEV] <@snapshots/@name | @stock-s
 $HELP_YES
 $HELP_DEVICE
   Delete a restore-point snapshot under @snapshots or a _stock golden base under
-  @stock-snapshots (see list-snapshots). For profiles or .old leftovers use delete-profile.
+  @stock-snapshots (see list-snapshots). For profiles or _old leftovers use delete-profile.
 EOF
 }
 

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -25,7 +25,8 @@ while [ $# -gt 0 ]; do
         -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
-        *)           echo "Error: unexpected argument: $1" >&2; usage >&2; exit 1 ;;
+        -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)           echo "Error: unexpected argument: $1 (this tool takes no arguments)" >&2; usage >&2; exit 1 ;;
     esac
     shift
 done

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -1,13 +1,13 @@
 #!/bin/sh
 # list-profiles - list the bootable PROFILES at the btrfs top level: the profile roots
-# (@Desktop, @Minimal, ...) and @<profile>.old_* leftovers from create-profile. KIND tags each
+# (@Desktop, @Minimal, ...) and @<profile>_old_* leftovers from create-profile. KIND tags each
 # (profile/old); PARENT is what it was snapshotted from (via Parent UUID). Names are top-level
 # paths (what create-profile/rename-profile/delete-profile take). The booted profile is marked
 # <- booted. For _stock golden bases and restore points, see list-snapshots.
 # Works via a subvolid=5 (top-level) mount.
 #
 # Example:
-#   list-profiles   # @SourceProfile / @DestinationProfile roots, _stock bases and .old leftovers
+#   list-profiles   # @SourceProfile / @DestinationProfile roots, _stock bases and _old leftovers
 set -eu
 . /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
 
@@ -15,7 +15,7 @@ usage() {
     cat <<EOF
 Usage: list-profiles [-d|--device DEV]
 $HELP_DEVICE
-  List bootable profiles at the btrfs top level: profile roots and @<profile>.old_*
+  List bootable profiles at the btrfs top level: profile roots and @<profile>_old_*
   leftovers. For _stock golden bases and restore points, see list-snapshots.
 EOF
 }
@@ -54,7 +54,9 @@ emit() {  # $1=display name  $2=fs path
     flags=$(get "$info" "Flags"); case "$flags" in *readonly*) flags=ro ;; *) flags=rw ;; esac
     parent=$(parent_of "$map" "$(get "$info" "Parent UUID")")
     case "$1" in
-        *.old_*) kind=old ;;
+        # _old_<ts> leftovers from create-profile; anchored on the stamp so a user-chosen
+        # name that merely contains "_old_" stays a profile ('.old_' is the legacy spelling)
+        *_old_[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_*|*.old_*) kind=old ;;
         *)       kind=profile ;;
     esac
     mark=""; is_running_id "$id" "$cur_id" && mark="<- booted"
@@ -62,7 +64,7 @@ emit() {  # $1=display name  $2=fs path
 }
 
 printf 'NAME\t\tKIND\tID\tCREATED\tRO\tPARENT\n' > "$rows"
-# top-level profile roots + @.old_* leftovers; skip shared/reserved subvols (@snapshots,
+# top-level profile roots + @_old_* leftovers; skip shared/reserved subvols (@snapshots,
 # @stock-snapshots, ...) so stocks (now nested under @stock-snapshots) are not listed here
 for d in "$TOP"/@*; do
     [ -e "$d" ] || continue

--- a/overlays/usr/local/sbin/list-snapshots
+++ b/overlays/usr/local/sbin/list-snapshots
@@ -24,7 +24,8 @@ while [ $# -gt 0 ]; do
         -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
-        *)           echo "Error: unexpected argument: $1" >&2; usage >&2; exit 1 ;;
+        -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)           echo "Error: unexpected argument: $1 (this tool takes no arguments)" >&2; usage >&2; exit 1 ;;
     esac
     shift
 done


### PR DESCRIPTION
Changes to what the tools tell you. Nothing about what they do to the filesystem changes.

- **Aside copies are named `_old_<ts>` instead of `.old_<ts>`**, because `validate_profile_name` rejects
  a leading dot, so the old name could not be passed back to the very tools meant to consume it.
  `list-profiles` classifies them with a pattern anchored on the timestamp shape, so a user-chosen name
  that merely contains `_old_` stays a profile.
- **`create-profile` warns that replacing the booted profile needs a reboot.** Doing so is deliberate,
  since it is how a profile is reset to its `_stock`, and unlike `delete-profile` and `rename-profile`
  there is no reason to refuse it. What was missing was the consequence: the running system keeps using
  the subvolume moved aside as `_old_<ts>`, so everything written afterwards lands in that copy. With
  `-y` this happened with no prompt at all. Verified end to end on hardware, including the reboot.
- **`list-profiles` and `list-snapshots` say `unknown option`** like the other ten tools rather than
  `unexpected argument`, and now tell a typo'd flag from a stray positional.
- **`btrfs-maintenance` explains its own failures** instead of relaying someone else's. A missing
  `@var-cache`, which is exactly the `-d` case, no longer surfaces duperemove's opaque
  `Error opening db ... rc=14` but falls back to a per-run temp hashfile; a balance on a full filesystem
  says it needs free space rather than leaving you with `try dmesg | tail`.

Split out of the closed #141. Only the combined final state was run on hardware; each
commit parses and defines the helpers it uses, and the stack tip is byte-identical to what
was tested.

