### PR TITLE
migrate-profile: hardening, and the defects device testing found

### DIFF
--- a/overlays/usr/lib/flipper-accountdb.awk
+++ b/overlays/usr/lib/flipper-accountdb.awk
@@ -1,0 +1,60 @@
+# flipper-accountdb.awk - per-entry 3-way merge of the account databases, run by migrate-profile as:
+#   awk -v LF=<list-fields> -f this base ours theirs
+# Keyed by the first field, not by line order, so an epoch bump cannot conflict and entries cannot
+# duplicate: untouched accounts follow the new base, user-added or changed ones ride along from src,
+# memberships are set-merged. LF = field numbers holding member lists (group=4, gshadow=3,4).
+BEGIN { FS=":"; nlf=split(LF,_l,","); for(i=1;i<=nlf;i++) islist[_l[i]+0]=1; fidx=0 }
+FNR==1 { fidx++ }
+{
+    if ($0=="") next
+    k=$1
+    if      (fidx==1) { Bl[k]=$0; hB[k]=1 }
+    else if (fidx==2) { Ol[k]=$0; hO[k]=1; if(!(k in os)){ os[k]=1; oord[++no]=k } }
+    else              { Tl[k]=$0; hT[k]=1; if(!(k in ts)){ ts[k]=1; tord[++nt]=k } }
+}
+END {
+    for (i=1;i<=no;i++) put(oord[i])
+    for (i=1;i<=nt;i++) if (!(tord[i] in os)) put(tord[i])
+}
+function put(k,   line) { line=decide(k); if (line!="") print line }
+function decide(k,   ib,io,it) {
+    ib=(k in hB); io=(k in hO); it=(k in hT)
+    if (!io && !it) return ""
+    if ( io && !it) { if (ib && Ol[k]==Bl[k]) return ""; return Ol[k] }
+    if (!io &&  it) { if (ib && Tl[k]==Bl[k]) return ""; return Tl[k] }
+    if (LF!="") return mergerec(k, ib)
+    if (Ol[k]==Tl[k]) return Ol[k]
+    if (!ib)          return Ol[k]
+    if (Tl[k]==Bl[k]) return Ol[k]
+    if (Ol[k]==Bl[k]) return Tl[k]
+    return Tl[k]
+}
+function mergerec(k, ib,   nb,no2,nt2,fb,fo,ft,fi,res) {
+    nb  = ib ? split(Bl[k], fb, ":") : 0
+    no2 =      split(Ol[k], fo, ":")
+    nt2 =      split(Tl[k], ft, ":")
+    for (fi=1; fi<=no2; fi++)
+        rf[fi] = (fi in islist) ? merge_members(fi, ib, fb, fo, ft, nb, no2, nt2) : fo[fi]
+    res=rf[1]; for(fi=2;fi<=no2;fi++) res=res ":" rf[fi]
+    delete rf
+    return res
+}
+function merge_members(fi, ib, fb, fo, ft, nb, no2, nt2,   i,m,res) {
+    delete inB; delete inO; delete inT; delete ordm; delete ordseen; nord=0
+    if (ib && nb >=fi) mark(fb[fi], inB)
+    if (      no2>=fi) mark(fo[fi], inO)
+    if (      nt2>=fi) mark(ft[fi], inT)
+    if (      no2>=fi) order(fo[fi])
+    if (      nt2>=fi) order(ft[fi])
+    if (ib && nb >=fi) order(fb[fi])
+    res=""
+    for (i=1;i<=nord;i++) {
+        m=ordm[i]
+        if ((m in inB) && !(m in inO)) continue
+        if ((m in inB) && !(m in inT)) continue
+        res = (res=="") ? m : res "," m
+    }
+    return res
+}
+function mark(s, arr,   n,a,i) { n=split(s,a,","); for(i=1;i<=n;i++) if(a[i]!="") arr[a[i]]=1 }
+function order(s,   n,a,i)     { n=split(s,a,","); for(i=1;i<=n;i++) if(a[i]!="" && !(a[i] in ordseen)){ ordseen[a[i]]=1; ordm[++nord]=a[i] } }

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -289,12 +289,10 @@ with_bls() {  # $1 = what fails, for the warning; rest = function and arguments.
 }
 
 # Stamp a _stock's factory-origin marker (/etc/profile_origin) so migrate-profile can find a
