### PR TITLE
Add kexec-tools to the list of required packages

### DIFF
--- a/debian-rk3576-ospack.yaml
+++ b/debian-rk3576-ospack.yaml
@@ -66,6 +66,7 @@ actions:
       - iw
       - iwd
       - jq
+      - kexec-tools
       - kmscube
       - less
       - libcanberra-pulse


### PR DESCRIPTION
flipctl's boot menu boots another profile by kexec'ing into it, so the image needs
`kexec-tools` present at runtime. Without it the menu can list the profiles but not switch
to one: `boot-profile`, the tool behind it in flipperos-btrfs-tools, refuses to start with
`kexec not installed (kexec-tools)`.

Kept in the list's alphabetical order, between `jq` and `kmscube`.
