### PR TITLE
list-profiles: show when each profile was last running

### DIFF
--- a/overlays/configs/kernel/install.d/90-loaderentry.install
+++ b/overlays/configs/kernel/install.d/90-loaderentry.install
@@ -40,7 +40,7 @@ set_dtb_dirs
 # content (version + rootflags=subvol=), so it never touches another profile's entries and
 # survives any purge/cleanup path. kernel-install itself removes this root's staged dir.
 if [ "$COMMAND" = "remove" ]; then
-    remove_entries "$(current_subvol)" "$KERNEL_VERSION"
+    remove_entries "$(booted_subvol)" "$KERNEL_VERSION"
     # kernel-install removed this version's staged dir; reap the now-empty per-token parent
     # ($BOOT_ROOT/$ENTRY_TOKEN) too. rmdir (not rm -rf) only succeeds if truly empty, so it
     # never touches a token dir that still has another version staged.
@@ -78,7 +78,7 @@ discover_devicetreedir
 
 # Write this root's entry. apt/dpkg only ever touch the booted root, so emit ONLY its entry: match
 # the booted root to a profile line for its title/overlays, else treat it as a clone (title = name).
-CUR_SUBVOL="$(current_subvol)"
+CUR_SUBVOL="$(booted_subvol)"
 [ -n "$CUR_SUBVOL" ] || die "cannot determine current root subvol (findmnt)"
 
 # kernel + initrd from this root's own /usr/lib/modules/<ver>/, else /boot (resolve_kernel_paths)

--- a/overlays/usr/lib/flipper-accountdb.awk
+++ b/overlays/usr/lib/flipper-accountdb.awk
@@ -1,0 +1,60 @@
+# flipper-accountdb.awk - per-entry 3-way merge of the account databases, run by migrate-profile as:
+#   awk -v LF=<list-fields> -f this base ours theirs
+# Keyed by the first field, not by line order, so an epoch bump cannot conflict and entries cannot
+# duplicate: untouched accounts follow the new base, user-added or changed ones ride along from src,
+# memberships are set-merged. LF = field numbers holding member lists (group=4, gshadow=3,4).
+BEGIN { FS=":"; nlf=split(LF,_l,","); for(i=1;i<=nlf;i++) islist[_l[i]+0]=1; fidx=0 }
+FNR==1 { fidx++ }
+{
+    if ($0=="") next
+    k=$1
+    if      (fidx==1) { Bl[k]=$0; hB[k]=1 }
+    else if (fidx==2) { Ol[k]=$0; hO[k]=1; if(!(k in os)){ os[k]=1; oord[++no]=k } }
+    else              { Tl[k]=$0; hT[k]=1; if(!(k in ts)){ ts[k]=1; tord[++nt]=k } }
+}
+END {
+    for (i=1;i<=no;i++) put(oord[i])
+    for (i=1;i<=nt;i++) if (!(tord[i] in os)) put(tord[i])
+}
+function put(k,   line) { line=decide(k); if (line!="") print line }
+function decide(k,   ib,io,it) {
+    ib=(k in hB); io=(k in hO); it=(k in hT)
+    if (!io && !it) return ""
+    if ( io && !it) { if (ib && Ol[k]==Bl[k]) return ""; return Ol[k] }
+    if (!io &&  it) { if (ib && Tl[k]==Bl[k]) return ""; return Tl[k] }
+    if (LF!="") return mergerec(k, ib)
+    if (Ol[k]==Tl[k]) return Ol[k]
+    if (!ib)          return Ol[k]
+    if (Tl[k]==Bl[k]) return Ol[k]
+    if (Ol[k]==Bl[k]) return Tl[k]
+    return Tl[k]
+}
+function mergerec(k, ib,   nb,no2,nt2,fb,fo,ft,fi,res) {
+    nb  = ib ? split(Bl[k], fb, ":") : 0
+    no2 =      split(Ol[k], fo, ":")
+    nt2 =      split(Tl[k], ft, ":")
+    for (fi=1; fi<=no2; fi++)
+        rf[fi] = (fi in islist) ? merge_members(fi, ib, fb, fo, ft, nb, no2, nt2) : fo[fi]
+    res=rf[1]; for(fi=2;fi<=no2;fi++) res=res ":" rf[fi]
+    delete rf
+    return res
+}
+function merge_members(fi, ib, fb, fo, ft, nb, no2, nt2,   i,m,res) {
+    delete inB; delete inO; delete inT; delete ordm; delete ordseen; nord=0
+    if (ib && nb >=fi) mark(fb[fi], inB)
+    if (      no2>=fi) mark(fo[fi], inO)
+    if (      nt2>=fi) mark(ft[fi], inT)
+    if (      no2>=fi) order(fo[fi])
+    if (      nt2>=fi) order(ft[fi])
+    if (ib && nb >=fi) order(fb[fi])
+    res=""
+    for (i=1;i<=nord;i++) {
+        m=ordm[i]
+        if ((m in inB) && !(m in inO)) continue
+        if ((m in inB) && !(m in inT)) continue
+        res = (res=="") ? m : res "," m
+    }
+    return res
+}
+function mark(s, arr,   n,a,i) { n=split(s,a,","); for(i=1;i<=n;i++) if(a[i]!="") arr[a[i]]=1 }
+function order(s,   n,a,i)     { n=split(s,a,","); for(i=1;i<=n;i++) if(a[i]!="" && !(a[i] in ordseen)){ ordseen[a[i]]=1; ordm[++nord]=a[i] } }