-# profile's base after the btrfs parent chain is broken by deletions. Records the stock's own
-# name and its build id (BUILD_GIT from os-release). Profiles snapshotted from the stock inherit
-# the file; matching later is by name + BUILD_GIT, not by uuid (uuid is cleared by snapshots).
-# $1 = the stock's mounted dir, $2 = the stock's name (e.g. @Desktop_stock).
+# profile's base after the btrfs parent chain is broken by deletions. Profiles snapshotted from
+# the stock inherit the file; matching later is by name, not by uuid (a snapshot clears that).
+# The name carries the build id (@Desktop_744_stock), so it identifies the exact base on its own.
+# $1 = the stock's mounted dir, $2 = the stock's name (e.g. @Desktop_744_stock).
 stamp_stock_origin() {
-    _bg=$( . "$1/etc/os-release" >/dev/null 2>&1; printf '%s' "${BUILD_GIT:-}" ) || _bg=
-    [ -n "$_bg" ] || _bg=-
-    printf 'origin_stock_name=%s\norigin_base_build=%s\n' "$2" "$_bg" > "$1/etc/profile_origin"
+    printf 'origin_stock_name=%s\n' "$2" > "$1/etc/profile_origin"
 }

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -208,6 +208,7 @@ migrate compares $src against the _stock it was built from to work out what you 
   receive-snapshot <path-to-${base#@}_pack.zst>"
 
 echo "migrate: $src -> $dst"
+[ -n "$cur_subvol" ] || echo "  filesystem: $ROOTDEV, which is not the one you booted from"
 echo "  ancestor: $base"
 echo "  merge engine: $merger"
 [ "$apply" = 1 ] && echo "  mode: APPLY" || echo "  mode: dry run"

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -283,6 +283,40 @@ manual_set() {  # $1 = subvol rel -> sorted list of manually-installed packages
     else : > "$WORK/auto"; fi
     comm -23 "$WORK/inst" "$WORK/auto"
 }
+
+# The version src has installed, so a recovered .deb can be matched against it. $1 = package.
+installed_ver() {
+    awk -v p="$1" 'BEGIN{RS="";FS="\n"} { n=""; v="";
+        for(i=1;i<=NF;i++){ if($i ~ /^Package: /) n=substr($i,10); else if($i ~ /^Version: /) v=substr($i,10) }
+        if(n==p){ print v; exit } }' "$TOP/$src/var/lib/dpkg/status" 2>/dev/null
+}
+
+# A hand-installed package is in no repository, but its .deb often still exists: src's apt cache, or
+# wherever the user put it. @home and @root are shared, so a .deb there is reachable from dst. No
+# depth limit, since one below a cutoff would be reported as missing.
+collect_debs() {
+    : > "$WORK/debs"
+    for _dir in "$TOP/$src/var/cache/apt/archives" "$TOP/@root" "$TOP/@home"; do
+        # find exits non-zero if anything under these roots is unreadable or vanishes mid-walk,
+        # which would end the migration here rather than just yielding fewer candidates
+        if [ -d "$_dir" ]; then find "$_dir" -type f -name '*.deb' >> "$WORK/debs" 2>/dev/null || true; fi
+    done
+    return 0
+}
+
+# Print a .deb whose control says it really is this package, preferring the version src had.
+# $1 = package, $2 = wanted version, $3 = dpkg architecture.
+find_deb() {
+    _fallback=""
+    while IFS= read -r _cand; do
+        [ "$(dpkg-deb -f "$_cand" Package 2>/dev/null)" = "$1" ] || continue
+        case "$(dpkg-deb -f "$_cand" Architecture 2>/dev/null)" in "$3"|all) ;; *) continue ;; esac
+        [ "$(dpkg-deb -f "$_cand" Version 2>/dev/null)" = "$2" ] && { printf '%s' "$_cand"; return 0; }
+        [ -n "$_fallback" ] || _fallback=$_cand
+    done < "$WORK/debs"
+    [ -n "$_fallback" ] || return 1
+    printf '%s' "$_fallback"
+}
 manual_set "$base_rel" > "$WORK/pkg.base"
 manual_set "$src"  > "$WORK/pkg.src"
 added_pkgs=$(comm -13 "$WORK/pkg.base" "$WORK/pkg.src" | tr '\n' ' ')
