### PR TITLE
Install jq and tinycbor-utils for flipmeta

### DIFF
--- a/debian-rk3576-ospack.yaml
+++ b/debian-rk3576-ospack.yaml
@@ -65,6 +65,7 @@ actions:
       - iputils-ping
       - iw
       - iwd
+      - jq
       - kmscube
       - less
       - libcanberra-pulse
@@ -116,6 +117,7 @@ actions:
       - systemd-sysv
       - systemd-timesyncd
       - tcpdump
+      - tinycbor-utils
       - traceroute
       - udev
       - umtp-responder


### PR DESCRIPTION
`flipmeta` (in flipperos-btrfs-tools) reads and writes the CBOR blob in the 4 MiB `metadata`
partition. It needs two things the ospack does not install today:

- `tinycbor-utils`, for `cbordump` and `tinycbor-json2cbor`, which convert between CBOR and JSON
  in both directions
- `jq`, for reading and modifying individual keys

Without them the tool exits with `Command not installed`.

Verified on Flipper One with both packages installed by hand: flipmeta initialises the partition
from blank, stores and reads back keys, preserves keys it was not asked to change, falls back to
the previous generation when the active copy is damaged, and refuses to write when both copies
are.