--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -260,7 +260,8 @@ compute_base_opts() {
     BASE_OPTS="$(trim "$BASE_OPTS")"
     # rewrite the shipped cmdline's build-time root=UUID to the fs we install onto, so a _stock
     # received onto a device with a different btrfs UUID still boots.
-    _fsuuid="$(current_fsuuid)"
+    # the filesystem the entry will boot from, which under -d is not the one we are running
+    _fsuuid="${TARGET_FSUUID:-$(current_fsuuid)}"
     [ -n "$_fsuuid" ] && BASE_OPTS="$(printf '%s' " $BASE_OPTS " | sed "s/ root=UUID=[^ ]*/ root=UUID=$_fsuuid/")"
     BASE_OPTS="$(trim "$BASE_OPTS")"
     # Pin systemd.machine_id= only when entries are named after the machine-id (no-op otherwise).

--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -28,8 +28,15 @@ has_config() { [ -f "$KCONFIG" ] && grep -q "^CONFIG_$1=[ym]" "$KCONFIG"; }
 # Last rootflags=subvol= value in a cmdline/options string (empty if none).
 subvol_of() { printf '%s' "$1" | tr ' ' '\n' | sed -n 's/^rootflags=subvol=//p' | tail -n1; }
 
-# BLS sort-key from os-release (IMAGE_ID, else ID); empty if no os-release.
-os_sort_key() { [ -r /etc/os-release ] && ( . /etc/os-release; printf '%s' "${IMAGE_ID:-$ID}" ) || :; }
+# BLS sort-key from os-release (IMAGE_ID, else ID); empty if the root has no os-release.
+# $1 = mounted root to describe (default /). Reads the TARGET's os-release and nothing else: under
+# -d the running root is a different image entirely, and in a recovery boot its ID is the recovery
+# system's, so borrowing it would put the wrong name on the entry rather than no name at all.
+os_sort_key() {
+    _osr="${1:-}/etc/os-release"
+    [ -r "$_osr" ] || { log "no os-release in ${1:-/}, entry gets no sort-key"; return 0; }
+    ( . "$_osr"; printf '%s' "${IMAGE_ID:-$ID}" ) || :
+}
 
 # Set DTB_DIR + DTB_DIRS (primary dir + modules fallback) for the current $KERNEL_VERSION.
 set_dtb_dirs() { DTB_DIR="/usr/lib/linux-image-$KERNEL_VERSION"; DTB_DIRS="$DTB_DIR /usr/lib/modules/$KERNEL_VERSION/dtb"; }
@@ -124,6 +131,14 @@ remove_root_entries() {  # $1 = subvol
 }
 
 # Base menu slot (900,800,700,... by flipper-profiles position) for the profile $1 belongs to.
+# Which profile list to read bands from: the target's own copy when it has one, else the running
+# root's. flipper_write_entry can be pointed at a filesystem we did not boot from, whose bands are
+# defined by its own list.
+target_profiles() {
+    if [ -f "${1:-}/etc/kernel/flipper-profiles" ]; then printf '%s' "$1/etc/kernel/flipper-profiles"
+    else printf '%s' "${PROFILES:-/etc/kernel/flipper-profiles}"; fi
+}
+
 # $1 is a btrfs-PARENT name. It anchors on an ACTUAL profile: the exact name (@Desktop) or its
 # golden base / snapshot (@Desktop_stock, @Desktop_<stamp>: profile name followed by '_'). A
 # hyphen-suffixed clone (@Desktop-2) must NOT match here, so origin_base_depth can walk THROUGH
@@ -341,7 +356,11 @@ flipper_write_entry() {
     [ -n "$KERNEL_VERSION" ] || { echo "flipper-bls: no /usr/lib/linux-image-* inside $_name" >&2; return 1; }
     resolve_kconfig "$_snap"
     set_dtb_dirs
-    SORT_KEY="$(os_sort_key)"
+    SORT_KEY="$(os_sort_key "$_snap")"
+    # The band comes from the profile list, which lives INSIDE a profile, not in the /etc of
+    # whatever is running. Under -d the running root may have no list at all (recovery), and an
+    # empty band silently drops the sort prefix from the entry filename.
+    PROFILES="${PROFILES:-$(target_profiles "$_snap")}"
     ENTRY_TOKEN="$(make_token "$(clone_slot "$_snap" "$_origin")" "$_name")"
     mkdir -p "$ENTRIES" || { echo "flipper-bls: cannot create $ENTRIES" >&2; return 1; }
     compute_base_opts

--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -350,7 +350,12 @@ flipper_write_entry() {
     _name="$1"; _snap="$2"; _origin="${3:-}"
     { [ -n "$_name" ] && [ -d "$_snap" ]; } || { echo "flipper-bls: usage: flipper_write_entry <name> <mounted-path>" >&2; return 1; }
     ENTRIES="${ENTRIES:-/boot/loader/entries}"
-    CONF_ROOT="${KERNEL_INSTALL_CONF_ROOT:-/etc/kernel}"
+    # The base cmdline (root=UUID and policy) belongs to the root being written, not to whatever
+    # is running. kernel-install still wins when it sets its own conf root. Without this, an entry
+    # written from a recovery boot came out with no root= at all, and so could not boot.
+    if [ -n "${KERNEL_INSTALL_CONF_ROOT:-}" ]; then CONF_ROOT="$KERNEL_INSTALL_CONF_ROOT"
+    elif [ -f "$_snap/etc/kernel/cmdline" ]; then CONF_ROOT="$_snap/etc/kernel"
+    else CONF_ROOT=/etc/kernel; fi
     MACHINE_ID=""; DEVICETREE=""; DEVICETREE_ENTRY=""
     # version from the target's OWN tree, so modules + dtbs are self-consistent
     KERNEL_VERSION="$(ls -1d "$_snap"/usr/lib/linux-image-* 2>/dev/null | sed 's,.*/linux-image-,,' | sort -V | tail -n1)"

--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -80,20 +80,18 @@ fdt_prefix() {  # $1 = options string -> "/<rootflags-subvol>" (or $FDT_SUBVOL_P
     return 0
 }
 
-# btrfs subvol of the current root (e.g. @Desktop); empty if not one. findmnt answers on a booted
-# system; in a chroot it can't, so fall back to the mount-agnostic btrfs subvolume show.
-current_subvol() {
+# Copies of flipper-btrfs.sh's booted_subvol/booted_fsuuid, kept byte-identical: kernel-install
+# sources this file without that one, so it needs its own. Keep the bodies in sync with it.
+booted_subvol() {
     _cs=$(findmnt -nro FSROOT / 2>/dev/null | sed 's,^/,,')
     [ -n "$_cs" ] || _cs=$(btrfs subvolume show / 2>/dev/null | sed -n '1{s,^/*,,;s,[[:space:]]*$,,;p}')
-    printf '%s\n' "$_cs"
+    printf '%s' "$_cs"
 }
 
-# btrfs FS UUID of the current root; empty if unknown. findmnt on a booted system, btrfs filesystem
-# show as the chroot-safe fallback (like current_subvol).
-current_fsuuid() {
+booted_fsuuid() {
     _fu=$(findmnt -nro UUID / 2>/dev/null)
     [ -n "$_fu" ] || _fu=$(btrfs filesystem show / 2>/dev/null | sed -n 's/.*[[:space:]]uuid:[[:space:]]*//p' | head -1)
-    printf '%s\n' "$_fu"
+    printf '%s' "$_fu"
 }
 
 # Remove loader entries whose options select SUBVOL and whose version == VERSION. Content-based
@@ -261,7 +259,7 @@ compute_base_opts() {
     # rewrite the shipped cmdline's build-time root=UUID to the fs we install onto, so a _stock
     # received onto a device with a different btrfs UUID still boots.
     # the filesystem the entry will boot from, which under -d is not the one we are running
-    _fsuuid="${TARGET_FSUUID:-$(current_fsuuid)}"
+    _fsuuid="${TARGET_FSUUID:-$(booted_fsuuid)}"
     [ -n "$_fsuuid" ] && BASE_OPTS="$(printf '%s' " $BASE_OPTS " | sed "s/ root=UUID=[^ ]*/ root=UUID=$_fsuuid/")"
     BASE_OPTS="$(trim "$BASE_OPTS")"
     # Pin systemd.machine_id= only when entries are named after the machine-id (no-op otherwise).

--- a/overlays/usr/lib/flipper-bls.sh
+++ b/overlays/usr/lib/flipper-bls.sh
@@ -98,7 +98,7 @@ remove_entries() {  # $1 = subvol  $2 = version
         [ "$(awk '$1=="version"{print $2; exit}' "$_c")" = "$2" ] || continue
         _es="$(awk '$1=="options"{for(i=2;i<=NF;i++) if($i ~ /^rootflags=subvol=/) s=$i}
                     END{sub(/^rootflags=subvol=/,"",s); print s}' "$_c")"
-        [ "$_es" = "$1" ] && rm -f "$_c"
+        [ "$_es" = "$1" ] && rm -f "$_c" || true
     done
     return 0   # a non-matching last entry must not fail the loop under set -e
 }

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -263,6 +263,21 @@ align_table() {
     }' "$1"
 }
 
+# Run a flipper-bls.sh function against the filesystem being operated on: its entries directory and
+# its UUID for the cmdline, not the running root's under -d. Subshell so the library's die cannot
+# abort us; a failure warns and returns, as the boot entry is never the point of the operation.
+with_bls() {  # $1 = what fails, for the warning; rest = function and arguments. Needs TOP
+    _what=$1; shift
+    _lib=/usr/lib/flipper-bls.sh
+    if [ -r "$_lib" ]; then
+        ( ENTRIES="$TOP/boot/loader/entries"; TARGET_FSUUID="$(top_fsuuid)"; . "$_lib"; "$@" ) \
+            || echo "Warning: $_what" >&2
+    else
+        echo "Warning: $_lib not found; $_what" >&2
+    fi
+    return 0
+}
+
 # Stamp a _stock's factory-origin marker (/etc/profile_origin) so migrate-profile can find a
 # profile's base after the btrfs parent chain is broken by deletions. Profiles snapshotted from
 # the stock inherit the file; matching later is by name, not by uuid (a snapshot clears that).

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -99,14 +99,16 @@ set_lock() {
 # ROOTDEV may be preset (by -d/--device) to run against a filesystem that is not the
 # booted root, e.g. from a RAM recovery boot where / is not the btrfs filesystem.
 mount_top() {
-    [ -n "${ROOTDEV:-}" ] || ROOTDEV=$(findmnt -no SOURCE / | sed 's/\[.*//')
-    [ -n "$ROOTDEV" ] || die "Cannot determine root device (use -d/--device)"
-    [ -b "$ROOTDEV" ] || die "Not a block device: $ROOTDEV"
-    TOP=$(mktemp -d)
+    # Arm cleanup FIRST: callers set TOP_TMPFILES before calling us, so a die on the checks below
+    # (a bad -d argument, no btrfs root) must still take their temp files with it.
     trap 'top_cleanup' EXIT
     # dash runs the EXIT trap on exit, not on a signal, so a plain kill would leave $TOP mounted;
     # route the usual signals through exit so the cleanup happens once, in one place
     trap 'exit 130' INT; trap 'exit 143' TERM; trap 'exit 129' HUP
+    [ -n "${ROOTDEV:-}" ] || ROOTDEV=$(findmnt -no SOURCE / | sed 's/\[.*//')
+    [ -n "$ROOTDEV" ] || die "Cannot determine root device (use -d/--device)"
+    [ -b "$ROOTDEV" ] || die "Not a block device: $ROOTDEV"
+    TOP=$(mktemp -d)
     _err=$(mount -o subvolid=5 "$ROOTDEV" "$TOP" 2>&1) || die "Mount failed: $_err"
 }
 top_cleanup() {

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -104,10 +104,22 @@ mount_top() {
     [ -b "$ROOTDEV" ] || die "Not a block device: $ROOTDEV"
     TOP=$(mktemp -d)
     trap 'top_cleanup' EXIT
+    # dash runs the EXIT trap on exit, not on a signal, so a plain kill would leave $TOP mounted;
+    # route the usual signals through exit so the cleanup happens once, in one place
+    trap 'exit 130' INT; trap 'exit 143' TERM; trap 'exit 129' HUP
     _err=$(mount -o subvolid=5 "$ROOTDEV" "$TOP" 2>&1) || die "Mount failed: $_err"
 }
 top_cleanup() {
-    [ -n "${TOP:-}" ] && { umount "$TOP" 2>/dev/null || true; rmdir "$TOP" 2>/dev/null || true; }
+    if [ -n "${TOP:-}" ]; then
+        for _i in 1 2 3 4 5; do
+            umount "$TOP" 2>/dev/null && break
+            # the callers run under set -e, where a failing detach would abort the trap and
+            # abandon the mount
+            [ "$_i" = 5 ] && umount -l "$TOP" 2>/dev/null || true
+            sleep 1
+        done
+        rmdir "$TOP" 2>/dev/null || true
+    fi
     [ -n "${TOP_TMPFILES:-}" ] && rm -f $TOP_TMPFILES
     return 0
 }

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -44,14 +44,11 @@ current_fsuuid() {
 HELP_YES="  -y,--yes    assume yes to prompts (non-interactive)"
 HELP_DEVICE="  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)"
 
-# UUID of the filesystem mount_top opened, which is the one being operated on. current_fsuuid()
-# answers for the BOOTED root instead, which is a different filesystem under -d and nothing at all
-# in a recovery boot, where every consumer then silently skipped its work.
-top_fsuuid() {
-    _tfu=$(blkid -o value -s UUID "${ROOTDEV:-}" 2>/dev/null)
-    [ -n "$_tfu" ] || _tfu=$(current_fsuuid)
-    printf '%s' "$_tfu"
-}
+# UUID of the filesystem being operated on, empty if blkid cannot say. Never falls back to the
+# booted root's: under -d that is a different filesystem, so a fallback would hand every caller the
+# wrong UUID exactly when it cannot check. Callers that want the booted root when this is empty say
+# so themselves (flipper-bls.sh does, for the cmdline root=UUID).
+top_fsuuid() { blkid -o value -s UUID "${ROOTDEV:-}" 2>/dev/null; }
 
 # Non-interactive switch for confirm(): set to 1 by -y/--yes, or via the environment
 # (ASSUME_YES=1 <tool> ...) so the tools can run unattended from scripts.
@@ -160,14 +157,6 @@ mount_top() {
     TOP=$(mktemp -d /run/flipper-btrfs.mnt.XXXXXX 2>/dev/null || mktemp -d)
     _err=$(mount -o subvolid=5 "$ROOTDEV" "$TOP" 2>&1) || die "Mount failed: $_err"
 }
-# True if the filesystem mount_top opened is the one we booted from, so the booted profile and its
-# subvolume ids mean something here. Under -d/--device (recovery) the two filesystems are unrelated
-# and their ids collide by accident, which would mark or refuse the wrong subvolume. Needs ROOTDEV.
-top_is_booted_fs() {
-    root_is_btrfs || return 1
-    _tu=$(blkid -o value -s UUID "${ROOTDEV:-}" 2>/dev/null)
-    [ -n "$_tu" ] && [ "$_tu" = "$(current_fsuuid)" ]
-}
 
 # Best-effort was not good enough: on a signal the children (btrfs send/receive, zstd) are still
 # dying, so the first umount can lose the race with EBUSY and the top-level mount leaks for the rest
@@ -206,7 +195,16 @@ resolve_rel() {
 get() { printf '%s\n' "$1" | awk -v k="$2" -F':[[:space:]]+' 'index($0,k){print $2; exit}'; }
 
 subvol_id() { get "$(btrfs subvolume show "$1" 2>/dev/null)" "Subvolume ID"; }
-booted_id() { subvol_id /; }
+
+# The booted profile as it applies to the filesystem being operated on ($1 = id|subvol), empty when
+# that is provably another one, where ids and names repeat and a match would be coincidence. Only
+# proof empties it: a probe that cannot answer must not disarm the refusals that read this.
+top_booted() {  # needs ROOTDEV
+    root_is_btrfs || return 0
+    _bu=$(current_fsuuid); _tu=$(top_fsuuid)
+    [ -n "$_bu" ] && [ -n "$_tu" ] && [ "$_bu" != "$_tu" ] && return 0
+    case "$1" in id) subvol_id / ;; subvol) current_subvol ;; esac
+}
 
 # True if the subvolume at $1 is read-only.
 is_ro() {

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -14,6 +14,10 @@ die() { echo "Error: $*" >&2; exit 1; }
 need_root()  { [ "$(id -u)" -eq 0 ] || die "Must run as root (use sudo)"; }
 need_btrfs() { command -v btrfs >/dev/null 2>&1 || die "Btrfs-progs not installed"; }
 need_cmd()   { command -v "$1" >/dev/null 2>&1 || die "Command not installed: $1${2:+ ($2)}"; }
+# Guard for the -d/--device value: fail (with the tool's usage) if the flag was the last token.
+# Call with the arg count remaining AFTER shifting the flag off:
+#   -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
+need_device_arg() { [ "$1" -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; }
 
 # True if / is a btrfs mount (a normally booted system, not a RAM recovery root).
 root_is_btrfs() { [ "$(findmnt -no FSTYPE / 2>/dev/null)" = btrfs ]; }

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -44,6 +44,15 @@ current_fsuuid() {
 HELP_YES="  -y,--yes    assume yes to prompts (non-interactive)"
 HELP_DEVICE="  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)"
 
+# UUID of the filesystem mount_top opened, which is the one being operated on. current_fsuuid()
+# answers for the BOOTED root instead, which is a different filesystem under -d and nothing at all
+# in a recovery boot, where every consumer then silently skipped its work.
+top_fsuuid() {
+    _tfu=$(blkid -o value -s UUID "${ROOTDEV:-}" 2>/dev/null)
+    [ -n "$_tfu" ] || _tfu=$(current_fsuuid)
+    printf '%s' "$_tfu"
+}
+
 # Non-interactive switch for confirm(): set to 1 by -y/--yes, or via the environment
 # (ASSUME_YES=1 <tool> ...) so the tools can run unattended from scripts.
 ASSUME_YES=${ASSUME_YES:-0}

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -266,12 +266,10 @@ align_table() {
 }
 
 # Stamp a _stock's factory-origin marker (/etc/profile_origin) so migrate-profile can find a
-# profile's base after the btrfs parent chain is broken by deletions. Records the stock's own
-# name and its build id (BUILD_GIT from os-release). Profiles snapshotted from the stock inherit
-# the file; matching later is by name + BUILD_GIT, not by uuid (uuid is cleared by snapshots).
-# $1 = the stock's mounted dir, $2 = the stock's name (e.g. @Desktop_stock).
+# profile's base after the btrfs parent chain is broken by deletions. Profiles snapshotted from
+# the stock inherit the file; matching later is by name, not by uuid (a snapshot clears that).
+# The name carries the build id (@Desktop_744_stock), so it identifies the exact base on its own.
+# $1 = the stock's mounted dir, $2 = the stock's name (e.g. @Desktop_744_stock).
 stamp_stock_origin() {
-    _bg=$( . "$1/etc/os-release" >/dev/null 2>&1; printf '%s' "${BUILD_GIT:-}" ) || _bg=
-    [ -n "$_bg" ] || _bg=-
-    printf 'origin_stock_name=%s\norigin_base_build=%s\n' "$2" "$_bg" > "$1/etc/profile_origin"
+    printf 'origin_stock_name=%s\n' "$2" > "$1/etc/profile_origin"
 }

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -25,14 +25,14 @@ root_is_btrfs() { [ "$(findmnt -no FSTYPE / 2>/dev/null)" = btrfs ]; }
 # The subvolume mounted at / (e.g. @Desktop), empty if there is none. findmnt cannot answer inside a
 # chroot, so fall back to asking btrfs. flipper-bls.sh keeps its own copy: kernel-install hooks
 # source that file without this one.
-current_subvol() {
+booted_subvol() {
     _cs=$(findmnt -nro FSROOT / 2>/dev/null | sed 's,^/,,')
     [ -n "$_cs" ] || _cs=$(btrfs subvolume show / 2>/dev/null | sed -n '1{s,^/*,,;s,[[:space:]]*$,,;p}')
     printf '%s' "$_cs"
 }
 
-# btrfs FS UUID of the mounted root, empty if unknown. Same reasoning as current_subvol.
-current_fsuuid() {
+# btrfs FS UUID of the mounted root, empty if unknown. Same reasoning as booted_subvol.
+booted_fsuuid() {
     _fu=$(findmnt -nro UUID / 2>/dev/null)
     [ -n "$_fu" ] || _fu=$(btrfs filesystem show / 2>/dev/null | sed -n 's/.*[[:space:]]uuid:[[:space:]]*//p' | head -1)
     printf '%s' "$_fu"
@@ -201,9 +201,9 @@ subvol_id() { get "$(btrfs subvolume show "$1" 2>/dev/null)" "Subvolume ID"; }
 # proof empties it: a probe that cannot answer must not disarm the refusals that read this.
 top_booted() {  # needs ROOTDEV
     root_is_btrfs || return 0
-    _bu=$(current_fsuuid); _tu=$(top_fsuuid)
+    _bu=$(booted_fsuuid); _tu=$(top_fsuuid)
     [ -n "$_bu" ] && [ -n "$_tu" ] && [ "$_bu" != "$_tu" ] && return 0
-    case "$1" in id) subvol_id / ;; subvol) current_subvol ;; esac
+    case "$1" in id) subvol_id / ;; subvol) booted_subvol ;; esac
 }
 
 # True if the subvolume at $1 is read-only.

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -88,10 +88,17 @@ set_lock() {
     exec 9<>"$LOCK_FILE" || die "Cannot open lock $LOCK_FILE"   # <> = don't truncate the holder line
     if ! flock -w 0 9 2>/dev/null; then
         _h=$(cat "$LOCK_FILE" 2>/dev/null); [ -n "$_h" ] || _h="PID unknown"
+        # the line is written by whoever holds it; if that process is gone the line is stale
+        # leftovers from a crash, so do not present it as the reason we are waiting
+        _hp=${_h#PID }; _hp=${_hp%% *}
+        case "$_hp" in
+            [0-9]*) kill -0 "$_hp" 2>/dev/null || _h="$_h, which is no longer running; the line is stale" ;;
+        esac
         echo "Another flipper-btrfs operation is in progress ($_h); waiting for it to finish..." >&2
         flock 9 || die "Cannot acquire lock $LOCK_FILE"
     fi
     printf 'PID %s (%s)\n' "$$" "${0##*/}" >"$LOCK_FILE" || true
+    LOCK_HELD=1
 }
 
 # Mount the btrfs top level (subvolid=5) at a temp dir and arrange teardown on EXIT.
@@ -112,6 +119,9 @@ mount_top() {
     _err=$(mount -o subvolid=5 "$ROOTDEV" "$TOP" 2>&1) || die "Mount failed: $_err"
 }
 top_cleanup() {
+    # the holder line outlives the flock the kernel drops for us, so blank it: no waiter should read
+    # a pid gone for days
+    [ "${LOCK_HELD:-0}" = 1 ] && : > "$LOCK_FILE" 2>/dev/null
     if [ -n "${TOP:-}" ]; then
         for _i in 1 2 3 4 5; do
             umount "$TOP" 2>/dev/null && break

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -84,6 +84,18 @@ validate_profile_name() {
 # file so a blocked waiter can say who it is waiting on. Read-only tools do not take it, and it
 # does NOT guard against concurrent native `btrfs` commands, which honor no lock.
 LOCK_FILE=/run/flipper-btrfs.lock
+
+# True if we are the OPPOSITE end of a pipe from that pid (our stdout is its stdin, or the reverse).
+# Sharing the same end does not count: siblings from one shell inherit the same stdin. /proc names a
+# pipe as pipe:[<inode>], so the inode is the identity.
+pipe_shared_with() {  # $1 = pid
+    _out=$(readlink "/proc/$$/fd/1" 2>/dev/null || true)
+    _in=$(readlink "/proc/$$/fd/0" 2>/dev/null || true)
+    case "$_out" in pipe:*) [ "$_out" = "$(readlink "/proc/$1/fd/0" 2>/dev/null || true)" ] && return 0 ;; esac
+    case "$_in" in pipe:*) [ "$_in" = "$(readlink "/proc/$1/fd/1" 2>/dev/null || true)" ] && return 0 ;; esac
+    return 1
+}
+
 set_lock() {
     exec 9<>"$LOCK_FILE" || die "Cannot open lock $LOCK_FILE"   # <> = don't truncate the holder line
     if ! flock -w 0 9 2>/dev/null; then
@@ -94,11 +106,29 @@ set_lock() {
         case "$_hp" in
             [0-9]*) kill -0 "$_hp" 2>/dev/null || _h="$_h, which is no longer running; the line is stale" ;;
         esac
+        # A holder on the other end of our pipe can never release: it is blocked reading what we
+        # have not written. Waiting is then a deadlock, so say so. A holder that merely shares our
+        # process group (a sibling job from one script) is not that case and must be waited for.
+        case "$_hp" in
+            [0-9]*) if kill -0 "$_hp" 2>/dev/null && pipe_shared_with "$_hp"; then
+                        die "$_h holds the lock and is on the other end of our pipe, so waiting would deadlock. Piping one of our tools into another on the same machine cannot work: write the stream to a file and read it back, or run one side on another host"
+                    fi ;;
+        esac
         echo "Another flipper-btrfs operation is in progress ($_h); waiting for it to finish..." >&2
         flock 9 || die "Cannot acquire lock $LOCK_FILE"
     fi
     printf 'PID %s (%s)\n' "$$" "${0##*/}" >"$LOCK_FILE" || true
     LOCK_HELD=1
+}
+
+# Drop the lock before a long read-only phase, so a writer does not queue behind work that no
+# longer mutates anything. The kernel releases the flock when the last descriptor closes, and
+# children inherit fd 9, so this only takes effect for what we start afterwards.
+release_lock() {
+    [ "${LOCK_HELD:-0}" = 1 ] || return 0
+    ( : > "$LOCK_FILE" ) 2>/dev/null || true
+    exec 9>&-
+    LOCK_HELD=0
 }
 
 # Mount the btrfs top level (subvolid=5) at a temp dir and arrange teardown on EXIT.

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -115,7 +115,10 @@ mount_top() {
     [ -n "${ROOTDEV:-}" ] || ROOTDEV=$(findmnt -no SOURCE / | sed 's/\[.*//')
     [ -n "$ROOTDEV" ] || die "Cannot determine root device (use -d/--device)"
     [ -b "$ROOTDEV" ] || die "Not a block device: $ROOTDEV"
-    TOP=$(mktemp -d)
+    # NOT under /tmp: `rm -rf /tmp/tmp.*` while a tool holds its mount recurses through the whole
+    # filesystem, and rmdir removes an empty subvolume, so it deletes profiles, @home and boot.
+    # /run is tmpfs, root-only, and nobody sweeps it by glob.
+    TOP=$(mktemp -d /run/flipper-btrfs.mnt.XXXXXX 2>/dev/null || mktemp -d)
     _err=$(mount -o subvolid=5 "$ROOTDEV" "$TOP" 2>&1) || die "Mount failed: $_err"
 }
 top_cleanup() {

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -151,6 +151,18 @@ mount_top() {
     TOP=$(mktemp -d /run/flipper-btrfs.mnt.XXXXXX 2>/dev/null || mktemp -d)
     _err=$(mount -o subvolid=5 "$ROOTDEV" "$TOP" 2>&1) || die "Mount failed: $_err"
 }
+# True if the filesystem mount_top opened is the one we booted from, so the booted profile and its
+# subvolume ids mean something here. Under -d/--device (recovery) the two filesystems are unrelated
+# and their ids collide by accident, which would mark or refuse the wrong subvolume. Needs ROOTDEV.
+top_is_booted_fs() {
+    root_is_btrfs || return 1
+    _tu=$(blkid -o value -s UUID "${ROOTDEV:-}" 2>/dev/null)
+    [ -n "$_tu" ] && [ "$_tu" = "$(current_fsuuid)" ]
+}
+
+# Best-effort was not good enough: on a signal the children (btrfs send/receive, zstd) are still
+# dying, so the first umount can lose the race with EBUSY and the top-level mount leaks for the rest
+# of the uptime. Retry briefly, then detach lazily so it goes away once the last reference does.
 top_cleanup() {
     # the holder line outlives the flock the kernel drops for us, so blank it: no waiter should read
     # a pid gone for days. Subshell: a failed '>' on the special builtin ':' exits the shell outright,

--- a/overlays/usr/lib/flipper-btrfs.sh
+++ b/overlays/usr/lib/flipper-btrfs.sh
@@ -123,8 +123,9 @@ mount_top() {
 }
 top_cleanup() {
     # the holder line outlives the flock the kernel drops for us, so blank it: no waiter should read
-    # a pid gone for days
-    [ "${LOCK_HELD:-0}" = 1 ] && : > "$LOCK_FILE" 2>/dev/null
+    # a pid gone for days. Subshell: a failed '>' on the special builtin ':' exits the shell outright,
+    # too early for '|| true' to catch, and the unmount below still has to run
+    [ "${LOCK_HELD:-0}" = 1 ] && ( : > "$LOCK_FILE" ) 2>/dev/null || true
     if [ -n "${TOP:-}" ]; then
         for _i in 1 2 3 4 5; do
             umount "$TOP" 2>/dev/null && break
@@ -135,7 +136,7 @@ top_cleanup() {
         done
         rmdir "$TOP" 2>/dev/null || true
     fi
-    [ -n "${TOP_TMPFILES:-}" ] && rm -f $TOP_TMPFILES
+    [ -n "${TOP_TMPFILES:-}" ] && rm -f $TOP_TMPFILES || true
     return 0
 }
 

--- a/overlays/usr/local/sbin/btrfs-maintenance
+++ b/overlays/usr/local/sbin/btrfs-maintenance
@@ -21,14 +21,14 @@ Usage: btrfs-maintenance [-d|--device DEV] <check|fix|dedup|balance|all>
   dedup     offline dedup via duperemove across all writable subvolumes
   balance   light filtered balance to reclaim partly-empty chunks
   all       check + dedup + balance
-  -d,--device  operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
 EOF
 }
 
 do_scrub=0; scrub_ro=; dedup=0; balance=0; lock=1; cmd=""
 while [ $# -gt 0 ]; do
     case "$1" in
-        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -y|--yes)    ASSUME_YES=1 ;;
         -h|--help)   usage; exit 0 ;;

--- a/overlays/usr/local/sbin/btrfs-maintenance
+++ b/overlays/usr/local/sbin/btrfs-maintenance
@@ -62,16 +62,60 @@ if [ -n "${ROOTDEV:-}" ] || ! root_is_btrfs; then mount_top; MNT=$TOP; fi
 do_dedup() {
     need_cmd duperemove
     [ -n "${TOP:-}" ] || mount_top
-    HASHFILE=$TOP/@var-cache/.duperemove_hashes.db
+    # @var-cache is where the hashfile belongs, so it survives between runs and is not itself
+    # deduped. It is only there on filesystems our image built, and -d/--device exists precisely
+    # for the others, where duperemove would otherwise fail with an opaque "Error opening db".
+    if [ -d "$TOP/@var-cache" ]; then
+        HASHFILE=$TOP/@var-cache/.duperemove_hashes.db
+    else
+        HASHFILE=$(mktemp -u)
+        TOP_TMPFILES="${TOP_TMPFILES:-} $HASHFILE"
+        echo "No @var-cache on this filesystem; keeping duperemove's hash db in $HASHFILE for this run only" >&2
+    fi
     _excl=""
     for _p in $(btrfs subvolume list -r "$TOP" | awk '{print $NF}'); do
         _excl="$_excl --exclude=$TOP/$_p"
     done
-    duperemove -dhr --hashfile="$HASHFILE" --exclude="$HASHFILE*" $_excl "$TOP" || die "Duperemove failed (rc=$?)"
+    # duperemove exits 22 with "No dedupe candidates found" when there is nothing to do, which is
+    # not a failure. Keep the output live and read the status separately, since a pipeline reports
+    # only the last command's.
+    _dlog=$(mktemp); _drc=$(mktemp)
+    TOP_TMPFILES="${TOP_TMPFILES:-} $_dlog $_drc"
+    { duperemove -dhr --hashfile="$HASHFILE" --exclude="$HASHFILE*" $_excl "$TOP" 2>&1 || echo $? > "$_drc"; } | tee "$_dlog"
+    _rc=0
+    if [ -s "$_drc" ]; then _rc=$(cat "$_drc"); fi
+    if [ "$_rc" != 0 ]; then
+        if [ "$_rc" = 22 ] && grep -q 'No dedupe candidates found' "$_dlog"; then
+            echo "Nothing to dedup here: duperemove found no candidates, so no space was reclaimed"
+        else
+            die "Duperemove failed (rc=$_rc)"
+        fi
+    fi
 }
 
 [ "$lock" = 1 ]     && set_lock
-[ "$do_scrub" = 1 ] && btrfs scrub start -B $scrub_ro "$MNT"
+# A scrub that reports errors ended the run here with nothing said, so 'all' silently did no dedup
+# and no balance. Stopping is right, since both rewrite extents and that is not what a filesystem
+# with unfixed errors needs, but it has to be stated.
+if [ "$do_scrub" = 1 ] && ! btrfs scrub start -B $scrub_ro "$MNT"; then
+    if [ "$dedup" = 1 ] || [ "$balance" = 1 ]; then
+        die "Scrub failed or reported errors, so dedup and balance were not run: both rewrite extents, which a filesystem with unfixed errors does not need. Try 'btrfs-maintenance fix', then run this again"
+    fi
+    die "Scrub failed or reported errors on $MNT"
+fi
 [ "$dedup" = 1 ]    && do_dedup
-[ "$balance" = 1 ]  && btrfs balance start -dusage=20 -musage=10 "$MNT"
+if [ "$balance" = 1 ]; then
+    # A balance needs somewhere to move chunks to. On a nearly full filesystem btrfs reports
+    # ENOSPC through the kernel log and leaves the caller with "try dmesg | tail", so say it here.
+    if ! _berr=$(btrfs balance start -dusage=20 -musage=10 "$MNT" 2>&1); then
+        printf '%s\n' "$_berr" >&2
+        case "$_berr" in
+            *"No space left"*|*ENOSPC*|*enospc*) die "Balance needs free space to move chunks into, and this filesystem has too little; free some and retry" ;;
+        esac
+        if dmesg 2>/dev/null | tail -40 | grep -qi 'enospc errors during balance'; then
+            die "Balance hit ENOSPC (kernel log): too little free space to move chunks; free some and retry"
+        fi
+        die "Balance failed"
+    fi
+fi
 exit 0

--- a/overlays/usr/local/sbin/btrfs-show-space
+++ b/overlays/usr/local/sbin/btrfs-show-space
@@ -1,7 +1,7 @@
 #!/bin/sh
 # btrfs-show-space [-q|--quick] - btrfs usage + per-root-subvolume space.
 # (-q/--quick skips the compsize REFERENCED column, one less extent-walk per subvol.)
-# Lists EVERY subvolume: profile roots and @.old_* leftovers, the snapshots under @snapshots,
+# Lists EVERY subvolume: profile roots and @_old_* leftovers, the snapshots under @snapshots,
 # the _stock bases under @stock-snapshots, and the shared @home / @var-* / boot.
 #   UNIQUE     - data only this subvolume holds; freed if you delete IT ALONE,
 #                others kept (btrfs fi du, exact, uncompressed)
@@ -70,7 +70,7 @@ row() {  # $1=display name  $2=fs path  -> append a TSV row
 }
 
 # collect EVERY subvolume (cheap), then measure with progress: each row walks extents (slow on
-# flash). btrfs subvolume list gives top-relative paths: profile roots + @.old_*, the nested
+# flash). btrfs subvolume list gives top-relative paths: profile roots + @_old_*, the nested
 # @snapshots/* and @stock-snapshots/* children, and the shared @home / @var-* / boot.
 btrfs subvolume list "$TOP" 2>/dev/null | sed -n 's/.* path //p' | sort | while read -r p; do
     printf '%s\t%s\n' "$p" "$TOP/$p" >> "$list"

--- a/overlays/usr/local/sbin/btrfs-show-space
+++ b/overlays/usr/local/sbin/btrfs-show-space
@@ -47,7 +47,7 @@ rows=$(mktemp)
 list=$(mktemp)
 TOP_TMPFILES="$rows $list"
 mount_top
-cur_id=$(booted_id)
+cur_id=""; top_is_booted_fs && cur_id=$(booted_id)
 
 echo "== filesystem =="
 btrfs filesystem usage -T "$TOP"

--- a/overlays/usr/local/sbin/btrfs-show-space
+++ b/overlays/usr/local/sbin/btrfs-show-space
@@ -21,7 +21,7 @@ usage() {
 Usage: btrfs-show-space [-q|--quick] [-d|--device DEV]
   Btrfs usage plus per-root-subvolume space (UNIQUE / REFERENCED / TOTAL).
   -q,--quick  skip the compsize REFERENCED column (one less extent-walk per subvol)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
 EOF
 }
 
@@ -29,7 +29,7 @@ quick=0
 while [ $# -gt 0 ]; do
     case "$1" in
         -q|--quick)  quick=1 ;;
-        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
         -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;

--- a/overlays/usr/local/sbin/btrfs-show-space
+++ b/overlays/usr/local/sbin/btrfs-show-space
@@ -47,7 +47,7 @@ rows=$(mktemp)
 list=$(mktemp)
 TOP_TMPFILES="$rows $list"
 mount_top
-cur_id=""; top_is_booted_fs && cur_id=$(booted_id)
+cur_id=$(top_booted id)
 
 echo "== filesystem =="
 btrfs filesystem usage -T "$TOP"
@@ -65,7 +65,7 @@ row() {  # $1=display name  $2=fs path  -> append a TSV row
         ref_h="-"
     fi
     id=$(subvol_id "$2")
-    mark=""; [ -n "$cur_id" ] && [ "$id" = "$cur_id" ] && mark="<- booted"
+    mark=""; [ "$id" = "$cur_id" ] && mark="<- booted"
     printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$mark" "$(human "$exc")" "$ref_h" "$(human "$tot")" >> "$rows"
 }
 

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -27,8 +27,8 @@ usage() {
     cat <<EOF
 Usage: create-profile [-m|--move] [-y|--yes] [-d|--device DEV] <@source> [<@dest>|current]
   -m,--move   move <@source> into <@dest> (consume source, preserve parent_uuid)
-  -y,--yes    assume yes to prompts (non-interactive)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_YES
+$HELP_DEVICE
   <@source>   full path or bare name: @snapshots/<name>, @<profile>_<stamp>, @<profile>_stock
   <@dest>     profile to write (default: booted profile; or current|booted)
 EOF
@@ -39,7 +39,7 @@ while :; do
     case "${1:-}" in
         -m|--move)   move=1; shift ;;
         -y|--yes)    ASSUME_YES=1; shift ;;
-        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1; shift ;;
+        -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1; shift ;;
         --device=*)  ROOTDEV=${1#*=}; shift ;;
         -h|--help)   usage; exit 0 ;;
         -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -13,7 +13,7 @@
 #             profile root while keeping its _stock parent.
 #
 # If <@dest> does not exist it is created and a BLS boot entry is generated for it. If it
-# already exists it is replaced and the previous copy kept as <@dest>.old_<ts> (recoverable;
+# already exists it is replaced and the previous copy kept as <@dest>_old_<ts> (recoverable;
 # its boot entry is refreshed in place, so no duplicate is left behind). The result is always
 # writable, even when <@source> is read-only.
 #
@@ -83,7 +83,7 @@ else
     how="with a writable copy of '$src_name'"
 fi
 if [ "$existed" = 1 ]; then
-    confirm "$(printf "Replace existing profile '%s' %s on %s?\nThe current '%s' is kept as %s.old_<ts>." \
+    confirm "$(printf "Replace existing profile '%s' %s on %s?\nThe current '%s' is kept as %s_old_<ts>." \
         "$rel" "$how" "$ROOTDEV" "$rel" "$rel")"
 else
     confirm "Create bootable profile '$rel' $how on $ROOTDEV?"
@@ -99,11 +99,11 @@ if [ "$move" = 1 ]; then
 fi
 if [ "$existed" = 1 ]; then
     # the stamp is per-second, so a second replace within the same second would land on an
-    # existing .old_<ts> and mv would nest the profile INSIDE it; take the next free name
+    # existing _old_<ts> and mv would nest the profile INSIDE it; take the next free name
     ts=$(stamp)
-    aside="$tgt.old_$ts"
+    aside="${tgt}_old_$ts"
     n=1
-    while [ -e "$aside" ]; do aside="$tgt.old_${ts}_$n"; n=$((n + 1)); done
+    while [ -e "$aside" ]; do aside="${tgt}_old_${ts}_$n"; n=$((n + 1)); done
     mv -T "$tgt" "$aside" || die "Could not move '$rel' aside; nothing changed"
 fi
 if [ "$move" = 1 ]; then

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -144,21 +144,9 @@ if [ -f "$fst" ]; then
     [ -n "$cur" ] && [ -n "$old" ] && [ "$cur" != "$old" ] && { sed -i "s/$old/$cur/g" "$fst"; echo "fstab: rewrote fs UUID $old -> $cur"; }
 fi
 
-# BLS entry + /etc/kernel/entry-token via flipper-bls.sh, in a subshell so its die can't abort
-# us. Pass the SOURCE as origin hint so the root lands in that profile's band if parent_uuid is
-# left dangling.
-lib=/usr/lib/flipper-bls.sh
-if [ -r "$lib" ]; then
-    (
-      # entries live on the filesystem we are operating on, not on the running root under -d,
-      # and its UUID is what the cmdline must name
-      ENTRIES="$TOP/boot/loader/entries"
-      TARGET_FSUUID="$(top_fsuuid)"
-      . "$lib"; flipper_write_entry "$rel" "$tgt" "$src_rel" ) \
-        || echo "Warning: Boot entry not created for $rel" >&2
-else
-    echo "Warning: $lib not found; no boot entry created for $rel" >&2
-fi
+# BLS entry + /etc/kernel/entry-token. Pass the SOURCE as origin hint so the root lands in that
+# profile's band if parent_uuid is left dangling.
+with_bls "boot entry not created for $rel" flipper_write_entry "$rel" "$tgt" "$src_rel"
 
 if [ "$move" = 1 ]; then verb="moved"; else verb="created"; fi
 if [ "$existed" = 1 ]; then

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -136,7 +136,10 @@ fi
 # left dangling.
 lib=/usr/lib/flipper-bls.sh
 if [ -r "$lib" ]; then
-    ( . "$lib"; flipper_write_entry "$rel" "$tgt" "$src_rel" ) \
+    (
+      # entries live on the filesystem we are operating on, not on the running root under -d
+      ENTRIES="$TOP/boot/loader/entries"
+      . "$lib"; flipper_write_entry "$rel" "$tgt" "$src_rel" ) \
         || echo "Warning: Boot entry not created for $rel" >&2
 else
     echo "Warning: $lib not found; no boot entry created for $rel" >&2

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -64,13 +64,11 @@ src="$TOP/$src_rel"
 
 # dest -> exact top-level name (default: booted root)
 case "$dest" in
-    current|booted|"") root_is_btrfs || die "No booted profile to default <@dest> to; pass an explicit <@dest> (e.g. @Desktop-2)"
-                       # 'current' means the profile we booted from, which does not exist on another
-                       # filesystem. Resolving it there would take its NAME and replace whatever
-                       # happens to be called that on the target, moving the user's profile aside.
-                       top_is_booted_fs || die "No booted profile to default <@dest> to on $ROOTDEV, which is not the filesystem you booted from; pass an explicit <@dest> (e.g. @Desktop-2)"
-                       rel=$(current_subvol)
-                       [ -n "$rel" ] || die "Cannot determine booted subvolume" ;;
+    # 'current' means the profile we booted from, which does not exist on another filesystem.
+    # Resolving it there would take its NAME and replace whatever happens to be called that on the
+    # target, moving the user's profile aside.
+    current|booted|"") rel=$(top_booted subvol)
+                       [ -n "$rel" ] || die "No booted profile on $ROOTDEV to default <@dest> to; pass an explicit <@dest> (e.g. @Desktop-2)" ;;
     *)                 rel=$dest; validate_profile_name "$rel" ;;
 esac
 is_reserved_subvol "$rel" && die "Refusing to write reserved subvolume: $rel"
@@ -81,11 +79,11 @@ existed=0; [ -e "$TOP/$rel" ] && existed=1
 # a _stock), but the running system keeps using the copy moved aside until a reboot, so say so
 # before doing it and warn again afterwards.
 replacing_booted=0
-# Only ask the id question on the filesystem we booted from: ids are per-filesystem, so 265 here and
-# 265 on a target reached through -d are unrelated, and comparing them claims a reboot is needed for
-# a profile the running system never used.
-if [ "$existed" = 1 ] && root_is_btrfs && top_is_booted_fs; then
-    [ "$(subvol_id "$TOP/$rel")" = "$(booted_id)" ] && replacing_booted=1
+# ids are per-filesystem, so 265 here and 265 on a target reached through -d are unrelated, and
+# comparing them claims a reboot is needed for a profile the running system never used.
+cur_id=$(top_booted id)
+if [ "$existed" = 1 ] && [ "$(subvol_id "$TOP/$rel")" = "$cur_id" ]; then
+    replacing_booted=1
 fi
 if [ "$move" = 1 ]; then
     how="by MOVING '$src_name' into it (source consumed, parent preserved)"

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -126,7 +126,7 @@ rm -f "$tgt/var/lib/dbus/machine-id" 2>/dev/null || true
 # entry uses; swap every occurrence for the live one.
 fst="$tgt/etc/fstab"
 if [ -f "$fst" ]; then
-    cur=$(current_fsuuid)
+    cur=$(top_fsuuid)
     old=$(awk '$2=="/"{for(i=1;i<=NF;i++) if($i ~ /^UUID=/){sub(/^UUID=/,"",$i); print $i; exit}}' "$fst")
     [ -n "$cur" ] && [ -n "$old" ] && [ "$cur" != "$old" ] && { sed -i "s/$old/$cur/g" "$fst"; echo "fstab: rewrote fs UUID $old -> $cur"; }
 fi
@@ -137,8 +137,10 @@ fi
 lib=/usr/lib/flipper-bls.sh
 if [ -r "$lib" ]; then
     (
-      # entries live on the filesystem we are operating on, not on the running root under -d
+      # entries live on the filesystem we are operating on, not on the running root under -d,
+      # and its UUID is what the cmdline must name
       ENTRIES="$TOP/boot/loader/entries"
+      TARGET_FSUUID="$(top_fsuuid)"
       . "$lib"; flipper_write_entry "$rel" "$tgt" "$src_rel" ) \
         || echo "Warning: Boot entry not created for $rel" >&2
 else

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -77,14 +77,25 @@ is_reserved_subvol "$rel" && die "Refusing to write reserved subvolume: $rel"
 [ "$rel" = "$src_rel" ] && die "Dest and source are the same subvolume"
 
 existed=0; [ -e "$TOP/$rel" ] && existed=1
+# Replacing the profile we are booted from is allowed on purpose (it is how a profile is reset to
+# a _stock), but the running system keeps using the copy moved aside until a reboot, so say so
+# before doing it and warn again afterwards.
+replacing_booted=0
+# Only ask the id question on the filesystem we booted from: ids are per-filesystem, so 265 here and
+# 265 on a target reached through -d are unrelated, and comparing them claims a reboot is needed for
+# a profile the running system never used.
+if [ "$existed" = 1 ] && root_is_btrfs && top_is_booted_fs; then
+    [ "$(subvol_id "$TOP/$rel")" = "$(booted_id)" ] && replacing_booted=1
+fi
 if [ "$move" = 1 ]; then
     how="by MOVING '$src_name' into it (source consumed, parent preserved)"
 else
     how="with a writable copy of '$src_name'"
 fi
 if [ "$existed" = 1 ]; then
-    confirm "$(printf "Replace existing profile '%s' %s on %s?\nThe current '%s' is kept as %s_old_<ts>." \
-        "$rel" "$how" "$ROOTDEV" "$rel" "$rel")"
+    confirm "$(printf "Replace existing profile '%s' %s on %s?\nThe current '%s' is kept as %s_old_<ts>.%s" \
+        "$rel" "$how" "$ROOTDEV" "$rel" "$rel" \
+        "$([ "$replacing_booted" = 1 ] && printf "\nThis is the profile you are booted from: the running system stays on the copy moved aside until you reboot.")")"
 else
     confirm "Create bootable profile '$rel' $how on $ROOTDEV?"
 fi
@@ -154,7 +165,14 @@ fi
 if [ "$move" = 1 ]; then verb="moved"; else verb="created"; fi
 if [ "$existed" = 1 ]; then
     echo "Profile '$rel' $verb from '$src_name' (writable); previous kept as ${aside##*/}"
-    echo "Reboot into '$rel' to use it; remove the old copy later with:"
+    if [ "$replacing_booted" = 1 ]; then
+        echo "WARNING: REBOOT REQUIRED. '$rel' is the profile you are booted from, so the running" >&2
+        echo "         system is still the copy moved aside as ${aside##*/}; anything written" >&2
+        echo "         now lands there, not in the new '$rel'." >&2
+        echo "After rebooting, remove the old copy with:"
+    else
+        echo "Reboot into '$rel' to use it; remove the old copy later with:"
+    fi
     echo "  sudo delete-profile ${aside##*/}"
 else
     echo "Profile '$rel' $verb from '$src_name' (writable, boot entry added)"

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -65,6 +65,10 @@ src="$TOP/$src_rel"
 # dest -> exact top-level name (default: booted root)
 case "$dest" in
     current|booted|"") root_is_btrfs || die "No booted profile to default <@dest> to; pass an explicit <@dest> (e.g. @Desktop-2)"
+                       # 'current' means the profile we booted from, which does not exist on another
+                       # filesystem. Resolving it there would take its NAME and replace whatever
+                       # happens to be called that on the target, moving the user's profile aside.
+                       top_is_booted_fs || die "No booted profile to default <@dest> to on $ROOTDEV, which is not the filesystem you booted from; pass an explicit <@dest> (e.g. @Desktop-2)"
                        rel=$(current_subvol)
                        [ -n "$rel" ] || die "Cannot determine booted subvolume" ;;
     *)                 rel=$dest; validate_profile_name "$rel" ;;

--- a/overlays/usr/local/sbin/create-profile
+++ b/overlays/usr/local/sbin/create-profile
@@ -104,12 +104,12 @@ if [ "$existed" = 1 ]; then
 fi
 if [ "$move" = 1 ]; then
     if ! mv "$src" "$tgt"; then
-        [ -n "$aside" ] && mv "$aside" "$tgt"
+        [ -n "$aside" ] && mv "$aside" "$tgt" || true
         die "Move failed; ${aside:+previous $rel restored, }nothing changed"
     fi
 else
     if ! btrfs subvolume snapshot "$src" "$tgt" >/dev/null; then
-        [ -n "$aside" ] && mv "$aside" "$tgt"
+        [ -n "$aside" ] && mv "$aside" "$tgt" || true
         die "Snapshot failed; ${aside:+previous $rel restored, }nothing changed"
     fi
 fi

--- a/overlays/usr/local/sbin/create-snapshot
+++ b/overlays/usr/local/sbin/create-snapshot
@@ -41,7 +41,7 @@ if [ -n "$tag" ]; then
 fi
 # name after /'s source subvol, e.g. @Minimal_2026-06-29_19-52-31 (leaf only: booting a
 # snapshot must not nest the new name under @snapshots/@snapshots/)
-src=$(current_subvol); src=${src##*/}
+src=$(booted_subvol); src=${src##*/}
 [ -n "$src" ] || die "Cannot determine the source subvolume of /"
 name="${src}_$(stamp)${tag:+_$tag}"
 

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -68,7 +68,11 @@ echo "Deleted '$rel'"
 # drop this profile's BLS entries + /boot/<token>/ staging
 lib=/usr/lib/flipper-bls.sh
 if [ -r "$lib" ]; then
-    ( . "$lib"; remove_root_entries "$rel" ) || echo "Warning: Entries/staging not fully removed for $rel" >&2
+    (
+      # entries live on the filesystem we are operating on, not on the running root under -d
+      ENTRIES="$TOP/boot/loader/entries"
+      . "$lib"; remove_root_entries "$rel" ) \
+        || echo "Warning: Entries/staging not fully removed for $rel" >&2
 else
     echo "Warning: $lib not found; boot entry/staging not removed for $rel" >&2
 fi

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -69,8 +69,10 @@ echo "Deleted '$rel'"
 lib=/usr/lib/flipper-bls.sh
 if [ -r "$lib" ]; then
     (
-      # entries live on the filesystem we are operating on, not on the running root under -d
+      # entries live on the filesystem we are operating on, not on the running root under -d,
+      # and its UUID is what the cmdline must name
       ENTRIES="$TOP/boot/loader/entries"
+      TARGET_FSUUID="$(top_fsuuid)"
       . "$lib"; remove_root_entries "$rel" ) \
         || echo "Warning: Entries/staging not fully removed for $rel" >&2
 else

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -47,13 +47,13 @@ esac
 case "${arg##*/}" in *_stock) die "Top-level profiles only; for a golden base use: delete-snapshot $arg" ;; esac
 
 mount_top
-cur_id=""; top_is_booted_fs && cur_id=$(booted_id)
+cur_id=$(top_booted id)
 [ -e "$TOP/$arg" ] || die "No such profile: $arg (see list-profiles)"
 rel=$arg
 is_reserved_subvol "$rel" && die "Refusing to delete reserved subvolume: $rel"
 info=$(btrfs subvolume show "$TOP/$rel" 2>/dev/null) || die "Not a profile: $rel"
 tgt_id=$(get "$info" "Subvolume ID")
-[ -n "$cur_id" ] && [ "$tgt_id" = "$cur_id" ] && die "Refusing to delete the currently booted profile ($rel)"
+[ "$tgt_id" = "$cur_id" ] && die "Refusing to delete the currently booted profile ($rel)"
 
 is_ro=0; case "$(get "$info" "Flags")" in *readonly*) is_ro=1 ;; esac
 

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -1,6 +1,6 @@
 #!/bin/sh
 # delete-profile <@profile> - delete a bootable PROFILE at the btrfs top level (as listed by
-# list-profiles): a profile root (@Desktop, @Desktop-2, ...) or an @<profile>.old_* leftover. Also
+# list-profiles): a profile root (@Desktop, @Desktop-2, ...) or an @<profile>_old_* leftover. Also
 # removes its BLS boot entry. For @snapshots restore points and _stock golden bases (under
 # @stock-snapshots), use delete-snapshot.
 # Confirms once; AGAIN if the target is read-only. Refuses layout subvolumes and the currently
@@ -17,7 +17,7 @@ Usage: delete-profile [-y|--yes] [-d|--device DEV] <@profile>
 $HELP_YES
 $HELP_DEVICE
   Delete a bootable profile at the btrfs top level (see list-profiles) and its boot
-  entry: a profile root or an @<profile>.old_* leftover. For restore points and
+  entry: a profile root or an @<profile>_old_* leftover. For restore points and
   _stock golden bases use delete-snapshot.
 EOF
 }

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -14,8 +14,8 @@ set -eu
 usage() {
     cat <<EOF
 Usage: delete-profile [-y|--yes] [-d|--device DEV] <@profile>
-  -y,--yes    assume yes to prompts (non-interactive)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_YES
+$HELP_DEVICE
   Delete a bootable profile at the btrfs top level (see list-profiles) and its boot
   entry: a profile root or an @<profile>.old_* leftover. For restore points and
   _stock golden bases use delete-snapshot.
@@ -25,7 +25,7 @@ EOF
 while [ $# -gt 0 ]; do
     case "$1" in
         -y|--yes)    ASSUME_YES=1 ;;
-        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
         --)          shift; break ;;

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -66,15 +66,4 @@ btrfs subvolume delete "$TOP/$rel" >/dev/null
 echo "Deleted '$rel'"
 
 # drop this profile's BLS entries + /boot/<token>/ staging
