### PR TITLE
Retry the first-boot identity setup instead of losing it

### DIFF
--- a/overlays/configs/systemd/system/set-hostname-and-banner.service
+++ b/overlays/configs/systemd/system/set-hostname-and-banner.service
@@ -4,7 +4,12 @@ DefaultDependencies=no
 After=systemd-hostnamed.service dbus.service
 Before=systemd-machine-id-commit.service first-boot-complete.target network.target
 ConditionPathIsReadWrite=/etc
-ConditionFirstBoot=yes
+# ConditionFirstBoot is spent once PID1 writes /etc/machine-id, so an interrupted first boot
+# would never set the hostname, banner, avahi service or SSID again. The banner is written
+# last, so its absence means an unfinished run; a clone triggers on first boot instead, which
+# is what refreshes the profile name in its banner.
+ConditionFirstBoot=|yes
+ConditionPathExists=|!/etc/ssh/welcome_banner
 Wants=first-boot-complete.target
 
 [Service]

--- a/overlays/configs/systemd/system/sshd-keygen.service.d/10-any-boot.conf
+++ b/overlays/configs/systemd/system/sshd-keygen.service.d/10-any-boot.conf
@@ -1,0 +1,5 @@
+# ConditionFirstBoot is spent once PID1 writes /etc/machine-id, so an interrupted first boot would
+# leave a root with no host keys and no ssh. Retry on the keys instead; -A only fills what is missing.
+[Unit]
+ConditionFirstBoot=
+ConditionPathExists=!/etc/ssh/ssh_host_ed25519_key

--- a/overlays/usr/local/bin/set-hostname-and-banner.sh
+++ b/overlays/usr/local/bin/set-hostname-and-banner.sh
@@ -35,19 +35,6 @@ profile=$(findmnt -nro FSROOT / 2>/dev/null)
 profile=${profile#/}
 [ -n "$profile" ] && [ "$profile" != "/" ] || profile=unknown
 
-# Generate SSH welcome banner
-cat <<EOF >/etc/ssh/welcome_banner
-=================== Welcome to FlipperOne ===================
-Git:          $build_git
-Board:        $board
-CPU Serial:   $serial
-Memory:       $total_mem
-Build ID:     $build_id
-Profile:      $profile
-Default credentials: user / user
-=============================================================
-EOF
-
 # Generate Avahi mDNS service for LAN discovery via _flipper._tcp
 mkdir -p /etc/avahi/services
 cat <<EOF >/etc/avahi/services/flipper.service
@@ -68,3 +55,17 @@ sed -i "s/WIFISSIDSERIAL/${serial}/" /etc/NetworkManager/system-connections/wifi
 nmcli connection reload 2>/dev/null || true
 
 systemd-machine-id-setup
+
+# The SSH welcome banner, written last on purpose: the unit keys its retry off this file, so it
+# must not appear until everything above it is done.
+cat <<EOF >/etc/ssh/welcome_banner
+=================== Welcome to FlipperOne ===================
+Git:          $build_git
+Board:        $board
+CPU Serial:   $serial
+Memory:       $total_mem
+Build ID:     $build_id
+Profile:      $profile
+Default credentials: user / user
+=============================================================
+EOF


### PR DESCRIPTION
Two units set up a root's identity on its first boot and never get another chance, because
`ConditionFirstBoot` is spent as soon as PID1 persists `/etc/machine-id` - early in the boot,
well before either unit runs. Anything that interrupts that window leaves the root permanently
half-configured, and `systemctl start` cannot help: it re-evaluates the same spent condition and
skips.

**`sshd-keygen.service`** is the serious one. Now that the image ships no host keys, a root that
misses its one chance has none at all, `sshd -t` fails with no hostkeys, and ssh - the way back in -
is gone for good. The drop-in keys the unit off the keys themselves, so it retries until they exist
and costs nothing once they do, since `ssh-keygen -A` only creates what is missing.

**`set-hostname-and-banner.service`** is the one already seen in the wild: a root that came up with
the fallback `localhost` hostname, no ssh banner, no avahi service, and the AP SSID still holding the
literal `WIFISSIDSERIAL` placeholder. It now also triggers when the banner is absent, and the script
writes the banner last, so the banner exists only once everything before it is done. Any failure
point - power loss, a dbus hiccup, the `set -e` abort - therefore leaves the trigger armed for the
next boot. The first-boot trigger stays alongside it, because that is what makes a clone refresh the
profile name in its banner.

Both are idempotent: `ssh-keygen -A` fills gaps only, and the script recomputes the same values.
No new state files.

