### PR TITLE
list-profiles: show when each profile was last running

### DIFF
--- a/overlays/usr/local/sbin/list-profiles
+++ b/overlays/usr/local/sbin/list-profiles
@@ -3,7 +3,8 @@
 # (@Desktop, @Minimal, ...) and @<profile>_old_* leftovers from create-profile. KIND tags each
 # (profile/old); PARENT is what it was snapshotted from (via Parent UUID). Names are top-level
 # paths (what create-profile/rename-profile/delete-profile take). The booted profile is marked
-# <- booted. For _stock golden bases and restore points, see list-snapshots.
+# <- booted. LAST USED is when the profile last RAN: 'now' for the running one, 'never' if never.
+# For _stock golden bases and restore points, see list-snapshots.
 # Works via a subvolid=5 (top-level) mount.
 #
 # Example:
@@ -48,10 +49,30 @@ else
 fi
 echo
 
+# Newest of systemd's random-seed (written at every boot and clean shutdown) and timesyncd's clock
+# (written while the profile runs). Both are inherited from whatever the profile was made from, so
+# only a stamp newer than the profile's own creation counts; anything older reads 'never'.
+last_used() {  # $1 = fs path  $2 = creation epoch -> "YYYY-MM-DD HH:MM:SS" | never
+    _lu=""
+    for _w in var/lib/systemd/random-seed var/lib/systemd/timesync/clock; do
+        [ -f "$1/$_w" ] || continue
+        _t=$(stat -c '%Y %y' "$1/$_w" 2>/dev/null) || continue
+        [ -n "${2:-}" ] && [ "${_t%% *}" -le "$2" ] && continue
+        case "$_lu" in
+            "") _lu=$_t ;;
+            *)  [ "${_t%% *}" -gt "${_lu%% *}" ] && _lu=$_t ;;
+        esac
+    done
+    case "$_lu" in
+        "") printf 'never' ;;
+        *)  printf '%s' "$(printf '%s' "${_lu#* }" | cut -c1-19)" ;;
+    esac
+}
+
 emit() {  # $1=display name  $2=fs path
     info=$(btrfs subvolume show "$2" 2>/dev/null) || return 0
     id=$(get "$info" "Subvolume ID")
-    otime=$(get "$info" "Creation time"); otime=${otime% +*}
+    otime=$(get "$info" "Creation time")
     flags=$(get "$info" "Flags"); case "$flags" in *readonly*) flags=ro ;; *) flags=rw ;; esac
     parent=$(parent_of "$map" "$(get "$info" "Parent UUID")")
     case "$1" in
@@ -61,10 +82,17 @@ emit() {  # $1=display name  $2=fs path
         *)       kind=profile ;;
     esac
     mark=""; is_running_id "$id" "$cur_id" && mark="<- booted"
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$mark" "$kind" "${id:-?}" "${otime:-?}" "$flags" "$parent" >> "$rows"
+    # convert while the "+0000" btrfs prints is still there: date -d without a zone assumes the
+    # reader's, which shifts the epoch whenever that differs from the zone the profile was made in
+    oepoch=$(date -d "$otime" +%s 2>/dev/null || echo "")
+    otime=${otime% +*}   # the column shows the time without the zone
+    # the profile we are running from writes its state at boot and then only now and then, so a
+    # timestamp here would read as stale for the one profile that is definitely in use
+    if [ -n "$mark" ]; then lu=now; else lu=$(last_used "$2" "$oepoch"); fi
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$mark" "$kind" "${id:-?}" "${otime:-?}" "$lu" "$flags" "$parent" >> "$rows"
 }
 
-printf 'NAME\t\tKIND\tID\tCREATED\tRO\tPARENT\n' > "$rows"
+printf 'NAME\t\tKIND\tID\tCREATED\tLAST USED\tRO\tPARENT\n' > "$rows"
 # top-level profile roots + @_old_* leftovers; skip shared/reserved subvols (@snapshots,
 # @stock-snapshots, ...) so stocks (now nested under @stock-snapshots) are not listed here
 for d in "$TOP"/@*; do


### PR DESCRIPTION
`list-profiles` said when a profile was created but not whether it had ever been used, which is the
question you have with five bootable roots on one device.

Nothing records it directly, and `@var-log` is shared, so the journal cannot tell profiles apart. What
is per-profile is systemd's own state: `var/lib/systemd/random-seed`, rewritten at every boot and clean
shutdown, and `var/lib/systemd/timesync/clock`, rewritten while the profile runs. The newest of the two
is when that profile was last alive. Both are inherited from whatever the profile was made from, so
only a stamp newer than the profile's own creation counts; anything older reads `never`.

The running profile reads `now`. Its seed is written once at boot and timesyncd rewrites its clock only
periodically, so a timestamp there drifted up to half an hour behind the one profile that is certainly
in use, and `<- booted` already identifies it.

```
NAME                      KIND     ID   CREATED              LAST USED            RO  PARENT
@Minimal       <- booted  profile  263  2026-08-06 07:58:33  now                  rw  @Minimal_868_stock
@Desktop                  profile  265  2026-08-06 08:00:52  2026-08-06 08:51:18  rw  @Desktop_868_stock
@Router                   profile  269  2026-08-06 08:01:12  never                rw  @Router_868_stock
```

Verified on Flipper One in three environments: on a booted profile 5/5, including a stamp planted
before the profile existed (ignored) and one planted after (shown); in recoveryOS through `-d`, where
`/` is not btrfs, 6/6; and from the SD-card Installer reading the unmounted eMMC, where `now` correctly
does not appear for a profile that is not running.

Timezones do not affect it: `btrfs subvolume show` renders the creation time in the reader's zone, so
the same subvolume gives one epoch under UTC, Europe/Berlin and Asia/Tokyo, and the comparison is epoch
against epoch.

The clock does matter. A profile booted while the device clock is behind its own creation time has its
stamps rejected by the floor and reads `never` until a boot with a correct clock. That is the
conservative failure, so it is left as is.

The `now` row needs #144 below it: it is chosen from the same marker that prints `<- booted`, and #144
is what makes that marker check the filesystem before trusting a subvolume id. On a foreign filesystem the
listing therefore says so and no row claims to be running.