-lib=/usr/lib/flipper-bls.sh
-if [ -r "$lib" ]; then
-    (
-      # entries live on the filesystem we are operating on, not on the running root under -d,
-      # and its UUID is what the cmdline must name
-      ENTRIES="$TOP/boot/loader/entries"
-      TARGET_FSUUID="$(top_fsuuid)"
-      . "$lib"; remove_root_entries "$rel" ) \
-        || echo "Warning: Entries/staging not fully removed for $rel" >&2
-else
-    echo "Warning: $lib not found; boot entry/staging not removed for $rel" >&2
-fi
+with_bls "entries/staging not fully removed for $rel" remove_root_entries "$rel"

--- a/overlays/usr/local/sbin/delete-profile
+++ b/overlays/usr/local/sbin/delete-profile
@@ -47,7 +47,7 @@ esac
 case "${arg##*/}" in *_stock) die "Top-level profiles only; for a golden base use: delete-snapshot $arg" ;; esac
 
 mount_top
-cur_id=$(booted_id)
+cur_id=""; top_is_booted_fs && cur_id=$(booted_id)
 [ -e "$TOP/$arg" ] || die "No such profile: $arg (see list-profiles)"
 rel=$arg
 is_reserved_subvol "$rel" && die "Refusing to delete reserved subvolume: $rel"