@@ -548,7 +582,28 @@ if [ -n "$added_pkgs" ] || { [ "$purge_removed" = 1 ] && [ -n "$removed_pkgs" ];
             if chroot "$TOP/$dst" apt-get install -y --dry-run "$_p" >/dev/null 2>&1; then _ok="$_ok $_p"; else _miss="$_miss $_p"; fi
         done
         [ -n "$_ok" ] && { echo "  installing:$_ok"; chroot "$TOP/$dst" apt-get install -y $_ok || echo "WARN: apt install failed; packages not installed:$_ok" >&2; }
-        [ -n "$_miss" ] && echo "NOTE: could not reinstall (not in a repo; install by hand):$_miss" >&2
+        if [ -n "$_miss" ]; then
+            # nothing in a repo provides these, so look for the .deb itself before giving up
+            echo "  looking for a local .deb for:$_miss"
+            collect_debs
+            # the target's architecture, not ours: under -d they need not be the same
+            _debarch=$(chroot "$TOP/$dst" dpkg --print-architecture 2>/dev/null || echo all)
+            _recovered=""; _stillmiss=""
+            for _p in $_miss; do
+                _debfile=$(find_deb "$_p" "$(installed_ver "$_p")" "$_debarch") || _debfile=""
+                if [ -z "$_debfile" ]; then _stillmiss="$_stillmiss $_p"; continue; fi
+                mkdir -p "$TOP/$dst/var/cache/apt/archives"
+                cp -f "$_debfile" "$TOP/$dst/var/cache/apt/archives/" 2>/dev/null || true
+                if chroot "$TOP/$dst" apt-get install -y "/var/cache/apt/archives/${_debfile##*/}" >/dev/null 2>&1; then
+                    _recovered="$_recovered $_p($(dpkg-deb -f "$_debfile" Version 2>/dev/null))"
+                else
+                    _stillmiss="$_stillmiss $_p"
+                    echo "WARN: found ${_debfile#"$TOP"/} for $_p but installing it failed (dependencies?)" >&2
+                fi
+            done
+            [ -n "$_recovered" ] && echo "  installed from a local .deb:$_recovered"
+            [ -n "$_stillmiss" ] && echo "NOTE: could not reinstall (not in a repo, no .deb found; install by hand):$_stillmiss" >&2
+        fi
     fi
     [ "$purge_removed" = 1 ] && [ -n "$removed_pkgs" ] && { echo "  purging removed:$removed_pkgs"; chroot "$TOP/$dst" apt-get purge -y $removed_pkgs || true; }
     rm -f "$_rc"; [ -n "$_rcbak" ] && mv "$_rcbak" "$_rc"   # restore dst's original resolv.conf

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -548,8 +548,11 @@ confirm "Apply the above to '$dst'? A '$dst' snapshot is taken first."
 
 ts=$(stamp)
 snap="@snapshots/@${dst#@}_${ts}_before_migrate"
-btrfs subvolume snapshot -r "$TOP/$dst" "$TOP/$snap" >/dev/null \
-    && echo "snapshot: $snap" || die "could not snapshot $dst; aborting before any change"
+if btrfs subvolume snapshot -r "$TOP/$dst" "$TOP/$snap" >/dev/null; then
+    echo "snapshot: $snap"
+else
+    die "could not snapshot $dst; aborting before any change"
+fi
 
 : > "$WORK/merged"; : > "$WORK/conflicts"
 

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -226,6 +226,9 @@ awk -v snap="$snapname" '
 function strip(p,  s){ s="./" snap "/"; if (index(p,s)==1) return substr(p, length(s)+1); return "" }
 # Denylist: migrate everything the user changed EXCEPT known-useless paths. 1 = noise, 0 = migrate.
 function is_noise(p) {
+    # our own leftovers: an unresolved sidecar would otherwise count as a user change and be
+    # carried into the next migration, and .migrate-bak is the resolv.conf we move aside for apt
+    if (p ~ /\.migrate-(conflict|theirs|bak)$/) return 1
     if (p ~ /^(proc|sys|dev|run|tmp|mnt|media|home|boot)(\/|$)/) return 1
     if (p ~ /^flipperone-testing(\/|$)/) return 1
     if (p ~ /^var\/(cache|tmp|log)(\/|$)/) return 1

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -7,8 +7,8 @@
 # and data.
 #
 # <@src>'s factory base (the _stock it was built from) is read from /etc/profile_origin
-# (origin_stock_name); if that stock is present and its build (os-release BUILD_GIT) matches
-# <@src>'s, it is the merge ancestor. The delta ancestor -> src is computed with `btrfs send
+# (origin_stock_name), whose name carries the build id, so it names the exact base. If that stock
+# is present it is the merge ancestor. The delta ancestor -> src is computed with `btrfs send
 # --no-data` (adds/mods/deletes/renames). Packages are replayed by intent (apt); files are 3-way
 # merged (base=ancestor, ours=dst, theirs=src; syntax-aware via mergiraf when installed, else git
 # merge-file): non-overlapping changes auto-merge into dst, a real
@@ -68,6 +68,7 @@ need_root
 need_btrfs
 
 WORK=$(mktemp -d)
+ACCOUNTDB_AWK=/usr/lib/flipper-accountdb.awk
 SRCSNAP=""
 mig_cleanup() {
     [ -n "$SRCSNAP" ] && btrfs subvolume delete "$SRCSNAP" >/dev/null 2>&1 || true
@@ -186,30 +187,23 @@ if [ "$apply" = 1 ] && [ "$dst" = "$cur_subvol" ] && [ "$force" != 1 ]; then
 Boot into another profile and run this again, or pass --force to override."
 fi
 
-# --- resolve the merge ancestor: src's factory base, present and same build ---
-build_of() { sed -n 's/^BUILD_GIT=//p' "$TOP/$1/etc/os-release" 2>/dev/null | tr -d '"'; }
-
+# --- resolve the merge ancestor: the _stock src was built from, by name ---
+# The stock name carries the build id, so the name alone pins the exact base. btrfs send -p
+# below refuses a parent that is not a real ancestor, so there is nothing further to verify.
 marker="$TOP/$src/etc/profile_origin"
 [ -f "$marker" ] || die "$src has no /etc/profile_origin marker; cannot determine its base"
 base=$(sed -n 's/^origin_stock_name=//p' "$marker")
 [ -n "$base" ] || die "$src marker has no origin_stock_name"
-src_build=$(build_of "$src")
 
 # the marker records the stock by bare name; it now lives under @stock-snapshots (resolve_rel)
 base_rel=$(resolve_rel "$base")
 [ -n "$base_rel" ] || die "You must have the '$base' _stock image on disk to migrate $src.
 migrate compares $src against the _stock it was built from to work out what you changed, but
-'$base' (build ${src_build:-unknown}) is not on this device. Receive that _stock and retry:
+'$base' is not on this device. Receive that _stock and retry:
   receive-snapshot <path-to-${base#@}_pack.zst>"
-base_build=$(build_of "$base_rel")
-[ "$base_build" = "$src_build" ] || die "You must have the exact '$base' _stock $src was built from on disk.
-The '$base' on disk is a different build than $src:
-  on disk:    build ${base_build:-?}
-  $src needs: build ${src_build:-?}
-Receive the matching _stock and retry:  receive-snapshot <path-to-${base#@}_pack.zst>"
 
 echo "migrate: $src -> $dst"
-echo "  ancestor: $base (build ${src_build:-unknown})"
+echo "  ancestor: $base"
 echo "  merge engine: $merger"
 [ "$apply" = 1 ] && echo "  mode: APPLY" || echo "  mode: dry run"
 
@@ -316,83 +310,92 @@ mergiraf_lang() {
     esac
 }
 
-# Account databases (passwd/shadow/group/gshadow + backups) are keyed by the first field, not by
-# line order, so a text merge conflicts on every epoch bump and could duplicate entries. Merge them
-# per entry instead: an account the user did not touch follows the new base (apt replay is the
-# authority for service accounts), an account the user added or changed rides along from src, and
-# group/gshadow memberships are set-merged. Deterministic, never conflicts.
-cat > "$WORK/accountdb.awk" <<'AWK'
-BEGIN { FS=":"; nlf=split(LF,_l,","); for(i=1;i<=nlf;i++) islist[_l[i]+0]=1; fidx=0 }
-FNR==1 { fidx++ }
-{
-    if ($0=="") next
-    k=$1
-    if      (fidx==1) { Bl[k]=$0; hB[k]=1 }
-    else if (fidx==2) { Ol[k]=$0; hO[k]=1; if(!(k in os)){ os[k]=1; oord[++no]=k } }
-    else              { Tl[k]=$0; hT[k]=1; if(!(k in ts)){ ts[k]=1; tord[++nt]=k } }
-}
-END {
-    for (i=1;i<=no;i++) put(oord[i])
-    for (i=1;i<=nt;i++) if (!(tord[i] in os)) put(tord[i])
-}
-function put(k,   line) { line=decide(k); if (line!="") print line }
-function decide(k,   ib,io,it) {
-    ib=(k in hB); io=(k in hO); it=(k in hT)
-    if (!io && !it) return ""
-    if ( io && !it) { if (ib && Ol[k]==Bl[k]) return ""; return Ol[k] }
-    if (!io &&  it) { if (ib && Tl[k]==Bl[k]) return ""; return Tl[k] }
-    if (LF!="") return mergerec(k, ib)
-    if (Ol[k]==Tl[k]) return Ol[k]
-    if (!ib)          return Ol[k]
-    if (Tl[k]==Bl[k]) return Ol[k]
-    if (Ol[k]==Bl[k]) return Tl[k]
-    return Tl[k]
-}
-function mergerec(k, ib,   nb,no2,nt2,fb,fo,ft,fi,res) {
-    nb  = ib ? split(Bl[k], fb, ":") : 0
-    no2 =      split(Ol[k], fo, ":")
-    nt2 =      split(Tl[k], ft, ":")
-    for (fi=1; fi<=no2; fi++)
-        rf[fi] = (fi in islist) ? merge_members(fi, ib, fb, fo, ft, nb, no2, nt2) : fo[fi]
-    res=rf[1]; for(fi=2;fi<=no2;fi++) res=res ":" rf[fi]
-    delete rf
-    return res
-}
-function merge_members(fi, ib, fb, fo, ft, nb, no2, nt2,   i,m,res) {
-    delete inB; delete inO; delete inT; delete ordm; delete ordseen; nord=0
-    if (ib && nb >=fi) mark(fb[fi], inB)
-    if (      no2>=fi) mark(fo[fi], inO)
-    if (      nt2>=fi) mark(ft[fi], inT)
-    if (      no2>=fi) order(fo[fi])
-    if (      nt2>=fi) order(ft[fi])
-    if (ib && nb >=fi) order(fb[fi])
-    res=""
-    for (i=1;i<=nord;i++) {
-        m=ordm[i]
-        if ((m in inB) && !(m in inO)) continue
-        if ((m in inB) && !(m in inT)) continue
-        res = (res=="") ? m : res "," m
-    }
-    return res
-}
-function mark(s, arr,   n,a,i) { n=split(s,a,","); for(i=1;i<=n;i++) if(a[i]!="") arr[a[i]]=1 }
-function order(s,   n,a,i)     { n=split(s,a,","); for(i=1;i<=n;i++) if(a[i]!="" && !(a[i] in ordseen)){ ordseen[a[i]]=1; ordm[++nord]=a[i] } }
-AWK
+
 
 merge_accountdb() {  # $1 = etc/<db>: per-entry 3-way merge into dst (deterministic, no sidecar)
     _f=$1; _S="$TOP/$src/$_f"; _O="$TOP/$dst/$_f"; _B="$TOP/$base_rel/$_f"
     _mb="$EMPTY"; [ -f "$_B" ] && _mb="$_B"
+    # _lf: fields holding comma-separated member lists, set-merged instead of taken whole.
+    # _nf: how many colon-separated fields a record has, so a truncated result is rejected below.
     case "${_f##*/}" in
-        group|group-)     _lf=4 ;;
-        gshadow|gshadow-) _lf=3,4 ;;
-        *)                _lf="" ;;
+        group|group-)     _lf=4;   _nf=4 ;;
+        gshadow|gshadow-) _lf=3,4; _nf=4 ;;
+        shadow|shadow-)   _lf="";  _nf=9 ;;
+        *)                _lf="";  _nf=7 ;;
     esac
