### PR TITLE
Fix what a soft-reboot into a fresh profile exposed

### DIFF
--- a/overlays/configs/systemd/system/set-hostname-and-banner.service
+++ b/overlays/configs/systemd/system/set-hostname-and-banner.service
@@ -1,16 +1,22 @@
 [Unit]
 Description=Set dynamic hostname and SSH banner based on board and OS
 DefaultDependencies=no
+# DefaultDependencies=no also means nothing conflicts this unit with shutdown, so a
+# soft-reboot never stops it and PID1 carries its state into the root it lands in, where
+# the conditions below are never looked at again.
+Conflicts=shutdown.target
+Before=shutdown.target
 After=systemd-hostnamed.service dbus.service
 Before=systemd-machine-id-commit.service first-boot-complete.target network.target
 ConditionPathIsReadWrite=/etc
 # ConditionFirstBoot is spent once PID1 writes /etc/machine-id, so an interrupted first boot
-# would never set the hostname, banner, avahi service or SSID again. The banner is written
-# last, so its absence means an unfinished run; a clone triggers on first boot instead, which
-# is what refreshes the profile name in its banner. Empty counts as absent: a reset can leave the
-# file with its contents lost, and a banner nobody wrote is not a run that finished.
+# would never set the hostname, banner, avahi service or SSID again. The hostname is what says
+# whether a root has been named: the image ships debian-rk3576 and this unit is the only thing
+# that ever replaces it, so that name, or none at all, means the work is still to do. A clone
+# triggers on first boot instead, which is what refreshes the profile name in its banner.
 ConditionFirstBoot=|yes
-ConditionFileNotEmpty=|!/etc/ssh/welcome_banner
+ConditionHost=|debian-rk3576
+ConditionFileNotEmpty=|!/etc/hostname
 Wants=first-boot-complete.target
 
 [Service]

--- a/overlays/configs/systemd/system/usb-msc-gadget.service
+++ b/overlays/configs/systemd/system/usb-msc-gadget.service
@@ -1,4 +1,8 @@
 [Unit]
+# One gadget configuration can own the UDC, so starting one stops whichever is running
+# and lets its ExecStopPost tear the gadget down first. Conflicts without a matching
+# After=: four units each naming the other three would be an ordering cycle.
+Conflicts=usb-ncm-gadget.service usb-ncm-msc-gadget.service usb-ncm-msc-mtp-gadget.service
 Description=USB Mass Storage Gadget (share UFS as a thumb drive, read-only)
 After=sys-kernel-config.mount
 Requires=sys-kernel-config.mount

--- a/overlays/configs/systemd/system/usb-ncm-gadget.service
+++ b/overlays/configs/systemd/system/usb-ncm-gadget.service
@@ -1,4 +1,13 @@
+# No [Install] on purpose: one gadget configuration can own the UDC, and this image boots
+# usb-ncm-msc-mtp-gadget. A unit with an [Install] section is enabled by the preset pass
+# systemd makes on a profile's first boot, and all three then started within ten
+# milliseconds of each other, with this one winning and the boot ending up with no mass
+# storage and no MTP. Start it by hand to switch to it.
 [Unit]
+# One gadget configuration can own the UDC, so starting one stops whichever is running
+# and lets its ExecStopPost tear the gadget down first. Conflicts without a matching
+# After=: four units each naming the other three would be an ordering cycle.
+Conflicts=usb-msc-gadget.service usb-ncm-msc-gadget.service usb-ncm-msc-mtp-gadget.service
 Description=USB NCM Gadget Setup
 After=sys-kernel-config.mount
 Requires=sys-kernel-config.mount
@@ -10,6 +19,3 @@ Type=oneshot
 ExecStart=/usr/local/bin/usb-ncm-gadget.sh start
 ExecStopPost=/usr/local/bin/usb-ncm-gadget.sh stop
 RemainAfterExit=yes
-
-[Install]
-WantedBy=multi-user.target

--- a/overlays/configs/systemd/system/usb-ncm-msc-gadget.service
+++ b/overlays/configs/systemd/system/usb-ncm-msc-gadget.service
@@ -1,4 +1,10 @@
+# No [Install] on purpose: one gadget configuration can own the UDC, and this image boots
+# usb-ncm-msc-mtp-gadget. See usb-ncm-gadget.service. Start it by hand to switch to it.
 [Unit]