--- a/overlays/usr/local/sbin/delete-snapshot
+++ b/overlays/usr/local/sbin/delete-snapshot
@@ -2,7 +2,7 @@
 # delete-snapshot <@snapshots/@name | @stock-snapshots/@X_stock | @X_stock> - delete a read-only
 # restore-point SNAPSHOT under @snapshots or a _stock GOLDEN BASE under @stock-snapshots (as listed
 # by list-snapshots); a bare _stock name resolves under @stock-snapshots. Confirms once, plus again
-# for a golden base. For bootable profiles or .old leftovers, use delete-profile. Works via a
+# for a golden base. For bootable profiles or _old leftovers, use delete-profile. Works via a
 # subvolid=5 (top-level) mount.
 #
 # Examples:
@@ -17,7 +17,7 @@ Usage: delete-snapshot [-y|--yes] [-d|--device DEV] <@snapshots/@name | @stock-s
 $HELP_YES
 $HELP_DEVICE
   Delete a restore-point snapshot under @snapshots or a _stock golden base under
-  @stock-snapshots (see list-snapshots). For profiles or .old leftovers use delete-profile.
+  @stock-snapshots (see list-snapshots). For profiles or _old leftovers use delete-profile.
 EOF
 }
 

--- a/overlays/usr/local/sbin/delete-snapshot
+++ b/overlays/usr/local/sbin/delete-snapshot
@@ -14,8 +14,8 @@ set -eu
 usage() {
     cat <<EOF
 Usage: delete-snapshot [-y|--yes] [-d|--device DEV] <@snapshots/@name | @stock-snapshots/@X_stock | @X_stock>
-  -y,--yes    assume yes to prompts (non-interactive)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_YES
+$HELP_DEVICE
   Delete a restore-point snapshot under @snapshots or a _stock golden base under
   @stock-snapshots (see list-snapshots). For profiles or .old leftovers use delete-profile.
 EOF
@@ -24,7 +24,7 @@ EOF
 while [ $# -gt 0 ]; do
     case "$1" in
         -y|--yes)    ASSUME_YES=1 ;;
-        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
         --)          shift; break ;;

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -39,10 +39,15 @@ TOP_TMPFILES="$map $rows"
 mount_top
 build_uuid_map "$TOP" "$map"
 
