### PR TITLE
Give the TV profile the Kodi addons it needs

### DIFF
--- a/debian-rk3576-img.yaml
+++ b/debian-rk3576-img.yaml
@@ -333,6 +333,14 @@ actions:
       - cage
       - kodi
       - kodi-eventclients-kodi-send
+      - kodi-imagedecoder-heif
+      - kodi-inputstream-adaptive
+      - kodi-inputstream-ffmpegdirect
+      - kodi-peripheral-joystick
+      - kodi-pvr-iptvsimple
+      - kodi-repository-kodi
+      - kodi-vfs-libarchive
+      - kodi-vfs-sftp
   - action: run
     description: Prune orphaned packages and apt cache
     chroot: true


### PR DESCRIPTION
Stock `kodi` plays local files and little else, and Debian splits the official addon repository out of the `kodi` package, so the UI has no way to reach an addon either. Eight package-list additions cover both halves for `@TV-Media-Box`.

## What each brings

`inputstream.adaptive` and `ffmpegdirect` provide the streaming protocols nearly every video plugin expects, and `iptvsimple` turns an M3U playlist into live TV. The `sftp` and `libarchive` VFS backends read media straight off a remote share or out of an archive without unpacking it first. `heif` decodes the pictures phones now take by default, and `peripheral.joystick` lets a gamepad drive the UI from the sofa.

`kodi-repository-kodi` is `repository.xbmc.org` itself. Without it the only entry under *Install from repository* is Debian's language packs.

All verified present for trixie/arm64:

| package | candidate |
| --- | --- |
| kodi-imagedecoder-heif | 21.0.2+ds-1+b1 |
| kodi-inputstream-adaptive | 21.5.9+ds-1 |
| kodi-inputstream-ffmpegdirect | 21.3.7+ds-2 |
| kodi-peripheral-joystick | 21.1.22+ds-1 |
| kodi-pvr-iptvsimple | 21.10.2+ds-1 |
| kodi-repository-kodi | 2:21.2+dfsg-4 |
| kodi-vfs-libarchive | 21.0.2+ds-1 |
| kodi-vfs-sftp | 21.0.2+ds-1 |

`recommends` stays false, as everywhere else in this recipe. `kodi-inputstream-rtmp` is not listed because `iptvsimple` depends on it, and `heif` brings `libheif1` with the `dav1d` and `libde265` plugins. Nothing else is pulled in.

## Why the repository comes from apt

`kodi-repository-kodi` is built from the same source package as `kodi`, so it stays locked to whichever kodi the image carries. That matters because the repository declares the mirror branch it reads (`omega` for kodi 21): tracking it outside apt would mean refreshing it by hand on every major kodi bump, or serving addons built for the wrong version.

## Verified on device

Installed by hand on `@TV-Media-Box` (kodi `2:21.2+dfsg-4`) before committing. Kodi picked the repository up, fetched and checksummed the index, and enabled it with no UI step:

```
repo:    repository.xbmc.org  3.4.0  sha256 verified
addons indexed from the repo: 881
installed: ('repository.xbmc.org', 1)      <- enabled
```

## Note on binary addons

Team Kodi filters binary addons by platform and publishes **none** for a Linux distro build: of the 881 addons indexed, zero declare a `kodi.binary.*` dependency. So nothing installed from the repository can collide with the Debian-built addons above, and conversely any binary addon Debian does not package has no route on this image. That is why the binary ones are named explicitly rather than left to the repository. Debian's arm64 coverage is 54 packages including 22 PVR backends, should another backend ever be wanted.

## Testing

- Every package name and candidate checked with `apt-cache policy` on trixie/arm64, and the dependency footprint with `apt-get install -s`.
- Repository behaviour confirmed against Kodi's `Addons33.db`: index fetched, checksum verified, addon enabled without a prompt.
- **Not yet built.** Package-list additions only, no recipe or overlay changes, so the remaining risk is package resolution at build time.