+# One gadget configuration can own the UDC, so starting one stops whichever is running
+# and lets its ExecStopPost tear the gadget down first. Conflicts without a matching
+# After=: four units each naming the other three would be an ordering cycle.
+Conflicts=usb-msc-gadget.service usb-ncm-gadget.service usb-ncm-msc-mtp-gadget.service
 Description=USB Composite Gadget Setup (NCM Ethernet + Mass Storage)
 After=sys-kernel-config.mount
 Requires=sys-kernel-config.mount
@@ -10,6 +16,3 @@ Type=oneshot
 ExecStart=/usr/local/bin/usb-ncm-msc-gadget.sh start
 ExecStopPost=/usr/local/bin/usb-ncm-msc-gadget.sh stop
 RemainAfterExit=yes
-
-[Install]
-WantedBy=multi-user.target

--- a/overlays/configs/systemd/system/usb-ncm-msc-mtp-gadget.service
+++ b/overlays/configs/systemd/system/usb-ncm-msc-mtp-gadget.service
@@ -1,4 +1,8 @@
 [Unit]
+# One gadget configuration can own the UDC, so starting one stops whichever is running
+# and lets its ExecStopPost tear the gadget down first. Conflicts without a matching
+# After=: four units each naming the other three would be an ordering cycle.
+Conflicts=usb-msc-gadget.service usb-ncm-gadget.service usb-ncm-msc-gadget.service
 Description=USB Composite Gadget Setup (NCM Ethernet + Mass Storage + MTP)
 After=sys-kernel-config.mount local-fs.target
 Requires=sys-kernel-config.mount

--- a/overlays/configs/update-motd.d/00-flipperone
+++ b/overlays/configs/update-motd.d/00-flipperone
@@ -4,8 +4,15 @@
 board=$(cat /sys/firmware/devicetree/base/compatible | tr '\0' '\n' | awk -F, '$2 != "rk3576" { print $2; exit }')
 board=${board:-rk3576}
 
-# CPU serial from device tree, falls back to systemd machine-id for non-DT boards
-serial=$(tr -d '\0' < /sys/firmware/devicetree/base/serial-number 2>/dev/null || cat /etc/machine-id)
+# The serial from the device tree if the bootloader put it there, else recomputed from the OTP
+# the way U-Boot computes serial#, else the machine-id. Tested rather than read blind: the
+# redirection fails before the 2>/dev/null beside it can catch anything.
+if [ -r /sys/firmware/devicetree/base/serial-number ]; then
+    serial=$(tr -d '\0' < /sys/firmware/devicetree/base/serial-number)
+else
+    serial=$(/usr/local/bin/rk3576_cpu_serial.sh 2>/dev/null | awk -F'\t' '/^serial:/{print $2}')
+fi
+serial=${serial:-$(cat /etc/machine-id)}
 
 . /etc/os-release
 

--- a/overlays/usr/local/bin/set-hostname-and-banner.sh
+++ b/overlays/usr/local/bin/set-hostname-and-banner.sh
@@ -12,8 +12,15 @@ board=${board:-rk3576}
 device=$(echo "$compat" | sed 's/-rev-.*//; s/,//')
 device=${device:-rk3576}
 
-# CPU serial from device tree, falls back to systemd machine-id for non-DT boards
-serial=$(tr -d '\0' < /sys/firmware/devicetree/base/serial-number 2>/dev/null || rk3576_cpu_serial.sh | tail -n1 | awk -F"\t" '{ print $2; }' || cat /etc/machine-id)
+# The serial from the device tree if the bootloader put it there, else recomputed from the OTP
+# the way U-Boot computes serial#, else the machine-id. Tested rather than read blind: the
+# redirection fails before the 2>/dev/null beside it can catch anything.
+if [ -r /sys/firmware/devicetree/base/serial-number ]; then
+    serial=$(tr -d '\0' < /sys/firmware/devicetree/base/serial-number)
+else
+    serial=$(/usr/local/bin/rk3576_cpu_serial.sh 2>/dev/null | awk -F'\t' '/^serial:/{print $2}')
+fi
+serial=${serial:-$(cat /etc/machine-id)}
 
 # First 3 bytes (6 hex chars) of serial for hostname
 serial_prefix=$(printf '%.6s' "$serial")