-cur=$(btrfs subvolume show / 2>/dev/null) || cur=
-cur_id=$(get "$cur" "Subvolume ID")
-cur_path=$(printf '%s\n' "$cur" | head -n1)
-[ -n "$cur_path" ] && echo "Currently booted profile: $cur_path (id ${cur_id:-?})"
+cur=""; cur_id=""; cur_path=""
+if top_is_booted_fs; then
+    cur=$(btrfs subvolume show / 2>/dev/null) || cur=
+    cur_id=$(get "$cur" "Subvolume ID")
+    cur_path=$(printf '%s\n' "$cur" | head -n1)
+    [ -n "$cur_path" ] && echo "Currently booted profile: $cur_path (id ${cur_id:-?})"
+else
+    echo "Listing $ROOTDEV, which is not the filesystem you booted from"
+fi
 echo
 
 emit() {  # $1=display name  $2=fs path

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -14,7 +14,7 @@ set -eu
 usage() {
     cat <<EOF
 Usage: list-profiles [-d|--device DEV]
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   List bootable profiles at the btrfs top level: profile roots and @<profile>.old_*
   leftovers. For _stock golden bases and restore points, see list-snapshots.
 EOF
@@ -22,7 +22,7 @@ EOF
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
         *)           echo "Error: unexpected argument: $1" >&2; usage >&2; exit 1 ;;

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -25,7 +25,8 @@ while [ $# -gt 0 ]; do
         -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
-        *)           echo "Error: unexpected argument: $1" >&2; usage >&2; exit 1 ;;
+        -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)           echo "Error: unexpected argument: $1 (this tool takes no arguments)" >&2; usage >&2; exit 1 ;;
     esac
     shift
 done

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -41,12 +41,9 @@ TOP_TMPFILES="$map $rows"
 mount_top
 build_uuid_map "$TOP" "$map"
 
-cur=""; cur_id=""; cur_path=""
-if top_is_booted_fs; then
-    cur=$(btrfs subvolume show / 2>/dev/null) || cur=
-    cur_id=$(get "$cur" "Subvolume ID")
-    cur_path=$(printf '%s\n' "$cur" | head -n1)
-    [ -n "$cur_path" ] && echo "Currently booted profile: $cur_path (id ${cur_id:-?})"
+cur_id=$(top_booted id); cur_subvol=$(top_booted subvol)
+if [ -n "$cur_id" ]; then
+    echo "Currently booted profile: ${cur_subvol:-?} (id $cur_id)"
 else
     echo "Listing $ROOTDEV, which is not the filesystem you booted from"
 fi
@@ -84,7 +81,7 @@ emit() {  # $1=display name  $2=fs path
         *_old_[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_*|*.old_*) kind=old ;;
         *)       kind=profile ;;
     esac
-    mark=""; [ -n "$cur_id" ] && [ "$id" = "$cur_id" ] && mark="<- booted"
+    mark=""; [ "$id" = "$cur_id" ] && mark="<- booted"
     # convert while the "+0000" btrfs prints is still there: date -d without a zone assumes the
     # reader's, which shifts the epoch whenever that differs from the zone the profile was made in
     oepoch=$(date -d "$otime" +%s 2>/dev/null || echo "")

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -1,13 +1,13 @@
 #!/bin/sh
 # list-profiles - list the bootable PROFILES at the btrfs top level: the profile roots
-# (@Desktop, @Minimal, ...) and @<profile>.old_* leftovers from create-profile. KIND tags each
+# (@Desktop, @Minimal, ...) and @<profile>_old_* leftovers from create-profile. KIND tags each
 # (profile/old); PARENT is what it was snapshotted from (via Parent UUID). Names are top-level
 # paths (what create-profile/rename-profile/delete-profile take). The booted profile is marked
 # <- booted. For _stock golden bases and restore points, see list-snapshots.
 # Works via a subvolid=5 (top-level) mount.
 #
 # Example:
-#   list-profiles   # @SourceProfile / @DestinationProfile roots, _stock bases and .old leftovers
+#   list-profiles   # @SourceProfile / @DestinationProfile roots, _stock bases and _old leftovers
 set -eu
 . /usr/lib/flipper-btrfs.sh 2>/dev/null || { echo "Error: /usr/lib/flipper-btrfs.sh not found" >&2; exit 1; }
 
@@ -15,7 +15,7 @@ usage() {
     cat <<EOF
 Usage: list-profiles [-d|--device DEV]
 $HELP_DEVICE
-  List bootable profiles at the btrfs top level: profile roots and @<profile>.old_*
+  List bootable profiles at the btrfs top level: profile roots and @<profile>_old_*
   leftovers. For _stock golden bases and restore points, see list-snapshots.
 EOF
 }
@@ -57,7 +57,9 @@ emit() {  # $1=display name  $2=fs path
     flags=$(get "$info" "Flags"); case "$flags" in *readonly*) flags=ro ;; *) flags=rw ;; esac
     parent=$(parent_of "$map" "$(get "$info" "Parent UUID")")
     case "$1" in
-        *.old_*) kind=old ;;
+        # _old_<ts> leftovers from create-profile; anchored on the stamp so a user-chosen
+        # name that merely contains "_old_" stays a profile ('.old_' is the legacy spelling)
+        *_old_[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_*|*.old_*) kind=old ;;
         *)       kind=profile ;;
     esac
     mark=""; [ -n "$cur_id" ] && [ "$id" = "$cur_id" ] && mark="<- booted"
@@ -65,7 +67,7 @@ emit() {  # $1=display name  $2=fs path
 }
 
 printf 'NAME\t\tKIND\tID\tCREATED\tRO\tPARENT\n' > "$rows"
-# top-level profile roots + @.old_* leftovers; skip shared/reserved subvols (@snapshots,
+# top-level profile roots + @_old_* leftovers; skip shared/reserved subvols (@snapshots,
 # @stock-snapshots, ...) so stocks (now nested under @stock-snapshots) are not listed here
 for d in "$TOP"/@*; do
     [ -e "$d" ] || continue

--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -3,7 +3,8 @@
 # (@Desktop, @Minimal, ...) and @<profile>_old_* leftovers from create-profile. KIND tags each
 # (profile/old); PARENT is what it was snapshotted from (via Parent UUID). Names are top-level
 # paths (what create-profile/rename-profile/delete-profile take). The booted profile is marked
-# <- booted. For _stock golden bases and restore points, see list-snapshots.
+# <- booted. LAST USED is when the profile last RAN: 'now' for the running one, 'never' if never.
+# For _stock golden bases and restore points, see list-snapshots.
 # Works via a subvolid=5 (top-level) mount.
 #
 # Example:
@@ -51,10 +52,30 @@ else
 fi
 echo
 
+# Newest of systemd's random-seed (written at every boot and clean shutdown) and timesyncd's clock
+# (written while the profile runs). Both are inherited from whatever the profile was made from, so
+# only a stamp newer than the profile's own creation counts; anything older reads 'never'.
+last_used() {  # $1 = fs path  $2 = creation epoch -> "YYYY-MM-DD HH:MM:SS" | never
+    _lu=""
+    for _w in var/lib/systemd/random-seed var/lib/systemd/timesync/clock; do
+        [ -f "$1/$_w" ] || continue
+        _t=$(stat -c '%Y %y' "$1/$_w" 2>/dev/null) || continue
+        [ -n "${2:-}" ] && [ "${_t%% *}" -le "$2" ] && continue
+        case "$_lu" in
+            "") _lu=$_t ;;
+            *)  [ "${_t%% *}" -gt "${_lu%% *}" ] && _lu=$_t ;;
+        esac
+    done
+    case "$_lu" in
+        "") printf 'never' ;;
+        *)  printf '%s' "$(printf '%s' "${_lu#* }" | cut -c1-19)" ;;
+    esac
+}
+
 emit() {  # $1=display name  $2=fs path
     info=$(btrfs subvolume show "$2" 2>/dev/null) || return 0
     id=$(get "$info" "Subvolume ID")
-    otime=$(get "$info" "Creation time"); otime=${otime% +*}
+    otime=$(get "$info" "Creation time")
     flags=$(get "$info" "Flags"); case "$flags" in *readonly*) flags=ro ;; *) flags=rw ;; esac
     parent=$(parent_of "$map" "$(get "$info" "Parent UUID")")
     case "$1" in
@@ -64,10 +85,17 @@ emit() {  # $1=display name  $2=fs path
         *)       kind=profile ;;
     esac
     mark=""; [ -n "$cur_id" ] && [ "$id" = "$cur_id" ] && mark="<- booted"
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$mark" "$kind" "${id:-?}" "${otime:-?}" "$flags" "$parent" >> "$rows"
+    # convert while the "+0000" btrfs prints is still there: date -d without a zone assumes the
+    # reader's, which shifts the epoch whenever that differs from the zone the profile was made in
+    oepoch=$(date -d "$otime" +%s 2>/dev/null || echo "")
+    otime=${otime% +*}   # the column shows the time without the zone
+    # the profile we are running from writes its state at boot and then only now and then, so a
+    # timestamp here would read as stale for the one profile that is definitely in use
+    if [ -n "$mark" ]; then lu=now; else lu=$(last_used "$2" "$oepoch"); fi
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$mark" "$kind" "${id:-?}" "${otime:-?}" "$lu" "$flags" "$parent" >> "$rows"
 }
 
-printf 'NAME\t\tKIND\tID\tCREATED\tRO\tPARENT\n' > "$rows"
+printf 'NAME\t\tKIND\tID\tCREATED\tLAST USED\tRO\tPARENT\n' > "$rows"
 # top-level profile roots + @_old_* leftovers; skip shared/reserved subvols (@snapshots,
 # @stock-snapshots, ...) so stocks (now nested under @stock-snapshots) are not listed here
 for d in "$TOP"/@*; do

--- a/overlays/usr/local/sbin/list-snapshots
+++ b/overlays/usr/local/sbin/list-snapshots
@@ -24,7 +24,8 @@ while [ $# -gt 0 ]; do
         -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
-        *)           echo "Error: unexpected argument: $1" >&2; usage >&2; exit 1 ;;
+        -?*)         echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)           echo "Error: unexpected argument: $1 (this tool takes no arguments)" >&2; usage >&2; exit 1 ;;
     esac
     shift
 done

--- a/overlays/usr/local/sbin/list-snapshots
+++ b/overlays/usr/local/sbin/list-snapshots
@@ -13,7 +13,7 @@ set -eu
 usage() {
     cat <<EOF
 Usage: list-snapshots [-d|--device DEV]
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   List restore-point snapshots under @snapshots and _stock golden bases under
   @stock-snapshots. For bootable profiles, see list-profiles.
 EOF
@@ -21,7 +21,7 @@ EOF
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
         *)           echo "Error: unexpected argument: $1" >&2; usage >&2; exit 1 ;;

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -54,7 +54,7 @@ while :; do
         -v|--verbose)      verbose=1; shift ;;
         --show-noise)      show_noise=1; shift ;;
         --do-not-resolve)  no_resolve=1; shift ;;