-    if [ -f "$_O" ] && awk -v LF="$_lf" -f "$WORK/accountdb.awk" "$_mb" "$_O" "$_S" > "$WORK/adb" 2>/dev/null; then
-        cat "$WORK/adb" > "$_O"; sync_meta "$_S" "$_O" "$_B"
-    else
+    if [ ! -f "$_O" ]; then
         rsync -aHAX "$_S" "$_O"          # dst lacks the db -> take the user's copy verbatim
+        echo x >> "$WORK/merged"
+        return 0
     fi
-    echo x >> "$WORK/merged"
+    # These files decide whether the profile can be logged into, so the merged result has to
+    # look like an account database before it replaces one: every db here has a root entry, and
+    # a duplicate key is the corruption a text merge would have produced.
+    if [ ! -r "$ACCOUNTDB_AWK" ]; then
+        _why="$ACCOUNTDB_AWK not installed"
+    elif ! awk -v LF="$_lf" -f "$ACCOUNTDB_AWK" "$_mb" "$_O" "$_S" > "$WORK/adb" 2>/dev/null; then
+        _why="merge failed"
+    elif [ ! -s "$WORK/adb" ]; then
+        _why="empty result"
+    elif ! grep -q '^root:' "$WORK/adb"; then
+        _why="no root entry"
+    elif [ -n "$(cut -d: -f1 "$WORK/adb" | sort | uniq -d | head -n1)" ]; then
+        _why="duplicate entries"
+    else
+        _why=""
+    fi
+    if [ -n "$_why" ]; then
+        rsync -aHAX "$_S" "$_O.migrate-theirs"
+        printf '%s (account merge rejected: %s; %s kept)\n' "$_f" "$_why" "$dst" >> "$WORK/conflicts"
+        return 0
+    fi
+    # Staged, not installed: a record malformed in ANY database disqualifies that account in all of
+    # them, which is only known once every database has been merged.
+    cp "$WORK/adb" "$WORK/adb.${_f##*/}"
+    awk -F: -v n="$_nf" 'NF != n { print $1 }' "$WORK/adb" >> "$WORK/adbbad"
+    printf '%s|%s|%s|%s|%s\n' "$_f" "$_S" "$_O" "$_B" "$_nf" >> "$WORK/adbstaged"
+}
+
+# Install the staged databases, minus any account malformed in one of them. Where dst already had
+# that account, its own record stays rather than going with it.
+finalize_accountdbs() {
+    [ -f "$WORK/adbstaged" ] || return 0
+    _bad=$(sort -u "$WORK/adbbad" 2>/dev/null | tr '\n' ' ')
+    while IFS='|' read -r _f _S _O _B _nf; do
+        _st="$WORK/adb.${_f##*/}"
+        for _k in $_bad; do
+            grep -v "^$_k:" "$_st" > "$_st.keep" || true
+            mv "$_st.keep" "$_st"
+            grep "^$_k:" "$_O" >> "$_st" || true
+        done
+        if awk -F: -v n="$_nf" 'NF != n { exit 1 }' "$_st" && grep -q '^root:' "$_st"; then
+            cat "$_st" > "$_O"; sync_meta "$_S" "$_O" "$_B"
+            echo x >> "$WORK/merged"
+        else
+            rsync -aHAX "$_S" "$_O.migrate-theirs"
+            printf '%s (account merge rejected: still malformed after dropping bad records; %s kept)\n' "$_f" "$dst" >> "$WORK/conflicts"
+        fi
+    done < "$WORK/adbstaged"
+    if [ -n "$_bad" ]; then
+        echo "Warning: these accounts did not migrate, a record of theirs is malformed in one of the" >&2
+        echo "         account databases, and half an account cannot log in: $_bad" >&2
+        printf 'accounts dropped as malformed: %s\n' "$_bad" >> "$WORK/conflicts"
+    fi
+    return 0
+}
+
+# Report accounts present in a database but missing from its shadow companion, either way round.
+# Names only: the entries themselves are merged per file above, this checks the sets line up.
+check_db_pair() {  # $1 = passwd/group, $2 = its shadow/gshadow companion
+    [ -f "$TOP/$dst/$1" ] && [ -f "$TOP/$dst/$2" ] || return 0
+    cut -d: -f1 "$TOP/$dst/$1" | sort -u > "$WORK/k1"
+    cut -d: -f1 "$TOP/$dst/$2" | sort -u > "$WORK/k2"
+    _d=$(comm -3 "$WORK/k1" "$WORK/k2" | tr -d '\t' | tr '\n' ' ')
+    # At any verbosity: the summary counts merged files, which would never hint that an account is
+    # missing its companion entry.
+    [ -n "$_d" ] && echo "Warning: $1 and $2 disagree on: $_d (those accounts cannot authenticate until you fix them)" >&2
+    [ -n "$_d" ] && printf '%s and %s disagree on: %s\n' "$1" "$2" "$_d" >> "$WORK/conflicts"
+    return 0
 }
 
 # Merge one changed file onto dst. Clean auto-merges are written to dst; a conflict leaves dst's
