### PR TITLE
Flush the identity setup, and rerun it when the banner is empty

### DIFF
--- a/overlays/configs/systemd/system/set-hostname-and-banner.service
+++ b/overlays/configs/systemd/system/set-hostname-and-banner.service
@@ -7,9 +7,10 @@ ConditionPathIsReadWrite=/etc
 # ConditionFirstBoot is spent once PID1 writes /etc/machine-id, so an interrupted first boot
 # would never set the hostname, banner, avahi service or SSID again. The banner is written
 # last, so its absence means an unfinished run; a clone triggers on first boot instead, which
-# is what refreshes the profile name in its banner.
+# is what refreshes the profile name in its banner. Empty counts as absent: a reset can leave the
+# file with its contents lost, and a banner nobody wrote is not a run that finished.
 ConditionFirstBoot=|yes
-ConditionPathExists=|!/etc/ssh/welcome_banner
+ConditionFileNotEmpty=|!/etc/ssh/welcome_banner
 Wants=first-boot-complete.target
 
 [Service]

--- a/overlays/usr/local/bin/set-hostname-and-banner.sh
+++ b/overlays/usr/local/bin/set-hostname-and-banner.sh
@@ -56,6 +56,10 @@ nmcli connection reload 2>/dev/null || true
 
 systemd-machine-id-setup
 
+# On disk before the marker exists: a reset here leaves committed inodes with no contents, and the
+# banner appearing first would mean a hostname, machine-id or avahi service that never landed.
+sync
+
 # The SSH welcome banner, written last on purpose: the unit keys its retry off this file, so it
 # must not appear until everything above it is done.
 cat <<EOF >/etc/ssh/welcome_banner
@@ -69,3 +73,5 @@ Profile:      $profile
 Default credentials: user / user
 =============================================================
 EOF
+
+sync


### PR DESCRIPTION
Same failure shape as #165, one unit along.

`set-hostname-and-banner.sh` writes the hostname, the avahi service, the wifi SSID and the machine-id, then writes `/etc/ssh/welcome_banner` last on purpose: the unit keys its retry off that file. A reset in between can leave the marker committed with the contents of everything before it lost, and the unit then skips itself on every later boot, with no hostname, no mDNS record and no banner.

Two changes:

- `sync` before the banner is written, so the work is on disk before the marker that claims it is done, and `sync` after it.
- `ConditionPathExists=|!/etc/ssh/welcome_banner` becomes `ConditionFileNotEmpty=|!`, so an empty banner counts as an unfinished run, exactly as an empty host key now does.

Checked with `systemd-analyze condition`: a written banner skips the unit, an empty one runs it, a missing one runs it. Not yet exercised on hardware by truncating the banner and rebooting, the way the host key change was; the device was unreachable when this was written.