-        -d|--device)       shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1; shift ;;
+        -d|--device)       shift; need_device_arg "$#"; ROOTDEV=$1; shift ;;
         --device=*)        ROOTDEV=${1#*=}; shift ;;
         -h|--help)       usage; exit 0 ;;
         -?*)             echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -228,6 +228,7 @@ function is_noise(p) {
     if (p ~ /^var\/(cache|tmp|log)(\/|$)/) return 1
     if (p ~ /(^|\/)\.cache(\/|$)/) return 1
     if (p ~ /^usr\/local(\/|$)/) return 0
+    if (p ~ /^usr\/share\/keyrings(\/|$)/) return 0
     if (p ~ /^usr(\/|$)/) return 1
     if (p ~ /^var\/lib\/(dpkg|apt|ucf)(\/|$)/) return 1
     if (p=="var/.updated") return 1
@@ -478,6 +479,16 @@ btrfs subvolume snapshot -r "$TOP/$dst" "$TOP/$snap" >/dev/null \
 
 : > "$WORK/merged"; : > "$WORK/conflicts"
 
+# 0) apt configuration must land before the replay, or a package from a repository the user added is
+#    not findable while dst still has the old sources. Keyrings too, since a source without its key
+#    is useless. Step 2 re-merges these as a no-op.
+grep -E '^(etc/apt/|usr/share/keyrings/)' "$WORK/changed" > "$WORK/changed.apt" || :
+grep -vE '^(etc/apt/|usr/share/keyrings/)' "$WORK/changed" > "$WORK/changed.rest" || :
+if [ -s "$WORK/changed.apt" ]; then
+    echo "merging apt configuration first ($(cnt "$WORK/changed.apt") file(s))..."
+    while IFS= read -r f; do [ -n "$f" ] && merge_one "$f"; done < "$WORK/changed.apt"
+fi
+
 # 1) replay package intent FIRST (lays down package files + default conffiles), so the user's
 #    config edits in step 2 merge on top of them. Needs a working apt source / network.
 if [ -n "$added_pkgs" ] || { [ "$purge_removed" = 1 ] && [ -n "$removed_pkgs" ]; }; then
@@ -506,15 +517,15 @@ if [ -n "$added_pkgs" ] || { [ "$purge_removed" = 1 ] && [ -n "$removed_pkgs" ];
     for _m in dev/pts dev sys proc; do umount "$TOP/$dst/$_m" 2>/dev/null || true; done
 fi
 
-# 2) 3-way merge the user's changed files onto dst
-_total=$(wc -l < "$WORK/changed" 2>/dev/null | tr -d ' '); [ -n "$_total" ] || _total=0
+# 2) 3-way merge the rest of the user's changed files onto dst
+_total=$(cnt "$WORK/changed.rest")
 echo "merging your files onto $dst ($_total, via $merger)..."
 _n=0
 while IFS= read -r f; do
     [ -n "$f" ] || continue
     _n=$((_n+1)); printf '\r  merging %d/%d' "$_n" "$_total" >&2
     merge_one "$f"
-done < "$WORK/changed"
+done < "$WORK/changed.rest"
 [ "$_n" -gt 0 ] && printf '\r  merged %d/%d files \n' "$_n" "$_total" >&2
 
 # 3) apply the user's deletions, deepest-first (files before their dir) so empty dirs can rmdir

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -68,13 +68,13 @@ done
 need_root
 need_btrfs
 
-WORK=$(mktemp -d)
 ACCOUNTDB_AWK=/usr/lib/flipper-accountdb.awk
 SRCSNAP=""
 mig_cleanup() {
     [ -n "$SRCSNAP" ] && btrfs subvolume delete "$SRCSNAP" >/dev/null 2>&1 || true
     top_cleanup
-    rm -rf "$WORK"
+    if [ -n "${WORK:-}" ]; then rm -rf "$WORK" || true; fi
+    return 0
 }
 
 ask_tty() {
@@ -154,6 +154,10 @@ resolve_mode() {
 
 mount_top
 trap mig_cleanup EXIT
+# Created only once mig_cleanup owns the EXIT trap. mount_top installs its own trap and would
+# clobber ours, so anything made before this line is leaked when mount_top itself dies, which is
+# what a recovery boot does on every invocation that forgets -d.
+WORK=$(mktemp -d)
 
 if [ "$resolve" = 1 ]; then resolve_mode "$1"; exit 0; fi
 

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -68,6 +68,7 @@ need_root
 need_btrfs
 
 WORK=$(mktemp -d)
+ACCOUNTDB_AWK=/usr/lib/flipper-accountdb.awk
 SRCSNAP=""
 mig_cleanup() {
     [ -n "$SRCSNAP" ] && btrfs subvolume delete "$SRCSNAP" >/dev/null 2>&1 || true
@@ -308,69 +309,6 @@ mergiraf_lang() {
 
 
 
-# Account databases (passwd/shadow/group/gshadow + backups) are keyed by the first field, not by
-# line order, so a text merge conflicts on every epoch bump and could duplicate entries. Merge them
-# per entry instead: an account the user did not touch follows the new base (apt replay is the
-# authority for service accounts), an account the user added or changed rides along from src, and
-# group/gshadow memberships are set-merged. Deterministic, never conflicts.
-cat > "$WORK/accountdb.awk" <<'AWK'
-BEGIN { FS=":"; nlf=split(LF,_l,","); for(i=1;i<=nlf;i++) islist[_l[i]+0]=1; fidx=0 }
-FNR==1 { fidx++ }
-{
-    if ($0=="") next
-    k=$1
-    if      (fidx==1) { Bl[k]=$0; hB[k]=1 }
-    else if (fidx==2) { Ol[k]=$0; hO[k]=1; if(!(k in os)){ os[k]=1; oord[++no]=k } }
-    else              { Tl[k]=$0; hT[k]=1; if(!(k in ts)){ ts[k]=1; tord[++nt]=k } }
-}
-END {
-    for (i=1;i<=no;i++) put(oord[i])
-    for (i=1;i<=nt;i++) if (!(tord[i] in os)) put(tord[i])
-}
-function put(k,   line) { line=decide(k); if (line!="") print line }
-function decide(k,   ib,io,it) {
-    ib=(k in hB); io=(k in hO); it=(k in hT)
-    if (!io && !it) return ""
-    if ( io && !it) { if (ib && Ol[k]==Bl[k]) return ""; return Ol[k] }
-    if (!io &&  it) { if (ib && Tl[k]==Bl[k]) return ""; return Tl[k] }
-    if (LF!="") return mergerec(k, ib)
-    if (Ol[k]==Tl[k]) return Ol[k]
-    if (!ib)          return Ol[k]
-    if (Tl[k]==Bl[k]) return Ol[k]
-    if (Ol[k]==Bl[k]) return Tl[k]
-    return Tl[k]
-}
-function mergerec(k, ib,   nb,no2,nt2,fb,fo,ft,fi,res) {
-    nb  = ib ? split(Bl[k], fb, ":") : 0
-    no2 =      split(Ol[k], fo, ":")
-    nt2 =      split(Tl[k], ft, ":")
-    for (fi=1; fi<=no2; fi++)
-        rf[fi] = (fi in islist) ? merge_members(fi, ib, fb, fo, ft, nb, no2, nt2) : fo[fi]
-    res=rf[1]; for(fi=2;fi<=no2;fi++) res=res ":" rf[fi]
-    delete rf
-    return res
-}
-function merge_members(fi, ib, fb, fo, ft, nb, no2, nt2,   i,m,res) {
-    delete inB; delete inO; delete inT; delete ordm; delete ordseen; nord=0
-    if (ib && nb >=fi) mark(fb[fi], inB)
-    if (      no2>=fi) mark(fo[fi], inO)
-    if (      nt2>=fi) mark(ft[fi], inT)
-    if (      no2>=fi) order(fo[fi])
-    if (      nt2>=fi) order(ft[fi])
-    if (ib && nb >=fi) order(fb[fi])
-    res=""
-    for (i=1;i<=nord;i++) {
-        m=ordm[i]
-        if ((m in inB) && !(m in inO)) continue
-        if ((m in inB) && !(m in inT)) continue
-        res = (res=="") ? m : res "," m
-    }
-    return res
-}
-function mark(s, arr,   n,a,i) { n=split(s,a,","); for(i=1;i<=n;i++) if(a[i]!="") arr[a[i]]=1 }
-function order(s,   n,a,i)     { n=split(s,a,","); for(i=1;i<=n;i++) if(a[i]!="" && !(a[i] in ordseen)){ ordseen[a[i]]=1; ordm[++nord]=a[i] } }
-AWK
-
 merge_accountdb() {  # $1 = etc/<db>: per-entry 3-way merge into dst (deterministic, no sidecar)
     _f=$1; _S="$TOP/$src/$_f"; _O="$TOP/$dst/$_f"; _B="$TOP/$base_rel/$_f"
     _mb="$EMPTY"; [ -f "$_B" ] && _mb="$_B"
@@ -390,7 +328,9 @@ merge_accountdb() {  # $1 = etc/<db>: per-entry 3-way merge into dst (determinis
     # These files decide whether the profile can be logged into, so the merged result has to
     # look like an account database before it replaces one: every db here has a root entry, and
     # a duplicate key is the corruption a text merge would have produced.
-    if ! awk -v LF="$_lf" -f "$WORK/accountdb.awk" "$_mb" "$_O" "$_S" > "$WORK/adb" 2>/dev/null; then
+    if [ ! -r "$ACCOUNTDB_AWK" ]; then
+        _why="$ACCOUNTDB_AWK not installed"
+    elif ! awk -v LF="$_lf" -f "$ACCOUNTDB_AWK" "$_mb" "$_O" "$_S" > "$WORK/adb" 2>/dev/null; then
         _why="merge failed"
     elif [ ! -s "$WORK/adb" ]; then
         _why="empty result"

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -280,6 +280,40 @@ manual_set() {  # $1 = subvol rel -> sorted list of manually-installed packages
     else : > "$WORK/auto"; fi
     comm -23 "$WORK/inst" "$WORK/auto"
 }
+
+# The version src has installed, so a recovered .deb can be matched against it. $1 = package.
+installed_ver() {
+    awk -v p="$1" 'BEGIN{RS="";FS="\n"} { n=""; v="";
+        for(i=1;i<=NF;i++){ if($i ~ /^Package: /) n=substr($i,10); else if($i ~ /^Version: /) v=substr($i,10) }
+        if(n==p){ print v; exit } }' "$TOP/$src/var/lib/dpkg/status" 2>/dev/null
+}
+
+# A hand-installed package is in no repository, but its .deb often still exists: src's apt cache, or
+# wherever the user put it. @home and @root are shared, so a .deb there is reachable from dst. No
+# depth limit, since one below a cutoff would be reported as missing.
+collect_debs() {
+    : > "$WORK/debs"
+    for _dir in "$TOP/$src/var/cache/apt/archives" "$TOP/@root" "$TOP/@home"; do
+        # find exits non-zero if anything under these roots is unreadable or vanishes mid-walk,
+        # which would end the migration here rather than just yielding fewer candidates
+        if [ -d "$_dir" ]; then find "$_dir" -type f -name '*.deb' >> "$WORK/debs" 2>/dev/null || true; fi
+    done
+    return 0
+}
+
+# Print a .deb whose control says it really is this package, preferring the version src had.
+# $1 = package, $2 = wanted version, $3 = dpkg architecture.
+find_deb() {
+    _fallback=""
+    while IFS= read -r _cand; do
+        [ "$(dpkg-deb -f "$_cand" Package 2>/dev/null)" = "$1" ] || continue
+        case "$(dpkg-deb -f "$_cand" Architecture 2>/dev/null)" in "$3"|all) ;; *) continue ;; esac
+        [ "$(dpkg-deb -f "$_cand" Version 2>/dev/null)" = "$2" ] && { printf '%s' "$_cand"; return 0; }
+        [ -n "$_fallback" ] || _fallback=$_cand
+    done < "$WORK/debs"
+    [ -n "$_fallback" ] || return 1
+    printf '%s' "$_fallback"
+}
 manual_set "$base_rel" > "$WORK/pkg.base"
 manual_set "$src"  > "$WORK/pkg.src"
 added_pkgs=$(comm -13 "$WORK/pkg.base" "$WORK/pkg.src" | tr '\n' ' ')
@@ -513,7 +547,27 @@ if [ -n "$added_pkgs" ] || { [ "$purge_removed" = 1 ] && [ -n "$removed_pkgs" ];
             if chroot "$TOP/$dst" apt-get install -y --dry-run "$_p" >/dev/null 2>&1; then _ok="$_ok $_p"; else _miss="$_miss $_p"; fi
         done
         [ -n "$_ok" ] && { echo "  installing:$_ok"; chroot "$TOP/$dst" apt-get install -y $_ok || echo "WARN: apt install failed; packages not installed:$_ok" >&2; }
-        [ -n "$_miss" ] && echo "NOTE: could not reinstall (not in a repo; install by hand):$_miss" >&2
+        if [ -n "$_miss" ]; then
+            # nothing in a repo provides these, so look for the .deb itself before giving up
+            echo "  looking for a local .deb for:$_miss"
+            collect_debs
+            _debarch=$(dpkg --print-architecture 2>/dev/null || echo all)
+            _recovered=""; _stillmiss=""
+            for _p in $_miss; do
+                _debfile=$(find_deb "$_p" "$(installed_ver "$_p")" "$_debarch") || _debfile=""
+                if [ -z "$_debfile" ]; then _stillmiss="$_stillmiss $_p"; continue; fi
+                mkdir -p "$TOP/$dst/var/cache/apt/archives"
+                cp -f "$_debfile" "$TOP/$dst/var/cache/apt/archives/" 2>/dev/null || true
+                if chroot "$TOP/$dst" apt-get install -y "/var/cache/apt/archives/${_debfile##*/}" >/dev/null 2>&1; then
+                    _recovered="$_recovered $_p($(dpkg-deb -f "$_debfile" Version 2>/dev/null))"
+                else
+                    _stillmiss="$_stillmiss $_p"
+                    echo "WARN: found ${_debfile#"$TOP"/} for $_p but installing it failed (dependencies?)" >&2
+                fi
+            done
+            [ -n "$_recovered" ] && echo "  installed from a local .deb:$_recovered"
+            [ -n "$_stillmiss" ] && echo "NOTE: could not reinstall (not in a repo, no .deb found; install by hand):$_stillmiss" >&2
+        fi
     fi
     [ "$purge_removed" = 1 ] && [ -n "$removed_pkgs" ] && { echo "  purging removed:$removed_pkgs"; chroot "$TOP/$dst" apt-get purge -y $removed_pkgs || true; }
     rm -f "$_rc"; [ -n "$_rcbak" ] && mv "$_rcbak" "$_rc"   # restore dst's original resolv.conf

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -469,7 +469,9 @@ delete_one() {
 while IFS= read -r f; do
     [ -n "$f" ] || continue
     _O="$TOP/$dst/$f"; _B="$TOP/$base_rel/$f"; _S="$TOP/$src/$f"
-    if [ -d "$_S" ] && [ ! -L "$_S" ]; then echo "$f" >> "$WORK/clean"; continue; fi   # dir: created + metadata
+    # merge_one takes anything that is not a regular file wholesale (dirs are created, symlinks
+    # and specials are rsynced), so it is never a both-sides merge, whatever the base looks like
+    if [ ! -f "$_S" ] || [ -L "$_S" ]; then echo "$f" >> "$WORK/clean"; continue; fi
     if [ ! -e "$_O" ] || { [ -f "$_B" ] && cmp -s "$_B" "$_O"; }; then echo "$f" >> "$WORK/clean"
     elif [ -f "$_S" ] && cmp -s "$_S" "$_O"; then :
     else echo "$f" >> "$WORK/overlap"; fi

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -86,7 +86,8 @@ ask_tty() {
 # --- interactive resolution of leftover sidecars ---------------------------------------------
 resolve_mode() {
     _p=$1
-    case "$_p" in current|booted|"") root_is_btrfs || die "no booted profile to default to; name the profile explicitly"; _p=$(current_subvol) ;; esac
+    case "$_p" in current|booted|"") _p=$(top_booted subvol)
+        [ -n "$_p" ] || die "no booted profile on $ROOTDEV to default to; name the profile explicitly" ;; esac
     case "$_p" in *..*|/*|*/*) die "Invalid profile: $_p" ;; esac
     [ -d "$TOP/$_p" ] || die "No such profile: $_p"
     _root="$TOP/$_p"; _dstname=$_p; _srcname=${2:-}
@@ -175,7 +176,9 @@ esac
 
 [ -d "$TOP/$src" ] || die "No such profile: $src"
 case "$dst" in
-    current|booted|"") root_is_btrfs || die "no booted profile to default <@dst> to; pass an explicit <@dst>"; dst=$(current_subvol); [ -n "$dst" ] || die "cannot determine booted profile" ;;
+    # the booted profile's NAME on another filesystem is whatever happens to be called that there
+    current|booted|"") dst=$(top_booted subvol)
+                       [ -n "$dst" ] || die "no booted profile on $ROOTDEV to default <@dst> to; pass an explicit <@dst>" ;;
     *)                 case "$dst" in *..*|/*|*/*) die "Invalid dst: $dst (top-level name)" ;; esac ;;
 esac
 [ -d "$TOP/$dst" ] || die "No such profile: $dst"
@@ -183,8 +186,8 @@ esac
 is_reserved_subvol "$src" && die "src is a reserved subvolume"
 is_reserved_subvol "$dst" && die "dst is a reserved subvolume"
 
-booted=""; top_is_booted_fs && booted=$(current_subvol)
-if [ "$apply" = 1 ] && [ "$dst" = "$booted" ] && [ "$force" != 1 ]; then
+cur_subvol=$(top_booted subvol)
+if [ "$apply" = 1 ] && [ "$dst" = "$cur_subvol" ] && [ "$force" != 1 ]; then
     die "won't modify '$dst': it is the profile you are booted into.
 Boot into another profile and run this again, or pass --force to override."
 fi
@@ -205,7 +208,7 @@ migrate compares $src against the _stock it was built from to work out what you 
   receive-snapshot <path-to-${base#@}_pack.zst>"
 
 echo "migrate: $src -> $dst"
-top_is_booted_fs || echo "  filesystem: $ROOTDEV, which is not the one you booted from"
+[ -n "$cur_subvol" ] || echo "  filesystem: $ROOTDEV, which is not the one you booted from"
 echo "  ancestor: $base"
 echo "  merge engine: $merger"
 [ "$apply" = 1 ] && echo "  mode: APPLY" || echo "  mode: dry run"

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -205,6 +205,7 @@ migrate compares $src against the _stock it was built from to work out what you 
   receive-snapshot <path-to-${base#@}_pack.zst>"
 
 echo "migrate: $src -> $dst"
+top_is_booted_fs || echo "  filesystem: $ROOTDEV, which is not the one you booted from"
 echo "  ancestor: $base"
 echo "  merge engine: $merger"
 [ "$apply" = 1 ] && echo "  mode: APPLY" || echo "  mode: dry run"

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -513,8 +513,11 @@ confirm "Apply the above to '$dst'? A '$dst' snapshot is taken first."
 
 ts=$(stamp)
 snap="@snapshots/@${dst#@}_${ts}_before_migrate"
-btrfs subvolume snapshot -r "$TOP/$dst" "$TOP/$snap" >/dev/null \
-    && echo "snapshot: $snap" || die "could not snapshot $dst; aborting before any change"
+if btrfs subvolume snapshot -r "$TOP/$dst" "$TOP/$snap" >/dev/null; then
+    echo "snapshot: $snap"
+else
+    die "could not snapshot $dst; aborting before any change"
+fi
 
 : > "$WORK/merged"; : > "$WORK/conflicts"
 

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -17,8 +17,9 @@
 # text: user-added or user-changed accounts and group memberships are carried while service
 # accounts follow the new base. Everything the user changed is migrated EXCEPT a denylist of noise: package
 # files (replayed via apt instead), caches, regenerated runtime state, and generated/per-device
-# identity files (machine-id, ld.so.cache, and the like). SSH host keys ARE carried, so the
-# migrated profile keeps the device's ssh identity (no host-key-changed warnings).
+# identity files (machine-id, ld.so.cache, and the like). SSH host keys are carried explicitly,
+# by policy rather than by delta, so the migrated profile keeps the device's ssh identity even
+# though the build bakes the same keys into every image (no host-key-changed warnings).
 #
 # Default is a DRY RUN. -a/--apply performs it (snapshots <@dst> to @snapshots/<dst>_<ts>_before_
 # migrate first) and then, if any conflicts remain, drops straight into interactive resolution
@@ -477,6 +478,18 @@ while IFS= read -r f; do
     else echo "$f" >> "$WORK/overlap"; fi
 done < "$WORK/changed"
 
+# The ssh host keys ARE the device identity, so they follow the device, not the base. The delta never
+# mentions them (the image bakes the same keys everywhere, so src's copy equals the ancestor's), so
+# carry them by policy. Prints the files dst lacks, so preview and apply agree on the count.
+ssh_identity_files() {
+    [ -d "$TOP/$src/etc/ssh" ] || return 0
+    for _k in "$TOP/$src"/etc/ssh/ssh_host_*; do
+        [ -f "$_k" ] || continue
+        cmp -s "$_k" "$TOP/$dst/etc/ssh/${_k##*/}" && continue
+        printf '%s\n' "$_k"
+    done
+}
+
 # --- report ---
 cnt() { _c=$(wc -l < "$1" 2>/dev/null | tr -d ' '); printf '%s' "${_c:-0}"; }
 _na=$(printf '%s' "$added_pkgs" | wc -w | tr -d ' ')
@@ -487,6 +500,8 @@ echo
 echo "== migration preview: $src -> $dst =="
 printf '  packages:  +%s added   -%s removed\n' "$_na" "$_nr"
 printf '  files:     %s carried   %s changed by both sides   %s deleted   %s skipped as noise\n' "$_nc" "$_no" "$_nd" "$_noise"
+_nid=$(ssh_identity_files | wc -l | tr -d ' ')
+[ "${_nid:-0}" -gt 0 ] && printf '  identity:  %s ssh host key file(s), carried so %s keeps this device identity\n' "$_nid" "$dst"
 echo
 echo "  Carried, deleted and account databases apply automatically. The $_no changed-by-both"
 echo "  file(s) are 3-way merged on apply; only those that cannot merge cleanly will ask you to"
@@ -597,7 +612,16 @@ if [ -s "$WORK/deleted" ]; then
     while IFS= read -r f; do [ -n "$f" ] && delete_one "$f"; done < "$WORK/deleted.rev"
 fi
 
-# 4) merge_accountdb handles each database on its own, so nothing above guarantees they still
+# 4) Carry the ssh host keys, listed by ssh_identity_files above.
+_idn=0; _idfail=0
+for _k in $(ssh_identity_files); do
+    if rsync -aHAX "$_k" "$TOP/$dst/etc/ssh/${_k##*/}"; then _idn=$((_idn+1))
+    else _idfail=$((_idfail+1)); echo "Warning: could not carry ${_k##*/}" >&2; fi
+done
+[ "$_idn" -gt 0 ] && echo "carried $_idn ssh host key file(s), so '$dst' keeps this device's identity"
+[ "$_idfail" -gt 0 ] && echo "WARNING: $_idfail ssh host key file(s) could not be carried; '$dst' will present a different ssh identity and clients will report a changed host key" >&2
+
+# 5) merge_accountdb handles each database on its own, so nothing above guarantees they still
 # agree with each other: a passwd entry with no shadow entry is an account that cannot
 # authenticate, and group drifting from gshadow is what grpck exists to complain about.
 if grep -qE '^etc/(passwd|shadow|group|gshadow)-?$' "$WORK/changed" 2>/dev/null; then

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -177,7 +177,7 @@ esac
 is_reserved_subvol "$src" && die "src is a reserved subvolume"
 is_reserved_subvol "$dst" && die "dst is a reserved subvolume"
 
-booted=$(current_subvol)
+booted=""; top_is_booted_fs && booted=$(current_subvol)
 if [ "$apply" = 1 ] && [ "$dst" = "$booted" ] && [ "$force" != 1 ]; then
     die "won't modify '$dst': it is the profile you are booted into.
 Boot into another profile and run this again, or pass --force to override."

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -7,8 +7,8 @@
 # and data.
 #
 # <@src>'s factory base (the _stock it was built from) is read from /etc/profile_origin
-# (origin_stock_name); if that stock is present and its build (os-release BUILD_GIT) matches
-# <@src>'s, it is the merge ancestor. The delta ancestor -> src is computed with `btrfs send
+# (origin_stock_name), whose name carries the build id, so it names the exact base. If that stock
+# is present it is the merge ancestor. The delta ancestor -> src is computed with `btrfs send
 # --no-data` (adds/mods/deletes/renames). Packages are replayed by intent (apt); files are 3-way
 # merged (base=ancestor, ours=dst, theirs=src; syntax-aware via mergiraf when installed, else git
 # merge-file): non-overlapping changes auto-merge into dst, a real
@@ -183,30 +183,23 @@ if [ "$apply" = 1 ] && [ "$dst" = "$booted" ] && [ "$force" != 1 ]; then
 Boot into another profile and run this again, or pass --force to override."
 fi
 
-# --- resolve the merge ancestor: src's factory base, present and same build ---
-build_of() { sed -n 's/^BUILD_GIT=//p' "$TOP/$1/etc/os-release" 2>/dev/null | tr -d '"'; }
-
+# --- resolve the merge ancestor: the _stock src was built from, by name ---
+# The stock name carries the build id, so the name alone pins the exact base. btrfs send -p
+# below refuses a parent that is not a real ancestor, so there is nothing further to verify.
 marker="$TOP/$src/etc/profile_origin"
 [ -f "$marker" ] || die "$src has no /etc/profile_origin marker; cannot determine its base"
 base=$(sed -n 's/^origin_stock_name=//p' "$marker")
 [ -n "$base" ] || die "$src marker has no origin_stock_name"
-src_build=$(build_of "$src")
 
 # the marker records the stock by bare name; it now lives under @stock-snapshots (resolve_rel)
 base_rel=$(resolve_rel "$base")
 [ -n "$base_rel" ] || die "You must have the '$base' _stock image on disk to migrate $src.
 migrate compares $src against the _stock it was built from to work out what you changed, but
-'$base' (build ${src_build:-unknown}) is not on this device. Receive that _stock and retry:
+'$base' is not on this device. Receive that _stock and retry:
   receive-snapshot <path-to-${base#@}_pack.zst>"
-base_build=$(build_of "$base_rel")
-[ "$base_build" = "$src_build" ] || die "You must have the exact '$base' _stock $src was built from on disk.
-The '$base' on disk is a different build than $src:
-  on disk:    build ${base_build:-?}
-  $src needs: build ${src_build:-?}
-Receive the matching _stock and retry:  receive-snapshot <path-to-${base#@}_pack.zst>"
 
 echo "migrate: $src -> $dst"
-echo "  ancestor: $base (build ${src_build:-unknown})"
+echo "  ancestor: $base"
 echo "  merge engine: $merger"
 [ "$apply" = 1 ] && echo "  mode: APPLY" || echo "  mode: dry run"
 
@@ -313,6 +306,8 @@ mergiraf_lang() {
     esac
 }
 
+
+
 # Account databases (passwd/shadow/group/gshadow + backups) are keyed by the first field, not by
 # line order, so a text merge conflicts on every epoch bump and could duplicate entries. Merge them
 # per entry instead: an account the user did not touch follows the new base (apt replay is the
@@ -379,17 +374,53 @@ AWK
 merge_accountdb() {  # $1 = etc/<db>: per-entry 3-way merge into dst (deterministic, no sidecar)
     _f=$1; _S="$TOP/$src/$_f"; _O="$TOP/$dst/$_f"; _B="$TOP/$base_rel/$_f"
     _mb="$EMPTY"; [ -f "$_B" ] && _mb="$_B"
+    # _lf: fields holding comma-separated member lists, set-merged instead of taken whole.
+    # _nf: how many colon-separated fields a record has, so a truncated result is rejected below.
     case "${_f##*/}" in
-        group|group-)     _lf=4 ;;
-        gshadow|gshadow-) _lf=3,4 ;;
-        *)                _lf="" ;;
+        group|group-)     _lf=4;   _nf=4 ;;
+        gshadow|gshadow-) _lf=3,4; _nf=4 ;;
+        shadow|shadow-)   _lf="";  _nf=9 ;;
+        *)                _lf="";  _nf=7 ;;
     esac
