### PR TITLE
Regenerate host keys that are empty, and flush them

### DIFF
--- a/overlays/configs/systemd/system/sshd-keygen.service.d/10-any-boot.conf
+++ b/overlays/configs/systemd/system/sshd-keygen.service.d/10-any-boot.conf
@@ -1,5 +1,15 @@
 # ConditionFirstBoot is spent once PID1 writes /etc/machine-id, so an interrupted first boot would
 # leave a root with no host keys and no ssh. Retry on the keys instead; -A only fills what is missing.
+#
+# On their contents rather than their names: a reset seconds after the keys are written leaves the
+# inodes committed and the data not, so they come back empty. -A skips a key that exists, empty or
+# not, and sshd then exits with "no hostkeys available" on that boot and every one after. Empty is
+# as good as absent here, so the empty ones go before -A runs, and what it writes is flushed before
+# ssh.service is told the keys are there.
 [Unit]
 ConditionFirstBoot=
-ConditionPathExists=!/etc/ssh/ssh_host_ed25519_key
+ConditionFileNotEmpty=!/etc/ssh/ssh_host_ed25519_key
+
+[Service]
+ExecStartPre=-/usr/bin/find /etc/ssh -maxdepth 1 -name 'ssh_host_*' -size 0 -delete
+ExecStartPost=/usr/bin/sync


### PR DESCRIPTION
A reset seconds after a first boot generates the host keys leaves their inodes committed and their contents not, so all six come back zero length.

`ssh-keygen -A` only creates keys that are *missing*, and the retry drop-in added in 33f0253 conditioned on the file being there, so once empty files exist the unit is skipped on every later boot:

```
sshd-keygen.service ... skipped, unmet condition check ConditionPathExists=!/etc/ssh/ssh_host_ed25519_key
sshd: no hostkeys available -- exiting.
ssh.service: Start request repeated too quickly.
```

The device is then unreachable over ssh, with a serial console the only way back in.

This conditions on the contents instead (`ConditionFileNotEmpty=!`), deletes zero length key files before `-A` runs so it treats them as missing, and syncs after it so the keys are on disk before `ssh.service` is told they exist. `ExecStart` is left to the Debian unit.

Verified on Flipper One. All six keys truncated to zero, then rebooted:

```
Starting sshd-keygen.service - Generate sshd host keys on first boot...
ssh-keygen: generating new host keys: RSA ECDSA ED25519
Finished sshd-keygen.service
Starting ssh.service - OpenBSD Secure Shell server...
Server listening on 0.0.0.0 port 22
```

Also checked, on the device's own systemd, that the condition behaves as intended: a non-empty key skips the unit, a zero length one runs it, a missing one runs it.
