### PR TITLE
Ship no ssh host keys, generate them per device on first boot

### DIFF
--- a/debian-rk3576-ospack.yaml
+++ b/debian-rk3576-ospack.yaml
@@ -255,10 +255,12 @@ actions:
     command: |
       echo 'BUILD_GIT="{{ $gitinfo }}"' >> /etc/os-release
 
+  # Ship no per-device identity: the missing machine-id makes systemd treat the first boot of
+  # every root as a first boot, which is what sshd-keygen.service waits for to run ssh-keygen -A.
   - action: run
-    description: Remove /etc/machine-id and default /etc/motd
+    description: Remove /etc/machine-id, default /etc/motd and the ssh host keys
     chroot: true
-    command: rm -f /etc/machine-id /etc/motd
+    command: rm -f /etc/machine-id /etc/motd /etc/ssh/ssh_host_*
 
   - action: run
     description: Switch to upstream signed regulatory.db


### PR DESCRIPTION
Every device flashed from one image shipped the same ssh host keys, because the openssh
postinst generates them during the build. Reflashing then changed that shared identity.

Removing them alongside `/etc/machine-id` hands the job to Debian's `sshd-keygen.service`
(`ConditionFirstBoot=yes`, `ExecStart=ssh-keygen -A`), which is enabled through both
`ssh.service.wants` and `ssh.socket.wants` in `openssh-server 1:10.0p1-7+deb13u4`. The
absent machine-id is what makes systemd call the next boot a first boot, so the two
removals are one mechanism, which is why they stay in one action.

Each profile root inherits the key-less, machine-id-less state from its `_stock`, so every
profile generates its own keys the first time it boots.

Verified on Flipper One: the running image's host keys carry the build timestamp while
`/etc/machine-id` was written at first boot, confirming both the shared-identity problem
and that first-boot detection fires. `sshd-keygen.service` is present and enabled there.