-    if [ -f "$_O" ] && awk -v LF="$_lf" -f "$WORK/accountdb.awk" "$_mb" "$_O" "$_S" > "$WORK/adb" 2>/dev/null; then
-        cat "$WORK/adb" > "$_O"; sync_meta "$_S" "$_O" "$_B"
-    else
+    if [ ! -f "$_O" ]; then
         rsync -aHAX "$_S" "$_O"          # dst lacks the db -> take the user's copy verbatim
+        echo x >> "$WORK/merged"
+        return 0
     fi
+    # These files decide whether the profile can be logged into, so the merged result has to
+    # look like an account database before it replaces one: every db here has a root entry, and
+    # a duplicate key is the corruption a text merge would have produced.
+    if ! awk -v LF="$_lf" -f "$WORK/accountdb.awk" "$_mb" "$_O" "$_S" > "$WORK/adb" 2>/dev/null; then
+        _why="merge failed"
+    elif [ ! -s "$WORK/adb" ]; then
+        _why="empty result"
+    elif ! grep -q '^root:' "$WORK/adb"; then
+        _why="no root entry"
+    elif ! awk -F: -v n="$_nf" 'NF != n { exit 1 }' "$WORK/adb"; then
+        _why="malformed record"
+    elif [ -n "$(cut -d: -f1 "$WORK/adb" | sort | uniq -d | head -n1)" ]; then
+        _why="duplicate entries"
+    else
+        _why=""
+    fi
+    if [ -n "$_why" ]; then
+        rsync -aHAX "$_S" "$_O.migrate-theirs"
+        printf '%s (account merge rejected: %s; %s kept)\n' "$_f" "$_why" "$dst" >> "$WORK/conflicts"
+        return 0
+    fi
+    cat "$WORK/adb" > "$_O"; sync_meta "$_S" "$_O" "$_B"
     echo x >> "$WORK/merged"
+}
+
+# Report accounts present in a database but missing from its shadow companion, either way round.
+# Names only: the entries themselves are merged per file above, this checks the sets line up.
+check_db_pair() {  # $1 = passwd/group, $2 = its shadow/gshadow companion
+    [ -f "$TOP/$dst/$1" ] && [ -f "$TOP/$dst/$2" ] || return 0
+    cut -d: -f1 "$TOP/$dst/$1" | sort -u > "$WORK/k1"
+    cut -d: -f1 "$TOP/$dst/$2" | sort -u > "$WORK/k2"
+    _d=$(comm -3 "$WORK/k1" "$WORK/k2" | tr -d '\t' | tr '\n' ' ')
+    [ -n "$_d" ] && printf '%s and %s disagree on: %s\n' "$1" "$2" "$_d" >> "$WORK/conflicts"
+    return 0
 }
 
 # Merge one changed file onto dst. Clean auto-merges are written to dst; a conflict leaves dst's
@@ -414,11 +445,11 @@ merge_one() {
         if [ "$merger" = mergiraf ]; then
             _lang=$(mergiraf_lang "$_f" "$_S")
             mergiraf merge "$_mb" "$_O" "$_S" -o "$WORK/m" -p "$_f" --allow-parse-errors ${_lang:+-L "$_lang"} \
-                -s "factory base (${src_build:-unknown})" -x "new base ($dst)" -y "your changes ($src)" 2>/dev/null
+                -s "factory base ($base)" -x "new base ($dst)" -y "your changes ($src)" 2>/dev/null
             _rc=$?
         else
             git merge-file -p --diff3 \
-                -L "new base ($dst)" -L "factory base (${src_build:-unknown})" -L "your changes ($src)" \
+                -L "new base ($dst)" -L "factory base ($base)" -L "your changes ($src)" \
                 "$_O" "$_mb" "$_S" > "$WORK/m" 2>/dev/null
             _rc=$?
         fi
@@ -551,6 +582,15 @@ if [ -s "$WORK/deleted" ]; then
     echo "applying your deletions..."
     sort -r "$WORK/deleted" > "$WORK/deleted.rev"
     while IFS= read -r f; do [ -n "$f" ] && delete_one "$f"; done < "$WORK/deleted.rev"
+fi
+
+# 4) merge_accountdb handles each database on its own, so nothing above guarantees they still
+# agree with each other: a passwd entry with no shadow entry is an account that cannot
+# authenticate, and group drifting from gshadow is what grpck exists to complain about.
+if grep -qE '^etc/(passwd|shadow|group|gshadow)-?$' "$WORK/changed" 2>/dev/null; then
+    echo "checking the account databases agree..."
+    check_db_pair etc/passwd etc/shadow
+    check_db_pair etc/group etc/gshadow
 fi
 
 _nmerged=$(cnt "$WORK/merged"); _nconf=$(cnt "$WORK/conflicts")

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -398,7 +398,7 @@ check_db_pair() {  # $1 = passwd/group, $2 = its shadow/gshadow companion
     cut -d: -f1 "$TOP/$dst/$1" | sort -u > "$WORK/k1"
     cut -d: -f1 "$TOP/$dst/$2" | sort -u > "$WORK/k2"
     _d=$(comm -3 "$WORK/k1" "$WORK/k2" | tr -d '\t' | tr '\n' ' ')
-    [ -n "$_d" ] && printf '%s and %s disagree on: %s\n' "$1" "$2" "$_d" >> "$WORK/conflicts"
+    [ -n "$_d" ] && printf '%s and %s disagree on: %s\n' "$1" "$2" "$_d" >> "$WORK/notices"
     return 0
 }
 
@@ -455,11 +455,11 @@ delete_one() {
     _f=$1; _O="$TOP/$dst/$_f"; _B="$TOP/$base_rel/$_f"
     { [ -e "$_O" ] || [ -L "$_O" ]; } || return 0
     if [ -d "$_O" ] && [ ! -L "$_O" ]; then
-        rmdir "$_O" 2>/dev/null || printf '%s/ (you deleted this dir; new base still has files in it -> kept)\n' "$_f" >> "$WORK/conflicts"
+        rmdir "$_O" 2>/dev/null || printf '%s/ (you deleted this dir; new base still has files in it -> kept)\n' "$_f" >> "$WORK/notices"
         return 0
     fi
     if [ -f "$_O" ] && [ ! -L "$_O" ] && [ -f "$_B" ] && ! cmp -s "$_O" "$_B"; then
-        printf '%s (you deleted it; new base changed it -> kept new version)\n' "$_f" >> "$WORK/conflicts"
+        printf '%s (you deleted it; new base changed it -> kept new version)\n' "$_f" >> "$WORK/notices"
         return 0
     fi
     rm -f "$_O"
@@ -534,7 +534,7 @@ else
     die "could not snapshot $dst; aborting before any change"
 fi
 
-: > "$WORK/merged"; : > "$WORK/conflicts"
+: > "$WORK/merged"; : > "$WORK/conflicts"; : > "$WORK/notices"
 
 # 0) apt configuration must land before the replay, or a package from a repository the user added is
 #    not findable while dst still has the old sources. Keyrings too, since a source without its key
@@ -630,7 +630,7 @@ if grep -qE '^etc/(passwd|shadow|group|gshadow)-?$' "$WORK/changed" 2>/dev/null;
     check_db_pair etc/group etc/gshadow
 fi
 
-_nmerged=$(cnt "$WORK/merged"); _nconf=$(cnt "$WORK/conflicts")
+_nmerged=$(cnt "$WORK/merged"); _nconf=$(cnt "$WORK/conflicts"); _nnote=$(cnt "$WORK/notices")
 echo
 echo "== migration summary: $src -> $dst =="
 printf '  packages:  +%s added   -%s removed\n' "$_na" "$_nr"
@@ -640,7 +640,11 @@ if [ "$_nconf" -gt 0 ]; then
 else
     echo "  everything merged cleanly; nothing to decide"
 fi
+# Settled by policy, so --resolve has nothing to offer for these: counted apart from the
+# decisions, or the summary would promise sidecars that do not exist.
+[ "$_nnote" -gt 0 ] && printf '  %s file(s) settled for you (no sidecar, nothing to resolve)\n' "$_nnote"
 [ "$verbose" = 1 ] && [ -s "$WORK/conflicts" ] && { echo; echo "-- files needing a decision --"; sed 's,^,  ,' "$WORK/conflicts"; }
+[ "$verbose" = 1 ] && [ -s "$WORK/notices" ]   && { echo; echo "-- settled for you --";        sed 's,^,  ,' "$WORK/notices"; }
 
 if [ -s "$WORK/conflicts" ]; then
     if [ "$no_resolve" = 1 ] || [ "$ASSUME_YES" = 1 ]; then

--- a/overlays/usr/local/sbin/migrate-profile
+++ b/overlays/usr/local/sbin/migrate-profile
@@ -223,6 +223,9 @@ awk -v snap="$snapname" '
 function strip(p,  s){ s="./" snap "/"; if (index(p,s)==1) return substr(p, length(s)+1); return "" }
 # Denylist: migrate everything the user changed EXCEPT known-useless paths. 1 = noise, 0 = migrate.
 function is_noise(p) {
+    # our own leftovers: an unresolved sidecar would otherwise count as a user change and be
+    # carried into the next migration, and .migrate-bak is the resolv.conf we move aside for apt
+    if (p ~ /\.migrate-(conflict|theirs|bak)$/) return 1
     if (p ~ /^(proc|sys|dev|run|tmp|mnt|media|home|boot)(\/|$)/) return 1
     if (p ~ /^flipperone-testing(\/|$)/) return 1
     if (p ~ /^var\/(cache|tmp|log)(\/|$)/) return 1

--- a/overlays/usr/local/sbin/receive-snapshot
+++ b/overlays/usr/local/sbin/receive-snapshot
@@ -15,7 +15,7 @@ set -eu
 usage() {
     cat <<EOF
 Usage: receive-snapshot [-d|--device DEV] <file|->
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   Receive a send-snapshot stream (a _stock base -> @stock-snapshots, else @snapshots). Put it onto a root
   with create-profile. Incremental streams need their parent to exist here first.
 EOF
@@ -24,7 +24,7 @@ EOF
 while [ $# -gt 0 ]; do
     case "$1" in
         -y|--yes)    ASSUME_YES=1 ;;
-        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
         --)          shift; break ;;

--- a/overlays/usr/local/sbin/receive-snapshot
+++ b/overlays/usr/local/sbin/receive-snapshot
@@ -53,6 +53,11 @@ if [ "$src" != "-" ]; then
     case "$name" in ?*_stock) target="$TOP/@stock-snapshots" ;; esac
 fi
 [ -d "$target" ] || die "${target##*/} not found at top level"
+# btrfs receive refuses to replace an existing subvolume, and it says so only once the stream has
+# been transferred. Where the name was read up front, answer it here instead.
+if [ -n "${name:-}" ] && [ -e "$target/$name" ]; then
+    die "Already present: ${target##*/}/$name (btrfs receive cannot replace it); delete-snapshot ${target##*/}/$name first"
+fi
 
 before=$(btrfs subvolume list -o "$target" 2>/dev/null | wc -l)
 
@@ -66,6 +71,23 @@ else                                               zstd -dc               | btrf
 fi
 rc=$?
 set -e
-[ "$rc" = 0 ] || die "Receive failed (rc=$rc); check the stream and that any parent snapshot exists here"
+if [ "$rc" != 0 ]; then
+    # btrfs turns the subvolume read-only only once the whole stream is in, so a failure leaves a
+    # writable partial behind. Left there, it is what the retry collides with.
+    if [ -n "${name:-}" ] && [ -e "$target/$name" ]; then
+        # ours only while it is still writable: btrfs sets ro on success, and our lock cannot stop
+        # a hand-run btrfs command from taking the name while we streamed
+        if is_ro "$target/$name"; then
+            echo "Warning: ${target##*/}/$name is read-only, so it is not our partial; left alone" >&2
+        elif btrfs subvolume delete "$target/$name" >/dev/null 2>&1; then
+            echo "Removed the incomplete ${target##*/}/$name" >&2
+        else
+            echo "Warning: could not remove the incomplete ${target##*/}/$name; delete it before retrying" >&2
+        fi
+    elif [ "$(btrfs subvolume list -o "$target" 2>/dev/null | wc -l)" != "$before" ]; then
+        echo "Warning: an incomplete subvolume may be left in ${target##*/}/; delete it before retrying" >&2
+    fi
+    die "Receive failed (rc=$rc); check the stream and that any parent snapshot exists here"
+fi
 
 echo "Received into ${target##*/}/ (now $(btrfs subvolume list -o "$target" 2>/dev/null | wc -l) entries, was $before)"

--- a/overlays/usr/local/sbin/receive-snapshot
+++ b/overlays/usr/local/sbin/receive-snapshot
@@ -44,14 +44,34 @@ have_pv=0; command -v pv >/dev/null 2>&1 && have_pv=1
 
 set_lock
 mount_top
+# the same figure bounds the compressed prefix we keep and the decompressed prefix we read out of
+# it: zstd never expands, so this many bytes in yield at most this many bytes out. The name is a
+# few hundred bytes in, in the stream's first command, so this is already far more than we need.
+PEEK_BYTES=262144
+stream_name() {
+    zstd -dc "$1" 2>/dev/null | head -c "$PEEK_BYTES" | btrfs receive --dump 2>/dev/null \
+        | awk '/^(subvol|snapshot)[[:space:]]/ { n=$2; sub(/^\.\//,"",n); print n; exit }'
+}
+
 # route a _stock golden base into @stock-snapshots; every other snapshot into @snapshots. The stream
-# carries the subvol name; peek it from a file (a pipe cannot be peeked, so it stays in @snapshots).
+# carries the subvol name; peek it from a file. A pipe cannot be peeked, so a stream arriving on
+# stdin lands in @snapshots first and is moved afterwards, once the name is on disk to read.
 target="$TOP/@snapshots"
+PEEK=""
 if [ "$src" != "-" ]; then
-    name=$(zstd -dc "$src" 2>/dev/null | head -c 262144 | btrfs receive --dump 2>/dev/null \
-           | awk '/^(subvol|snapshot)[[:space:]]/ { n=$2; sub(/^\.\//,"",n); print n; exit }')
-    case "$name" in ?*_stock) target="$TOP/@stock-snapshots" ;; esac
+    name=$(stream_name "$src")
+else
+    # A pipe cannot be rewound, so keep the first chunk and replay it ahead of the rest. Fixing
+    # it afterwards is not an option: clearing ro to move a received subvolume drops
+    # received_uuid, which is what btrfs matches a later incremental against.
+    PEEK=$(mktemp); TOP_TMPFILES="${TOP_TMPFILES:-} $PEEK"
+    # 9>&-: this blocks until the peer sends the chunk or closes, and it inherits the lock
+    # descriptor, so a kill while it waits would leave it holding the lock with no owner
+    head -c "$PEEK_BYTES" > "$PEEK" 9>&-
+    name=$(stream_name "$PEEK")
 fi
+case "$name" in ?*_stock) target="$TOP/@stock-snapshots" ;; esac
+[ -n "$name" ] && echo "Stream carries $name" >&2
 [ -d "$target" ] || die "${target##*/} not found at top level"
 # btrfs receive refuses to replace an existing subvolume, and it says so only once the stream has
 # been transferred. Where the name was read up front, answer it here instead.
