### PR TITLE
apt: offer a bootable backup profile before package changes

### DIFF
--- a/overlays/configs/apt/apt.conf.d/80-flipper-apt-backup
+++ b/overlays/configs/apt/apt.conf.d/80-flipper-apt-backup
@@ -1,0 +1,7 @@
+// Offers a bootable backup of the booted profile before apt changes packages: apt-backup-profile
+// asks whether to make one, under what name, and hands the work to create-profile. It runs only
+// when apt is about to call dpkg, so queries and `apt update` never see it, and it decides on its
+// own when there is nobody to ask (build-time chroot apt, no terminal, apt -y).
+// A non-zero exit is deliberate and aborts apt before dpkg: the backup failed and the user chose
+// not to go ahead without it. Single line: apt.conf strings cannot span multiple lines.
+DPkg::Pre-Invoke { "[ -x /usr/local/sbin/apt-backup-profile ] || exit 0; /usr/local/sbin/apt-backup-profile"; };

--- a/overlays/configs/apt/apt.conf.d/80-flipper-snapshot
+++ b/overlays/configs/apt/apt.conf.d/80-flipper-snapshot
@@ -1,5 +1,0 @@
-// Creates a read-only snapshot of the booted profile before apt changes packages, tagged
-// apt-<action>. Runs only when apt is about to call dpkg; $PPID is the apt process, so its cmdline
-// gives the subcommand. The case is the allowlist we protect. Skips build-time chroot apt; never
-// aborts apt. Single line: apt.conf strings cannot span multiple lines.
-DPkg::Pre-Invoke { "[ -d /run/systemd/system ] && [ -x /usr/local/sbin/create-snapshot ] || exit 0; V=$(xargs -0 -n1 </proc/$PPID/cmdline 2>/dev/null | awk 'NR==1{next} s{s=0;next} /^-[octap]$/{s=1;next} /^-/{next} {print;exit}'); case $V in ''|install|reinstall|remove|purge|autoremove|upgrade|full-upgrade|dist-upgrade|build-dep|satisfy|dselect-upgrade) create-snapshot apt-$V || true ;; esac"; };


### PR DESCRIPTION
The DPkg::Pre-Invoke drop-in now calls apt-backup-profile, which asks before creating a bootable backup of the booted profile, in place of the read-only snapshot it used to take unasked. The file is renamed to match what it does.