### PR TITLE
Probe the ethernet and LED drivers asynchronously

### DIFF
--- a/debian-rk3576-img.yaml
+++ b/debian-rk3576-img.yaml
@@ -3,7 +3,10 @@
 {{ $kerneldir  := or .kerneldir  "prebuilt/linux" }}
 # cmdline: shared facts + policy only. The BLS generator adds the per-entry rootflags=subvol=
 # and the serial consoles (console=ttyS0/ttyS4/fbcon or ttyFIQ0, per kernel config).
-{{ $cmdline    := or .cmdline    "audit=0 console=tty1" }}
+# driver_async_probe: the two gmacs and gpio-leds each block the probe thread ahead of the UFS
+# host (~570ms and ~600ms), so releasing them moves root discovery, and every milestone after
+# it, ~1.15s earlier. Measured: only these two help; typec, audio and dw-dp gain nothing.
+{{ $cmdline    := or .cmdline    "audit=0 console=tty1 driver_async_probe=rk_gmac-dwmac,leds-gpio" }}
 {{ $fslabel    := or .fslabel    "flipperos" }}
 # btrfsopts: fs-wide mount options. ssd is FORCED (loopback/eMMC isn't reliably
 # detected as non-rotational).


### PR DESCRIPTION
Takes the kernel phase of boot from 4.30s to 3.13s, about 1.15s, by adding `driver_async_probe=rk_gmac-dwmac,leds-gpio` to the shared kernel command line.

## Why

Both gmacs and gpio-leds probe synchronously ahead of the UFS host, so root discovery sits behind two drivers that nothing in the boot needs yet. `initcall_debug` puts the cost at 274ms and 272ms for the two ethernet controllers and 640ms for the LEDs. Releasing them moves every downstream milestone with them:

| milestone | before | after |
|---|---|---|
| `ufshcd-rockchip` probe | 3.114s | 2.327s |
| `sda: sda1 sda2 sda3` | 3.26s | 2.05s |
| `Run /init` | 3.357s | 2.845s |
| btrfs first mount | 3.990s | 3.460s |
| systemd start | 4.315s | 3.808s |

Since this is all before root is mounted, it comes straight off time to a usable UI.

## Measurements

10 boots, reboot to reboot:

| config | mean kernel | range |
|---|---|---|
| baseline | 4.30s | 4.249 - 4.362 |
| `rk_gmac-dwmac,leds-gpio` | 3.13s | 3.073 - 3.192 |

The ranges do not overlap: the slowest async boot beats the fastest baseline boot by a full second.

## Drivers deliberately left out

Each of these was measured over 2 boots and gains nothing, so none of them are in the parameter:

- `hd3ss3220` (208ms probe, and the most conspicuous stall in dmesg since it ends in `Failed to disable port for mode change: -6`): 4.28s / 4.31s, indistinguishable from baseline
- `asoc-simple-card` and `nau8822` (243ms of probe between them): 3.109s / 3.115s
- `dw-dp` (125ms): 3.132s / 3.123s

## Verification

Verified on Flipper One over 3 boots on the final config, identical every time: 11 LEDs registered with `[heartbeat]` active, all 4 DRM nodes present including the SPI panel at `platform-2acf0000.spi-cs-0-card`, `end0` up, 4 sound cards, 4 `sda` partitions, `cog-seat1` active, `systemctl is-system-running` reporting `running`, and 0 failed units.

Diffing every unique error-level dmesg line against a baseline boot returns nothing new. All 63 are pre-existing: the `hdmi-audio-codec` ASoC `-19` spam, the `rockchip-pm-domain` device-link failures, and the UFS RPMB registration failure.

Not covered: cold power-on. All timings above are reboot to reboot, which runs about 1s slower in userspace than a cold boot. The change lives entirely in the kernel phase, which was stable across every boot.

## Follow-ups

- The gpio-leds probe takes 640ms for two GPIO LEDs, which is anomalous by orders of magnitude. Async keeps it off the critical path but the underlying cost is still there and worth a look in the kernel repo.
- The initramfs is 11.3MB at `MODULES=most`, costing ~700ms to unpack plus ~950ms in `/init`, to mount a root whose UFS, SD and btrfs drivers are all built in.
- The raid6 benchmark burns 612ms every boot, selected by `BTRFS_FS=y`.