--- a/overlays/usr/local/bin/usb-gadget-setup.sh
+++ b/overlays/usr/local/bin/usb-gadget-setup.sh
@@ -34,9 +34,16 @@ DEV_ADDR="02:1A:7D:01:02:03"
 HOST_ADDR="02:1A:7D:01:02:04"
 USB_VID="0x37C1"
 MANUFACTURER="Flipper FZCO"
-# CPU serial from DT (set by U-Boot), else recomputed from OTP, else machine-id. Mass-storage
-# BOT needs >=12 uppercase hex, so strip to hex and uppercase (harmless for other functions).
-SERIAL=$(tr -d '\0' < /sys/firmware/devicetree/base/serial-number 2>/dev/null || rk3576_cpu_serial.sh 2>/dev/null | tail -n1 | awk -F"\t" '{ print $2; }' || cat /etc/machine-id 2>/dev/null)
+# The serial from the device tree if the bootloader put it there, else recomputed from the OTP
+# the way U-Boot computes serial#, else the machine-id. Tested rather than read blind: the
+# redirection fails before the 2>/dev/null beside it can catch anything.
+# Mass-storage BOT wants >=12 uppercase hex, hence the strip below; harmless for the rest.
+if [ -r /sys/firmware/devicetree/base/serial-number ]; then
+    SERIAL=$(tr -d '\0' < /sys/firmware/devicetree/base/serial-number)
+else
+    SERIAL=$(/usr/local/bin/rk3576_cpu_serial.sh 2>/dev/null | awk -F'\t' '/^serial:/{print $2}')
+fi
+SERIAL=${SERIAL:-$(cat /etc/machine-id)}
 SERIAL=$(printf '%s' "$SERIAL" | tr -cd '0-9A-Fa-f' | tr 'a-f' 'A-F')
 : "${SERIAL:=0123456789AB}"
 


### PR DESCRIPTION
Three things that only misbehave once a profile is switched into with `soft-reboot`, which is what `boot-profile` does from a running system.

PID1 applies presets when it detects a first boot, which every profile here is, since the image ships no machine-id. On a cold boot it reaches that point with `/etc` still read-only and gives up (`Failed to populate /etc with preset unit settings, ignoring: Read-only file system`), so nothing happened and nothing showed. A soft-reboot restarts userspace with the root already writable, the pass lands, and its default is to enable anything carrying an `[Install]` section.

**Only one USB gadget configuration.** Three units carried `[Install]`, so all three came up enabled and started ten milliseconds apart, racing for the one UDC. Plain NCM won and that boot had no mass storage and no MTP. The two that must not autostart lose their `[Install]`, as `usb-msc-gadget` never had one, and all four now conflict with each other so switching by hand replaces the running gadget rather than colliding with it.

**The SoC serial.** The callers ask the device tree for a `serial-number` node this board does not have, in a way that prints a shell error before the fallback runs, and the login banner then fell back to `/etc/machine-id`, printing a random per-profile value as the CPU serial one line under a hostname built from the real one. They now test for the node and share one fallback chain.

Concurrent reads of the OTP used to return silently wrong serials here (6 of 20 correct across ten concurrent pairs). That is fixed in the driver by `nvmem: rockchip-otp: Serialize reads`, measured 20/20 and 15/15 correct on a kernel carrying it, so nothing in userspace guards it and nothing needs to.

**The identity setup.** `DefaultDependencies=no` left `set-hostname-and-banner.service` with nothing conflicting it with shutdown, so a soft-reboot never stopped it and PID1 carried its "already ran" state into the new root. A profile switched into that way kept the default hostname, no avahi record of its own, and a banner naming the profile it came from. Its retry condition could not catch that either, since it asked whether a banner existed and the image ships one; it now asks the hostname, which the image ships as `debian-rk3576` and this unit is the only thing that replaces.

Verified on a Flipper One, on a freshly flashed image and across a real profile switch:

- one gadget enabled and active, three static, USB serial `45D2488F32838ACD` rather than the `0123456789AB` placeholder;
- 16/16 correct serials under concurrent reads, against 6/20 before, and a read costs 25ms;
- a pivot into a never-booted profile now logs `Starting set-hostname-and-banner.service` in the new root and comes up named, with a banner carrying its own profile;
- an already-named root skips the unit (`no trigger condition checks were met`).