@@ -417,11 +420,11 @@ merge_one() {
         if [ "$merger" = mergiraf ]; then
             _lang=$(mergiraf_lang "$_f" "$_S")
             mergiraf merge "$_mb" "$_O" "$_S" -o "$WORK/m" -p "$_f" --allow-parse-errors ${_lang:+-L "$_lang"} \
-                -s "factory base (${src_build:-unknown})" -x "new base ($dst)" -y "your changes ($src)" 2>/dev/null
+                -s "factory base ($base)" -x "new base ($dst)" -y "your changes ($src)" 2>/dev/null
             _rc=$?
         else
             git merge-file -p --diff3 \
-                -L "new base ($dst)" -L "factory base (${src_build:-unknown})" -L "your changes ($src)" \
+                -L "new base ($dst)" -L "factory base ($base)" -L "your changes ($src)" \
                 "$_O" "$_mb" "$_S" > "$WORK/m" 2>/dev/null
             _rc=$?
         fi
@@ -510,8 +513,8 @@ btrfs subvolume snapshot -r "$TOP/$dst" "$TOP/$snap" >/dev/null \
 
 : > "$WORK/merged"; : > "$WORK/conflicts"
 
-# 1) replay package intent FIRST (lays down package files + default conffiles), so the user's
-#    config edits in step 2 merge on top of them. Needs a working apt source / network.
+# Replay package intent FIRST (lays down package files + default conffiles), so the user's
+#    config edits merge on top of them afterwards. Needs a working apt source / network.
 if [ -n "$added_pkgs" ] || { [ "$purge_removed" = 1 ] && [ -n "$removed_pkgs" ]; }; then
     echo "replaying packages with apt (needs network; this can take a few minutes)..."
     for _m in proc sys dev dev/pts; do mount --bind "/$_m" "$TOP/$dst/$_m" 2>/dev/null || true; done
@@ -538,7 +541,7 @@ if [ -n "$added_pkgs" ] || { [ "$purge_removed" = 1 ] && [ -n "$removed_pkgs" ];
     for _m in dev/pts dev sys proc; do umount "$TOP/$dst/$_m" 2>/dev/null || true; done
 fi
 
-# 2) 3-way merge the user's changed files onto dst
+# 3-way merge the user's changed files onto dst
 _total=$(wc -l < "$WORK/changed" 2>/dev/null | tr -d ' '); [ -n "$_total" ] || _total=0
 echo "merging your files onto $dst ($_total, via $merger)..."
 _n=0
@@ -549,11 +552,22 @@ while IFS= read -r f; do
 done < "$WORK/changed"
 [ "$_n" -gt 0 ] && printf '\r  merged %d/%d files \n' "$_n" "$_total" >&2
 
-# 3) apply the user's deletions, deepest-first (files before their dir) so empty dirs can rmdir
+# Apply the user's deletions, deepest-first (files before their dir) so empty dirs can rmdir
 if [ -s "$WORK/deleted" ]; then
     echo "applying your deletions..."
     sort -r "$WORK/deleted" > "$WORK/deleted.rev"
     while IFS= read -r f; do [ -n "$f" ] && delete_one "$f"; done < "$WORK/deleted.rev"
+fi
+
+# The databases are merged one at a time, so beyond the malformed accounts finalize_accountdbs
+# drops from all of them, nothing guarantees they still agree: a passwd entry with no shadow entry
+# is an account that cannot authenticate, and group drifting from gshadow is what grpck exists to
+# complain about.
+if grep -qE '^etc/(passwd|shadow|group|gshadow)-?$' "$WORK/changed" 2>/dev/null; then
+    finalize_accountdbs
+    echo "checking the account databases agree..."
+    check_db_pair etc/passwd etc/shadow
+    check_db_pair etc/group etc/gshadow
 fi
 
 _nmerged=$(cnt "$WORK/merged"); _nconf=$(cnt "$WORK/conflicts")

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -68,13 +68,13 @@ done
 need_root
 need_btrfs
 
-WORK=$(mktemp -d)
 ACCOUNTDB_AWK=/usr/lib/flipper-accountdb.awk
 SRCSNAP=""
 mig_cleanup() {
     [ -n "$SRCSNAP" ] && btrfs subvolume delete "$SRCSNAP" >/dev/null 2>&1 || true
     top_cleanup
-    rm -rf "$WORK"
+    [ -n "${WORK:-}" ] && rm -rf "$WORK" || true
+    return 0
 }
 
 ask_tty() {
@@ -155,6 +155,10 @@ resolve_mode() {
 
 mount_top
 trap mig_cleanup EXIT
+# Created only once mig_cleanup owns the EXIT trap. mount_top installs its own trap and would
+# clobber ours, so anything made before this line is leaked when mount_top itself dies, which is
+# what a recovery boot does on every invocation that forgets -d.
+WORK=$(mktemp -d)
 
 if [ "$resolve" = 1 ]; then resolve_mode "$1"; exit 0; fi
 

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -504,7 +504,9 @@ delete_one() {
 while IFS= read -r f; do
     [ -n "$f" ] || continue
     _O="$TOP/$dst/$f"; _B="$TOP/$base_rel/$f"; _S="$TOP/$src/$f"
-    if [ -d "$_S" ] && [ ! -L "$_S" ]; then echo "$f" >> "$WORK/clean"; continue; fi   # dir: created + metadata
+    # merge_one takes anything that is not a regular file wholesale (dirs are created, symlinks
+    # and specials are rsynced), so it is never a both-sides merge, whatever the base looks like
+    if [ ! -f "$_S" ] || [ -L "$_S" ]; then echo "$f" >> "$WORK/clean"; continue; fi
     if [ ! -e "$_O" ] || { [ -f "$_B" ] && cmp -s "$_B" "$_O"; }; then echo "$f" >> "$WORK/clean"
     elif [ -f "$_S" ] && cmp -s "$_S" "$_O"; then :
     else echo "$f" >> "$WORK/overlap"; fi

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -17,8 +17,9 @@
 # text: user-added or user-changed accounts and group memberships are carried while service
 # accounts follow the new base. Everything the user changed is migrated EXCEPT a denylist of noise: package
 # files (replayed via apt instead), caches, regenerated runtime state, and generated/per-device
-# identity files (machine-id, ld.so.cache, and the like). SSH host keys ARE carried, so the
-# migrated profile keeps the device's ssh identity (no host-key-changed warnings).
+# identity files (machine-id, ld.so.cache, and the like). SSH host keys are carried explicitly,
+# by policy rather than by delta, so the migrated profile keeps the device's ssh identity even
+# though the build bakes the same keys into every image (no host-key-changed warnings).
 #
 # Default is a DRY RUN. -a/--apply performs it (snapshots <@dst> to @snapshots/<dst>_<ts>_before_
 # migrate first) and then, if any conflicts remain, drops straight into interactive resolution
@@ -512,6 +513,18 @@ while IFS= read -r f; do
     else echo "$f" >> "$WORK/overlap"; fi
 done < "$WORK/changed"
 
+# The ssh host keys ARE the device identity, so they follow the device, not the base. The delta never
+# mentions them (the image bakes the same keys everywhere, so src's copy equals the ancestor's), so
+# carry them by policy. Prints the files dst lacks, so preview and apply agree on the count.
+ssh_identity_files() {
+    [ -d "$TOP/$src/etc/ssh" ] || return 0
+    for _k in "$TOP/$src"/etc/ssh/ssh_host_*; do
+        [ -f "$_k" ] || continue
+        cmp -s "$_k" "$TOP/$dst/etc/ssh/${_k##*/}" && continue
+        printf '%s\n' "$_k"
+    done
+}
+
 # --- report ---
 cnt() { _c=$(wc -l < "$1" 2>/dev/null | tr -d ' '); printf '%s' "${_c:-0}"; }
 _na=$(printf '%s' "$added_pkgs" | wc -w | tr -d ' ')
@@ -522,6 +535,8 @@ echo
 echo "== migration preview: $src -> $dst =="
 printf '  packages:  +%s added   -%s removed\n' "$_na" "$_nr"
 printf '  files:     %s carried   %s changed by both sides   %s deleted   %s skipped as noise\n' "$_nc" "$_no" "$_nd" "$_noise"
+_nid=$(ssh_identity_files | wc -l | tr -d ' ')
+[ "${_nid:-0}" -gt 0 ] && printf '  identity:  %s ssh host key file(s), carried so %s keeps this device identity\n' "$_nid" "$dst"
 echo
 echo "  Carried, deleted and account databases apply automatically. The $_no changed-by-both"
 echo "  file(s) are 3-way merged on apply; only those that cannot merge cleanly will ask you to"
@@ -632,6 +647,15 @@ if [ -s "$WORK/deleted" ]; then
     sort -r "$WORK/deleted" > "$WORK/deleted.rev"
     while IFS= read -r f; do [ -n "$f" ] && delete_one "$f"; done < "$WORK/deleted.rev"
 fi
+
+# Carry the ssh host keys, listed by ssh_identity_files above.
+_idn=0; _idfail=0
+for _k in $(ssh_identity_files); do
+    if rsync -aHAX "$_k" "$TOP/$dst/etc/ssh/${_k##*/}"; then _idn=$((_idn+1))
+    else _idfail=$((_idfail+1)); echo "Warning: could not carry ${_k##*/}" >&2; fi
+done
+[ "$_idn" -gt 0 ] && echo "carried $_idn ssh host key file(s), so '$dst' keeps this device's identity"
+[ "$_idfail" -gt 0 ] && echo "WARNING: $_idfail ssh host key file(s) could not be carried; '$dst' will present a different ssh identity and clients will report a changed host key" >&2
 
 # The databases are merged one at a time, so beyond the malformed accounts finalize_accountdbs
 # drops from all of them, nothing guarantees they still agree: a passwd entry with no shadow entry

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -231,6 +231,7 @@ function is_noise(p) {
     if (p ~ /^var\/(cache|tmp|log)(\/|$)/) return 1
     if (p ~ /(^|\/)\.cache(\/|$)/) return 1
     if (p ~ /^usr\/local(\/|$)/) return 0
+    if (p ~ /^usr\/share\/keyrings(\/|$)/) return 0
     if (p ~ /^usr(\/|$)/) return 1
     if (p ~ /^var\/lib\/(dpkg|apt|ucf)(\/|$)/) return 1
     if (p=="var/.updated") return 1
@@ -513,6 +514,16 @@ btrfs subvolume snapshot -r "$TOP/$dst" "$TOP/$snap" >/dev/null \
 
 : > "$WORK/merged"; : > "$WORK/conflicts"
 
+# Apt configuration must land before the replay, or a package from a repository the user added is
+#    not findable while dst still has the old sources. Keyrings too, since a source without its key
+#    is useless. The file merge below takes the rest, so each file is merged exactly once.
+grep -E '^(etc/apt/|usr/share/keyrings/)' "$WORK/changed" > "$WORK/changed.apt" || :
+grep -vE '^(etc/apt/|usr/share/keyrings/)' "$WORK/changed" > "$WORK/changed.rest" || :
+if [ -s "$WORK/changed.apt" ]; then
+    echo "merging apt configuration first ($(cnt "$WORK/changed.apt") file(s))..."
+    while IFS= read -r f; do [ -n "$f" ] && merge_one "$f"; done < "$WORK/changed.apt"
+fi
+
 # Replay package intent FIRST (lays down package files + default conffiles), so the user's
 #    config edits merge on top of them afterwards. Needs a working apt source / network.
 if [ -n "$added_pkgs" ] || { [ "$purge_removed" = 1 ] && [ -n "$removed_pkgs" ]; }; then
@@ -541,15 +552,15 @@ if [ -n "$added_pkgs" ] || { [ "$purge_removed" = 1 ] && [ -n "$removed_pkgs" ];
     for _m in dev/pts dev sys proc; do umount "$TOP/$dst/$_m" 2>/dev/null || true; done
 fi
 
-# 3-way merge the user's changed files onto dst
-_total=$(wc -l < "$WORK/changed" 2>/dev/null | tr -d ' '); [ -n "$_total" ] || _total=0
+# 3-way merge the rest of the user's changed files onto dst
+_total=$(cnt "$WORK/changed.rest")
 echo "merging your files onto $dst ($_total, via $merger)..."
 _n=0
 while IFS= read -r f; do
     [ -n "$f" ] || continue
     _n=$((_n+1)); printf '\r  merging %d/%d' "$_n" "$_total" >&2
     merge_one "$f"
-done < "$WORK/changed"
+done < "$WORK/changed.rest"
 [ "$_n" -gt 0 ] && printf '\r  merged %d/%d files \n' "$_n" "$_total" >&2
 
 # Apply the user's deletions, deepest-first (files before their dir) so empty dirs can rmdir

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -418,7 +418,7 @@ finalize_accountdbs() {
     if [ -n "$_bad" ]; then
         echo "Warning: these accounts did not migrate, a record of theirs is malformed in one of the" >&2
         echo "         account databases, and half an account cannot log in: $_bad" >&2
-        printf 'accounts dropped as malformed: %s\n' "$_bad" >> "$WORK/conflicts"
+        printf 'accounts dropped as malformed: %s\n' "$_bad" >> "$WORK/notices"
     fi
     return 0
 }
@@ -433,7 +433,7 @@ check_db_pair() {  # $1 = passwd/group, $2 = its shadow/gshadow companion
     # At any verbosity: the summary counts merged files, which would never hint that an account is
     # missing its companion entry.
     [ -n "$_d" ] && echo "Warning: $1 and $2 disagree on: $_d (those accounts cannot authenticate until you fix them)" >&2
-    [ -n "$_d" ] && printf '%s and %s disagree on: %s\n' "$1" "$2" "$_d" >> "$WORK/conflicts"
+    [ -n "$_d" ] && printf '%s and %s disagree on: %s\n' "$1" "$2" "$_d" >> "$WORK/notices"
     return 0
 }
 
@@ -490,11 +490,11 @@ delete_one() {
     _f=$1; _O="$TOP/$dst/$_f"; _B="$TOP/$base_rel/$_f"
     { [ -e "$_O" ] || [ -L "$_O" ]; } || return 0
     if [ -d "$_O" ] && [ ! -L "$_O" ]; then
-        rmdir "$_O" 2>/dev/null || printf '%s/ (you deleted this dir; new base still has files in it -> kept)\n' "$_f" >> "$WORK/conflicts"
+        rmdir "$_O" 2>/dev/null || printf '%s/ (you deleted this dir; new base still has files in it -> kept)\n' "$_f" >> "$WORK/notices"
         return 0
     fi
     if [ -f "$_O" ] && [ ! -L "$_O" ] && [ -f "$_B" ] && ! cmp -s "$_O" "$_B"; then
-        printf '%s (you deleted it; new base changed it -> kept new version)\n' "$_f" >> "$WORK/conflicts"
+        printf '%s (you deleted it; new base changed it -> kept new version)\n' "$_f" >> "$WORK/notices"
         return 0
     fi
     rm -f "$_O"
@@ -569,7 +569,7 @@ else
     die "could not snapshot $dst; aborting before any change"
 fi
 
-: > "$WORK/merged"; : > "$WORK/conflicts"
+: > "$WORK/merged"; : > "$WORK/conflicts"; : > "$WORK/notices"
 
 # Apt configuration must land before the replay, or a package from a repository the user added is
 #    not findable while dst still has the old sources. Keyrings too, since a source without its key
@@ -668,7 +668,7 @@ if grep -qE '^etc/(passwd|shadow|group|gshadow)-?$' "$WORK/changed" 2>/dev/null;
     check_db_pair etc/group etc/gshadow
 fi
 
-_nmerged=$(cnt "$WORK/merged"); _nconf=$(cnt "$WORK/conflicts")
+_nmerged=$(cnt "$WORK/merged"); _nconf=$(cnt "$WORK/conflicts"); _nnote=$(cnt "$WORK/notices")
 echo
 echo "== migration summary: $src -> $dst =="
 printf '  packages:  +%s added   -%s removed\n' "$_na" "$_nr"
@@ -678,7 +678,11 @@ if [ "$_nconf" -gt 0 ]; then
 else
     echo "  everything merged cleanly; nothing to decide"
 fi
+# Settled by policy, so --resolve has nothing to offer for these: counted apart from the
+# decisions, or the summary would promise sidecars that do not exist.
+[ "$_nnote" -gt 0 ] && printf '  %s file(s) settled for you (no sidecar, nothing to resolve)\n' "$_nnote"
 [ "$verbose" = 1 ] && [ -s "$WORK/conflicts" ] && { echo; echo "-- files needing a decision --"; sed 's,^,  ,' "$WORK/conflicts"; }
+[ "$verbose" = 1 ] && [ -s "$WORK/notices" ]   && { echo; echo "-- settled for you --";        sed 's,^,  ,' "$WORK/notices"; }
 
 if [ -s "$WORK/conflicts" ]; then
     if [ "$no_resolve" = 1 ] || [ "$ASSUME_YES" = 1 ]; then


### PR DESCRIPTION
The migration tool, kept last so it can be reviewed on its own. Apart from one
`stamp_stock_origin` tidy it touches only `migrate-profile` and its awk helper.

**Hardening**

- Account databases are validated before a merge is accepted: field counts, a root entry, no duplicates,
  non-empty output. A malformed record disqualifies that account in **all four** databases instead of
  condemning a whole file, so one truncated line no longer costs every other account its migration; where
  the destination already had that account, its own record stays. Output that is unusable as a whole (no
  root entry, duplicate keys, empty, merge failed) still keeps the destination's file with a sidecar and a
  conflict line.
- The per-entry account merge ships as `/usr/lib/flipper-accountdb.awk` and runs with `awk -f`, so it
  can be syntax-checked and diffed on its own, and is clean under `mawk -W dump`, since the device has
  mawk rather than gawk.
- Apt configuration is merged **before** packages are replayed, or a package that exists only in a
  repository the user added cannot be resolved at all.
- Our own leftover sidecars count as noise, so an unresolved conflict is not carried into the next
  migration.
- A package whose version is no longer fetchable is recovered from a local `.deb`, matched on package
  name and architecture through `dpkg-deb -f` rather than on filename, with the architecture read from
  the target profile rather than the running system.
- Non-regular files are no longer counted as changed by both sides.

**Defects found by testing**

- **SSH host keys were not carried**, despite the header promising the device keeps its identity. The
  build bakes the keys in, so the source's copy is identical to its ancestor's and the delta never
  mentions them; a migration therefore changed the device's ssh identity. Now carried explicitly, driven
  by one helper that both the preview and the apply read. Verified by booting the migrated profile: a
  client holding the pre-migration keys connects under `StrictHostKeyChecking=yes` with no warning.
- **The conflict count promised sidecars that did not exist.** Outcomes settled by policy were counted
  as needing a decision, so the summary said four while three sidecars existed, and pointed at
  `--resolve` for a file it would never show. They are now counted apart, under "settled for you".
- **A malformed record left the account half-created.** Refusing one database while accepting the other
  three produced a `passwd` entry with no `shadow` entry, an account that cannot log in, and the summary
  called it "settled for you". The record now disqualifies the account everywhere, and a disagreement
  between a database and its shadow companion is reported at default verbosity instead of only under `-v`.
- **The work directory leaked whenever `mount_top` died**, because the trap that removes it can only be
  installed after `mount_top` installs its own. One leak per invocation in a recovery boot.
- A failed pre-migration snapshot was hidden behind `&& echo ... || die`, which also dies when the
  snapshot succeeded and only the echo failed.

**Testing.** Migration ran across two real builds from different commits, so both-sides conflicts had
somewhere to go, and the case that would have failed first passed: a package installed from a repository present only on
the source, which the destination can resolve only if apt configuration merged first. Every `--resolve`
menu key was driven through a pty against sidecars a real migration produced. A user account added before
the migration logs in afterwards with its carried password hash.

Re-verified on hardware after the account-merge change, on a throwaway loop filesystem so the real
profiles were never touched: a valid account migrates into all four databases with no warning; an account
malformed in `shadow` is dropped from all four while every other account migrates normally; an account the
destination already had keeps the destination's own record rather than being deleted with it; and output
with no root entry still falls back to the whole-file refusal with a sidecar. The `.deb` architecture now
comes from the target profile, also checked on hardware (`chroot ... dpkg --print-architecture` answers
`arm64`, and the `|| echo all` fallback narrows `find_deb` to `Architecture: all` rather than guessing).

The work-directory leak was confirmed fixed in a **recovery boot**, the case that commit describes:
`migrate-profile` without `-d` dies inside `mount_top` and leaves no work directory and no mount. Note
that migrate cannot do more than that in recovery today, since the recovery image ships neither `git` nor
`mergiraf` and the tool stops at its `need_cmd git` gate.

Split out of the closed #141. Each commit parses and defines the helpers it uses.