@@ -64,11 +84,15 @@ before=$(btrfs subvolume list -o "$target" 2>/dev/null | wc -l)
 # file src -> pv shows %/ETA; silence zstd so the two don't collide on one line.
 # No pipefail in POSIX sh, so the pipeline's status is btrfs receive's (the meaningful end).
 set +e
+# 9>&- for the same reason as the peek above: nothing in this pipeline needs the lock descriptor,
+# and anything that survives us must not keep the lock alive
+{
 if   [ "$have_pv" = 1 ] && [ "$src" != "-" ]; then pv "$src" | zstd -dc --no-progress | btrfs receive "$target"
-elif [ "$have_pv" = 1 ];                      then zstd -dc --no-progress | pv -btr   | btrfs receive "$target"
 elif [ "$src" != "-" ];                       then zstd -dc "$src"        | btrfs receive "$target"
-else                                               zstd -dc               | btrfs receive "$target"
+elif [ "$have_pv" = 1 ];                      then { cat "$PEEK"; cat; } | zstd -dc --no-progress | pv -btr | btrfs receive "$target"
+else                                               { cat "$PEEK"; cat; } | zstd -dc | btrfs receive "$target"
 fi
+} 9>&-
 rc=$?
 set -e
 if [ "$rc" != 0 ]; then

--- a/overlays/usr/local/sbin/rename-profile
+++ b/overlays/usr/local/sbin/rename-profile
@@ -59,7 +59,10 @@ echo "Renamed profile '$old' -> '$new'"
 # drop old name's BLS entry + staging, reissue for <@new>; parent chain intact -> right band
 lib=/usr/lib/flipper-bls.sh
 if [ -r "$lib" ]; then
-    ( . "$lib"; remove_root_entries "$old"; flipper_write_entry "$new" "$TOP/$new" ) \
+    (
+      # entries live on the filesystem we are operating on, not on the running root under -d
+      ENTRIES="$TOP/boot/loader/entries"
+      . "$lib"; remove_root_entries "$old"; flipper_write_entry "$new" "$TOP/$new" ) \
         || echo "Warning: Boot entry not updated for $new" >&2
 else
     echo "Warning: $lib not found; boot entry not updated for $new" >&2

--- a/overlays/usr/local/sbin/rename-profile
+++ b/overlays/usr/local/sbin/rename-profile
@@ -60,8 +60,10 @@ echo "Renamed profile '$old' -> '$new'"
 lib=/usr/lib/flipper-bls.sh
 if [ -r "$lib" ]; then
     (
-      # entries live on the filesystem we are operating on, not on the running root under -d
+      # entries live on the filesystem we are operating on, not on the running root under -d,
+      # and its UUID is what the cmdline must name
       ENTRIES="$TOP/boot/loader/entries"
+      TARGET_FSUUID="$(top_fsuuid)"
       . "$lib"; remove_root_entries "$old"; flipper_write_entry "$new" "$TOP/$new" ) \
         || echo "Warning: Boot entry not updated for $new" >&2
 else

--- a/overlays/usr/local/sbin/rename-profile
+++ b/overlays/usr/local/sbin/rename-profile
@@ -13,7 +13,7 @@ set -eu
 usage() {
     cat <<EOF
 Usage: rename-profile [-d|--device DEV] <@old> <@new>
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   Rename a bootable profile at the btrfs top level (see list-profiles) and reissue
   its boot entry. Both are top-level names. Cannot rename the booted profile.
 EOF
@@ -22,7 +22,7 @@ EOF
 while [ $# -gt 0 ]; do
     case "$1" in
         -y|--yes)    ASSUME_YES=1 ;;
-        -d|--device) shift; [ $# -ge 1 ] || { echo "Error: --device needs an argument" >&2; usage >&2; exit 1; }; ROOTDEV=$1 ;;
+        -d|--device) shift; need_device_arg "$#"; ROOTDEV=$1 ;;
         --device=*)  ROOTDEV=${1#*=} ;;
         -h|--help)   usage; exit 0 ;;
         --)          shift; break ;;

--- a/overlays/usr/local/sbin/rename-profile
+++ b/overlays/usr/local/sbin/rename-profile
@@ -57,17 +57,7 @@ mv "$TOP/$old" "$TOP/$new"
 echo "Renamed profile '$old' -> '$new'"
 
 # drop old name's BLS entry + staging, reissue for <@new>; parent chain intact -> right band
-lib=/usr/lib/flipper-bls.sh
-if [ -r "$lib" ]; then
-    (
-      # entries live on the filesystem we are operating on, not on the running root under -d,
-      # and its UUID is what the cmdline must name
-      ENTRIES="$TOP/boot/loader/entries"
-      TARGET_FSUUID="$(top_fsuuid)"
-      . "$lib"; remove_root_entries "$old"; flipper_write_entry "$new" "$TOP/$new" ) \
-        || echo "Warning: Boot entry not updated for $new" >&2
-else
-    echo "Warning: $lib not found; boot entry not updated for $new" >&2
-fi
+with_bls "old boot entry not removed for $old" remove_root_entries "$old"
+with_bls "boot entry not created for $new" flipper_write_entry "$new" "$TOP/$new"
 
 echo "Reboot and pick '$new' from the boot menu to use it"

--- a/overlays/usr/local/sbin/rename-profile
+++ b/overlays/usr/local/sbin/rename-profile
@@ -43,13 +43,13 @@ is_reserved_subvol "$new" && die "Refusing to use reserved name: $new"
 
 set_lock
 mount_top
-cur_id=""; top_is_booted_fs && cur_id=$(booted_id)
+cur_id=$(top_booted id)
 [ -e "$TOP/$old" ] || die "No such profile: $old (see list-profiles)"
 [ -e "$TOP/$new" ] && die "Target already exists: $new"
 is_reserved_subvol "$old" && die "Refusing to rename reserved subvolume: $old"
 info=$(btrfs subvolume show "$TOP/$old" 2>/dev/null) || die "Not a profile: $old"
 old_id=$(get "$info" "Subvolume ID")
-[ -n "$cur_id" ] && [ "$old_id" = "$cur_id" ] \
+[ "$old_id" = "$cur_id" ] \
     && die "Refusing to rename the currently booted profile ($old); boot into another profile first"
 
 # top-level dir entry: mv keeps UUID + btrfs parent

--- a/overlays/usr/local/sbin/rename-profile
+++ b/overlays/usr/local/sbin/rename-profile
@@ -43,7 +43,7 @@ is_reserved_subvol "$new" && die "Refusing to use reserved name: $new"
 
 set_lock
 mount_top
-cur_id=$(booted_id)
+cur_id=""; top_is_booted_fs && cur_id=$(booted_id)
 [ -e "$TOP/$old" ] || die "No such profile: $old (see list-profiles)"
 [ -e "$TOP/$new" ] && die "Target already exists: $new"
 is_reserved_subvol "$old" && die "Refusing to rename reserved subvolume: $old"

--- a/overlays/usr/local/sbin/send-snapshot
+++ b/overlays/usr/local/sbin/send-snapshot
@@ -140,10 +140,15 @@ echo "Sending $srel${parentpath:+ (incremental from $prel)}${dest:+ -> $dest}" >
 # no pipefail: run under set +e and check both ends (send via $send_stat, and compress);
 # discard partial output on any failure so a bad send never looks like a complete backup
 set +e
+# 9>&- : children inherit the lock descriptor, and the flock lives on the open file description, so
+# a child that outlives us keeps the lock held with no owner. A killed send used to leave zstd, pv
+# or a waiting flock holding it, and every writer tool would block until the next reboot.
+{
 if   [ "$have_pv" = 1 ] && [ "$sz" -gt 0 ]; then do_send | pv -pterb -s "$sz" | emit
 elif [ "$have_pv" = 1 ];                    then do_send | pv -btr | emit
 else                                              do_send | emit
 fi
+} 9>&-
 emit_rc=$?
 set -e
 send_rc=$(cat "$send_stat" 2>/dev/null || echo 1)

--- a/overlays/usr/local/sbin/send-snapshot
+++ b/overlays/usr/local/sbin/send-snapshot
@@ -27,7 +27,7 @@ usage() {
 Usage: send-snapshot [-p PARENT | -i] [-d|--device DEV] <@snapshot> <file|dir|->
   -p PARENT   incremental: send only changes since PARENT (ro, must exist on receiver)
   -i          incremental vs the source's _stock parent (else a full send)
-  -d,--device operate on btrfs filesystem DEV instead of the booted root (e.g. recovery)
+$HELP_DEVICE
   <@snapshot> full path or bare name, e.g. @snapshots/<name> (rw source auto-snapshotted ro)
   <file|dir>  output file, a directory (writes <leaf>_pack.zst), or - for stdout
 EOF

--- a/overlays/usr/local/sbin/send-snapshot
+++ b/overlays/usr/local/sbin/send-snapshot
@@ -61,7 +61,9 @@ fi
 
 send_stat=$(mktemp)
 TOP_TMPFILES="$send_stat"
-set_lock
+# No lock yet: a send only reads. Only the ro snapshot of a read-write source mutates, and it takes
+# the lock just for that. Holding it across the stream blocks every writer for the whole send, and
+# deadlocks a local 'send-snapshot - | receive-snapshot -'.
 mount_top
 
 parent_path_of() {  # $1 = fs path -> top-relative path of its parent subvol (empty if none)
@@ -90,9 +92,11 @@ case "${srel##*/}" in
             # btrfs send needs a ro source; snapshot the rw one ro into @snapshots (kept as a
             # restore point) and send that. Each send captures current state, so re-sends never collide.
             [ -d "$TOP/@snapshots" ] || die "@snapshots not found at top level (needed for a ro snapshot)"
+            set_lock
             rosnap="@snapshots/${src_name##*/}_$(stamp)"
             [ -e "$TOP/$rosnap" ] && die "Snapshot already exists: $rosnap"
             btrfs subvolume snapshot -r "$srcpath" "$TOP/$rosnap" >/dev/null || die "Failed to make a ro snapshot of $src_name"
+            release_lock
             echo "Source is read-write; made ro snapshot $rosnap (kept) and sending it" >&2
             srel=$rosnap; srcpath="$TOP/$rosnap"
         fi ;;


### PR DESCRIPTION
`list-profiles` said when a profile was created but not whether it had ever been used, which is the
question you have with five bootable roots on one device.

Nothing records it directly, and `@var-log` is shared, so the journal cannot tell profiles apart. What
is per-profile is systemd's own state: `var/lib/systemd/random-seed`, rewritten at every boot and clean
shutdown, and `var/lib/systemd/timesync/clock`, rewritten while the profile runs. The newest of the two
is when that profile was last alive. Both are inherited from whatever the profile was made from, so
only a stamp newer than the profile's own creation counts; anything older reads `never`.

The running profile reads `now`. Its seed is written once at boot and timesyncd rewrites its clock only
periodically, so a timestamp there drifted up to half an hour behind the one profile that is certainly
in use, and `<- booted` already identifies it.

```
NAME                      KIND     ID   CREATED              LAST USED            RO  PARENT
@Minimal       <- booted  profile  263  2026-08-06 07:58:33  now                  rw  @Minimal_868_stock
@Desktop                  profile  265  2026-08-06 08:00:52  2026-08-06 08:51:18  rw  @Desktop_868_stock
@Router                   profile  269  2026-08-06 08:01:12  never                rw  @Router_868_stock
```

Verified on Flipper One in three environments: on a booted profile 5/5, including a stamp planted
before the profile existed (ignored) and one planted after (shown); in recoveryOS through `-d`, where
`/` is not btrfs, 6/6; and from the SD-card Installer reading the unmounted eMMC, where `now` correctly
does not appear for a profile that is not running.

Timezones do not affect it: `btrfs subvolume show` renders the creation time in the reader's zone, so
the same subvolume gives one epoch under UTC, Europe/Berlin and Asia/Tokyo, and the comparison is epoch
against epoch.

The clock does matter. A profile booted while the device clock is behind its own creation time has its
stamps rejected by the floor and reads `never` until a boot with a correct clock. That is the
conservative failure, so it is left as is.

The `now` row needs #144 below it: it is chosen from the same marker that prints `<- booted`, and #144
is what makes that marker check the filesystem before trusting a subvolume id. On a foreign filesystem the
listing therefore says so and no row claims to be running.
