### PR TITLE
Boot flipctl on the panel instead of the flipctl2 prototype

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,18 +46,26 @@ RUN apt-get install -y \
     pipx \
     pigz \
     zstd \
-    cargo \
     golang \
     libglib2.0-dev \
     libostree-dev \
     fakemachine
 
+# Rust for zeekstd below and for flipctl during the ospack build, from backports rather
+# than trixie: slint 1.17.1 wants rustc 1.92 and trixie has 1.85. libstd-rust-dev:arm64
+# is the standard library for the target, which is what lets build-flipctl.sh cross-build
+# on an amd64 builder.
+RUN echo 'deb http://deb.debian.org/debian trixie-backports main' \
+        > /etc/apt/sources.list.d/backports.list \
+    && apt-get update \
+    && apt-get install -y -t trixie-backports \
+        cargo rustc libstd-rust-dev libstd-rust-dev:arm64
+
 RUN go install -v github.com/go-debos/debos/cmd/debos@latest
 
 RUN install -m 755 ~/go/bin/debos /usr/local/bin
 
-# v0.4.5-cli+ needs Rust 1.91 (Path::with_added_extension); see https://github.com/rorosen/zeekstd/tags
-RUN cargo install --git https://github.com/rorosen/zeekstd.git --tag v0.4.4-cli zeekstd_cli
+RUN cargo install --git https://github.com/rorosen/zeekstd.git zeekstd_cli
 
 RUN install -m 755 ~/.cargo/bin/zeekstd /usr/local/bin/
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Build scripts (run them in order):
 | `build-images.sh` | Assembles complete GPT disk images for all boards you've built bootloaders for; calls `build-rootfs-img.sh` to build the root filesystem if it doesn't exist yet |
 | `build-rootfs-img.sh` | Runs debos on `debian-rk3576-img.yaml` to install the kernel into a partitioned image, then zeekstd-compresses it |
 | `build-ospack.sh` | Runs mmdebstrap via debos (`debian-rk3576-ospack.yaml`) to build the Debian root filesystem tarball |
+| `build-flipctl.sh` | Builds flipctl (the panel UI) from `flipctl-slint` for arm64, natively or cross, and stages `/usr/bin/flipctl` plus its apps and assets for the ospack; called by `build-ospack.sh` |
 
 Other directories:
 
@@ -121,16 +122,24 @@ sudo apt install git build-essential crossbuild-essential-arm64 bc bison flex \
 For assembling disk images — debos, bmaptool, and zeekstd all need to be installed from source:
 
 ```bash
-sudo apt install golang pipx pigz cargo parted fdisk btrfs-progs mmdebstrap \
+sudo apt install golang pipx pigz parted fdisk btrfs-progs mmdebstrap \
     systemd-resolved systemd-container qemu-user-binfmt \
     libglib2.0-dev libostree-dev fakemachine
+
+# Rust, for zeekstd below and for flipctl during the ospack build. From backports:
+# flipctl needs rustc 1.92 (slint) and trixie has 1.85. libstd-rust-dev:arm64 is the
+# standard library for the target, needed to cross-build flipctl on an amd64 host.
+echo 'deb http://deb.debian.org/debian trixie-backports main' \
+    | sudo tee /etc/apt/sources.list.d/backports.list
+sudo apt update
+sudo apt install -t trixie-backports cargo rustc libstd-rust-dev libstd-rust-dev:arm64
 
 # debos
 go install -v github.com/go-debos/debos/cmd/debos@latest
 sudo install -m 755 ~/go/bin/debos /usr/local/bin
 
-# zeekstd (requires Rust; v0.4.5+ needs Rust 1.91 — stick to v0.4.4-cli for now)
-cargo install --git https://github.com/rorosen/zeekstd.git --tag v0.4.4-cli zeekstd_cli
+# zeekstd
+cargo install --git https://github.com/rorosen/zeekstd.git zeekstd_cli
 sudo install -m 755 ~/.cargo/bin/zeekstd /usr/local/bin/
 
 # bmaptool (Flipper fork)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Build scripts (run them in order):
 | `build-images.sh` | Assembles complete GPT disk images for all boards you've built bootloaders for; calls `build-rootfs-img.sh` to build the root filesystem if it doesn't exist yet |
 | `build-rootfs-img.sh` | Runs debos on `debian-rk3576-img.yaml` to install the kernel into a partitioned image, then zeekstd-compresses it |
 | `build-ospack.sh` | Runs mmdebstrap via debos (`debian-rk3576-ospack.yaml`) to build the Debian root filesystem tarball |
-| `build-flipctl.sh` | Builds flipctl (the panel UI) from `flipctl-slint` for arm64, natively or cross, and stages `/usr/bin/flipctl` plus its apps and assets for the ospack; called by `build-ospack.sh` |
+| `build-flipctl.sh` | Builds flipctl (the panel UI) from `flipctl-slint` for arm64, natively or cross, and stages `/usr/bin/flipctl`, its apps and assets, and the crates an app is compiled against, for the ospack; the apps in `FLIPCTL_APPS` ship built, the rest as sources; called by `build-ospack.sh` |
 
 Other directories:
 

--- a/build-flipctl.sh
+++ b/build-flipctl.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# build-flipctl.sh [<checkout> [<staging dir>]] - build flipctl for the image.
+#
+# Stages the tree the ospack overlays onto /usr: bin/flipctl, its apps and remote-view
+# assets under share/flipctl, and the unit the repository ships as
+# lib/systemd/system/flipctl.service. Called by build-ospack.sh once it has the checkout.
+#
+# Native on an arm64 builder, cross anywhere else. Nothing here links a C library (EGL
+# and GBM are dlopened, wayland-client uses its Rust backend, slint renders in software),
+# so a cross build needs the aarch64 std and a linker and nothing else.
+: "${FLIPCTL_DIR:=src/flipctl}"
+: "${FLIPCTL_OUT:=prebuilt/flipctl}"
+: "${FLIPCTL_FEATURES:=device,slint,remote,wayland,gpu}"
+
+set -e
+
+SRC=${1:-$FLIPCTL_DIR}
+OUT=${2:-$FLIPCTL_OUT}
+PKG=flipctl
+
+[ -d "$SRC" ] || { echo "build-flipctl: no checkout at $SRC" >&2; exit 1; }
+command -v cargo >/dev/null || { echo "build-flipctl: cargo not found" >&2; exit 1; }
+
+# slint 1.17.1 sets the floor. An older cargo gets there through the resolver instead,
+# a hundred lines of "requires rustc" for every crate in the graph, so check it here.
+MSRV=92
+ver=$(cargo --version 2>/dev/null | awk '{print $2}')
+case "$ver" in 1.*) minor=${ver#1.}; minor=${minor%%.*} ;; *) minor=0 ;; esac
+case "$minor" in ''|*[!0-9]*) minor=0 ;; esac
+if [ "$minor" -lt "$MSRV" ]; then
+        echo "build-flipctl: cargo ${ver:-unknown} is too old; flipctl needs 1.$MSRV (slint 1.17.1)" >&2
+        echo "build-flipctl: on Debian, apt-get install -t trixie-backports cargo rustc libstd-rust-dev" >&2
+        exit 1
+fi
+
+# Cross unless the builder is already arm64. Passing --target on an arm64 builder too
+# would flatten this, at the cost of cargo building every proc macro and build script for
+# the host separately from the target, which is the slint compiler twice over.
+TARGET_ARG=()
+if [ "$(uname -m)" != aarch64 ]; then
+        TARGET=aarch64-unknown-linux-gnu
+        TARGET_ARG=(--target "$TARGET")
+        export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+        # a toolchain carries the host's standard library and no other, and without the
+        # target's the build fails a long way in with "can't find crate for std"
+        [ -d "$(rustc --print sysroot)/lib/rustlib/$TARGET" ] || {
+                echo "build-flipctl: no std for $TARGET" >&2
+                echo "build-flipctl: on Debian, apt-get install libstd-rust-dev:arm64" >&2
+                exit 1
+        }
+fi
+
+# cargo install builds and places the binary in one step, and --root makes the staging
+# tree what it installs into: bin/flipctl, already the install layout, so the ospack
+# overlays it and moves nothing afterwards. --no-track keeps the .crates.toml it would
+# leave beside it out of a tree that becomes /usr, --target-dir keeps the build cache in
+# the checkout rather than the temporary directory cargo install builds in and throws
+# away, and --locked pins what cargo build would: this is the one cargo command that
+# ignores a lockfile unless told not to.
+rm -rf "$OUT"
+cargo install --path "$SRC/bin/$PKG" --root "$OUT" --no-track --locked \
+        --target-dir "$SRC/target" "${TARGET_ARG[@]}" --features "$FLIPCTL_FEATURES"
+mkdir -p "$OUT/share/flipctl"
+# An app's build output and its uv environment sit inside the app's own directory, and
+# a checkout kept between runs (KEEP_SRC) still has them.
+tar -C "$SRC" -cf - --exclude=.venv --exclude=target --exclude=__pycache__ apps \
+        | tar -C "$OUT/share/flipctl" -xf -
+mkdir -p "$OUT/share/flipctl/assets"
+cp -a "$SRC/crates/flipper-ui/assets/remote" "$OUT/share/flipctl/assets/remote"
+# The unit ships from the repository, not a copy in overlays/, so a deploy from a
+# checkout restarts the same unit the image boots.
+install -D -m 644 "$SRC/systemd/flipctl.service" "$OUT/lib/systemd/system/flipctl.service"
+
+echo "build-flipctl: staged $(du -sh "$OUT" | cut -f1) in $OUT"

--- a/build-flipctl.sh
+++ b/build-flipctl.sh
@@ -2,8 +2,9 @@
 # build-flipctl.sh [<checkout> [<staging dir>]] - build flipctl for the image.
 #
 # Stages the tree the ospack overlays onto /usr: bin/flipctl, its apps and remote-view
-# assets under share/flipctl, and the unit the repository ships as
-# lib/systemd/system/flipctl.service. Called by build-ospack.sh once it has the checkout.
+# assets under share/flipctl, the framework an app is compiled against, and the unit the
+# repository ships as lib/systemd/system/flipctl.service. Called by build-ospack.sh once
+# it has the checkout.
 #
 # Native on an arm64 builder, cross anywhere else. Nothing here links a C library (EGL
 # and GBM are dlopened, wayland-client uses its Rust backend, slint renders in software),
@@ -11,6 +12,9 @@
 : "${FLIPCTL_DIR:=src/flipctl}"
 : "${FLIPCTL_OUT:=prebuilt/flipctl}"
 : "${FLIPCTL_FEATURES:=device,slint,remote,wayland,gpu}"
+# The apps that ship already built. Every other app ships as sources and is compiled on
+# the device the first time somebody opens it, which is what the staged crates allow.
+: "${FLIPCTL_APPS:=radio}"
 
 set -e
 
@@ -65,8 +69,44 @@ mkdir -p "$OUT/share/flipctl"
 # a checkout kept between runs (KEEP_SRC) still has them.
 tar -C "$SRC" -cf - --exclude=.venv --exclude=target --exclude=__pycache__ apps \
         | tar -C "$OUT/share/flipctl" -xf -
+# The framework an app is compiled against, and the fonts, which are the part that is easy
+# to miss: flipper-ui's ui/fonts.slint imports the three TTFs as ../../../third_party, from
+# outside crates/ entirely. An app's manifest asks for ../../crates/flipctl-app, resolved
+# against where the app sits, so this layout mirrors the repository for exactly those paths.
+# Without them a build on the device stops at cargo's first step, unable to read
+# share/flipctl/crates/flipctl-app/Cargo.toml.
+#
+# tests/ is dropped because nothing an app builds reads it; examples/ cannot be, even though
+# nothing reads those either, because flipper-ui declares three of them by name and cargo
+# refuses to parse a manifest whose declared target has no file.
+tar -C "$SRC" -cf - --exclude=target --exclude=tests \
+        crates/flipctl-app crates/flipper-ui crates/flipper-tokens \
+        third_party/flipctl-fonts \
+        | tar -C "$OUT/share/flipctl" -xf -
 mkdir -p "$OUT/share/flipctl/assets"
 cp -a "$SRC/crates/flipper-ui/assets/remote" "$OUT/share/flipctl/assets/remote"
+
+# The apps that ship built, installed after their sources are staged: flipctl offers a
+# rebuild when the binary is older than the newest source beside it, and this order makes
+# the binary the later file.
+#
+# Built rather than installed, unlike flipctl above: cargo install only ever writes
+# <root>/bin/<name>, and app.toml names the binary as ./target/release/<name>, which is
+# where the app's own build leaves it and so where flipctl looks for it, here as much as
+# on the device. Each app directory is a workspace root of its own, carrying an empty
+# [workspace] table, so the build runs there rather than at the checkout.
+for _app in $FLIPCTL_APPS; do
+        _dir=$SRC/apps/$_app
+        [ -f "$_dir/Cargo.toml" ] || { echo "build-flipctl: apps/$_app carries no crate" >&2; exit 1; }
+        # app.toml names what it runs: wayland = "./target/release/radio-app".
+        _bin=$(sed -n 's|^wayland[[:space:]]*=[[:space:]]*"\./target/release/\([^"]*\)".*|\1|p' \
+                "$_dir/app.toml" | head -n1)
+        [ -n "$_bin" ] || { echo "build-flipctl: apps/$_app names no binary to build" >&2; exit 1; }
+        (cd "$_dir" && cargo build --release "${TARGET_ARG[@]}")
+        install -D -m 755 "$_dir/target${TARGET:+/$TARGET}/release/$_bin" \
+                "$OUT/share/flipctl/apps/$_app/target/release/$_bin"
+        echo "build-flipctl: staged apps/$_app built as $_bin"
+done
 # The unit ships from the repository, not a copy in overlays/, so a deploy from a
 # checkout restarts the same unit the image boots.
 install -D -m 644 "$SRC/systemd/flipctl.service" "$OUT/lib/systemd/system/flipctl.service"

--- a/build-ospack.sh
+++ b/build-ospack.sh
@@ -9,6 +9,10 @@
 : "${BTRFS_TOOLS_OUT:=prebuilt/btrfs-tools}"
 : "${BTRFS_TOOLS_GIT:=https://github.com/flipperdevices/flipperos-btrfs-tools.git}"
 : "${BTRFS_TOOLS_BRANCH:=dev}"
+: "${FLIPCTL_DIR:=src/flipctl}"
+: "${FLIPCTL_OUT:=prebuilt/flipctl}"
+: "${FLIPCTL_GIT:=https://github.com/flipperdevices/flipctl-slint.git}"
+: "${FLIPCTL_BRANCH:=dev}"
 
 set -e
 
@@ -19,7 +23,7 @@ set -e
 [ -n "${GIT_INFO}" ] || GIT_INFO="${GIT_BRANCH}@${GIT_HASH}: ${GIT_MSG}"
 GIT_INFO=$(echo "$GIT_INFO" | tr -dc '[:alnum:][:space:]')
 
-stage_repo() { # $1 = checkout  $2 = url  $3 = branch  $4 = staging dir
+fetch_repo() { # $1 = checkout  $2 = url  $3 = branch
         case "${KEEP_SRC}" in
                 update)
                         if [ -d "$1" ]; then
@@ -34,6 +38,10 @@ stage_repo() { # $1 = checkout  $2 = url  $3 = branch  $4 = staging dir
         esac
 
         [ -d "$1" ] || git clone --depth 1 -b "$3" "$2" "$1"
+}
+
+stage_repo() { # $1 = checkout  $2 = url  $3 = branch  $4 = staging dir
+        fetch_repo "$1" "$2" "$3"
 
         rm -rf "$4"
         mkdir -p "$4"
@@ -44,6 +52,11 @@ mkdir -p "$IMG_OUT"
 
 stage_repo "${TESTS_DIR}" "${TESTS_GIT}" "${TESTS_BRANCH}" "${TESTS_OUT}"
 stage_repo "${BTRFS_TOOLS_DIR}" "${BTRFS_TOOLS_GIT}" "${BTRFS_TOOLS_BRANCH}" "${BTRFS_TOOLS_OUT}"
+
+# flipctl is compiled rather than copied: fetch only, and build-flipctl.sh writes the
+# install tree the ospack overlays.
+fetch_repo "${FLIPCTL_DIR}" "${FLIPCTL_GIT}" "${FLIPCTL_BRANCH}"
+./build-flipctl.sh "${FLIPCTL_DIR}" "${FLIPCTL_OUT}"
 
 if [ -c /dev/kvm -a -w /dev/kvm ]; then
         # Have virtualization support, can use fakemachine (default, fast, safe)
@@ -58,4 +71,4 @@ else
         DEBOS="sudo debos --disable-fakemachine"
 fi
 
-$DEBOS --artifactdir="$IMG_OUT" -t gitinfo:"$GIT_INFO" -t testsdir:"${TESTS_OUT}" -t btrfstoolsdir:"${BTRFS_TOOLS_OUT}" debian-rk3576-ospack.yaml
+$DEBOS --artifactdir="$IMG_OUT" -t gitinfo:"$GIT_INFO" -t testsdir:"${TESTS_OUT}" -t btrfstoolsdir:"${BTRFS_TOOLS_OUT}" -t flipctldir:"${FLIPCTL_OUT}" debian-rk3576-ospack.yaml

--- a/debian-rk3576-img.yaml
+++ b/debian-rk3576-img.yaml
@@ -160,8 +160,15 @@ actions:
       . /usr/lib/flipper-bls.sh
       CONF_ROOT=/etc/kernel; PROFILES=/etc/kernel/flipper-profiles; ENTRIES=/boot/loader/entries
       MACHINE_ID=""; DEVICETREE=""; DEVICETREE_ENTRY=""; BOOT_MNT="/"
-      mkdir -p "$ENTRIES"; SORT_KEY="$(os_sort_key)"
-      for _k in /boot/vmlinuz-*; do
+      # The order lives in each entry's sort-key, so the os-release half is set once here and the
+      # rest per entry: os_sort_key alone is just "debian", and an image whose entries all carry
+      # the same key has no order at all -- what boots is then decided by whichever file was
+      # touched last. entry_sort_key composes the band, the autoboot digit and the rank.
+      mkdir -p "$ENTRIES"; SORT_KEY_OS="$(os_sort_key)"
+      # Oldest kernel first, so the newest is written last and emit_entry's demote_others leaves
+      # it as each profile's chosen one. Glob order would decide this alphabetically, which puts
+      # a 10.x kernel before a 6.x one.
+      for _k in $(ls /boot/vmlinuz-* 2>/dev/null | sort -V); do
         [ -e "$_k" ] || continue
         KERNEL_VERSION="${_k#/boot/vmlinuz-}"; resolve_kconfig
         set_dtb_dirs; discover_devicetreedir; compute_base_opts
@@ -169,7 +176,9 @@ actions:
         while IFS='|' read -r tok suf extra gate dtbos legend; do
           tok="$(echo "$tok" | tr -d '[:space:]')"; case "$tok" in ''|\#*) continue ;; esac
           extra="$(trim "$extra")"; _sv="$(subvol_of "$extra")"
-          ENTRY_TOKEN="$(make_token "$(printf '%03d' "$((900 - _i * 100))")" "$_sv")"
+          _nn="$(printf '%03d' "$((900 - _i * 100))")"
+          ENTRY_TOKEN="$(make_token "$_nn" "$_sv")"
+          SORT_KEY="$(entry_sort_key "$_sv" "$_nn")"
           remove_entries "$_sv" "$KERNEL_VERSION"; resolve_kernel_paths "$_sv"
           emit_entry "$(trim "$suf")" "$extra" "$(trim "$gate")" "$(trim "$dtbos")"
           _i=$((_i + 1))

--- a/debian-rk3576-ospack.yaml
+++ b/debian-rk3576-ospack.yaml
@@ -253,6 +253,16 @@ actions:
     source: {{ $btrfstoolsdir }}/hooks
     destination: /etc/kernel/install.d
 
+  # flipper-bless-boot.service, which removes a boot entry's counter once the boot it came
+  # from reached boot-complete.target. Without it every boot is counted and none is ever
+  # blessed, so three boots take every entry to 'bad'. It is wired to start, and Debian's
+  # own systemd-boot-check-no-failures.service is wired to gate the target, by the symlinks
+  # in overlays/configs/systemd.
+  - action: overlay
+    description: Overlay the btrfs boot-assessment unit
+    source: {{ $btrfstoolsdir }}/systemd
+    destination: /usr/lib/systemd/system
+
   - action: overlay
     description: Overlay flipctl, its apps and its remote-view assets
     source: {{ $flipctldir }}

--- a/debian-rk3576-ospack.yaml
+++ b/debian-rk3576-ospack.yaml
@@ -264,9 +264,35 @@ actions:
     destination: /usr/lib/systemd/system
 
   - action: overlay
-    description: Overlay flipctl, its apps and its remote-view assets
+    description: Overlay flipctl, its apps, its remote-view assets and the app framework
     source: {{ $flipctldir }}
     destination: /usr
+
+  # An app is built in its own directory, so it has to belong to whoever flipctl runs as
+  # or cargo cannot create its target/ and stops with "Permission denied (os error 13)".
+  # Read out of the unit rather than named here, because this image has two candidates: a
+  # dedicated flipctl system user, and the `user` the unit actually asks for. Only the
+  # apps change hands; the framework under share/flipctl/crates stays root-owned, since a
+  # build reads it and never writes to it.
+  - action: run
+    description: Let the user flipctl runs as rebuild an app in place
+    chroot: true
+    command: |
+      unit=/usr/lib/systemd/system/flipctl.service
+      u=$(sed -n 's/^User=//p' "$unit" | head -n1)
+      g=$(sed -n 's/^Group=//p' "$unit" | head -n1)
+      chown -R "${u:-user}:${g:-${u:-user}}" /usr/share/flipctl/apps
+
+  # flipctl offers to rebuild an app whose binary is older than a source beside it, and the
+  # order build-flipctl.sh installs them in does not survive the copy into the image: every
+  # file lands with the time it was written here, and radio's ui/app.slint came out 4ms after
+  # its binary, which was enough to ask. Stamping the binaries last says what was meant.
+  - action: run
+    description: Make each shipped app binary newer than its sources
+    chroot: true
+    command: |
+      find /usr/share/flipctl/apps -mindepth 4 -maxdepth 4 -path '*/target/release/*' \
+        -type f -exec touch {} +
 
   - action: overlay
     description: Overlay our usr/share files

--- a/debian-rk3576-ospack.yaml
+++ b/debian-rk3576-ospack.yaml
@@ -3,6 +3,7 @@
 {{ $gitinfo := or .gitinfo "unknown" }}
 {{ $testsdir := or .testsdir "prebuilt/tests" }}
 {{ $btrfstoolsdir := or .btrfstoolsdir "prebuilt/btrfs-tools" }}
+{{ $flipctldir := or .flipctldir "prebuilt/flipctl" }}
 
 architecture: arm64
 
@@ -111,6 +112,7 @@ actions:
       - strace
       - stress-ng
       - sudo
+      - sway
       - sysstat
       - systemd
       - systemd-repart
@@ -250,6 +252,11 @@ actions:
     description: Overlay the btrfs kernel-install plugins
     source: {{ $btrfstoolsdir }}/hooks
     destination: /etc/kernel/install.d
+
+  - action: overlay
+    description: Overlay flipctl, its apps and its remote-view assets
+    source: {{ $flipctldir }}
+    destination: /usr
 
   - action: overlay
     description: Overlay our usr/share files

--- a/overlays/configs/systemd/system/boot-complete.target.requires/systemd-boot-check-no-failures.service
+++ b/overlays/configs/systemd/system/boot-complete.target.requires/systemd-boot-check-no-failures.service
@@ -1,0 +1,1 @@
+/usr/lib/systemd/system/systemd-boot-check-no-failures.service

--- a/overlays/configs/systemd/system/cog-seat1.service
+++ b/overlays/configs/systemd/system/cog-seat1.service
@@ -1,3 +1,7 @@
+# No [Install] on purpose: flipctl owns the panel, and this browser is started only when
+# flipctl's Testing row hands it over. A unit with an [Install] section is enabled by the
+# preset pass systemd makes on a profile's first boot, which is how the prototype came back
+# on its own and took the panel from what the image actually boots.
 [Unit]
 Description=Cog browser on dedicated seat1
 After=systemd-logind.service fake-flipctl-node-server.service
@@ -51,6 +55,3 @@ ExecStart=/usr/bin/cog -P drm -O renderer=gles http://localhost:8899
 
 Restart=on-failure
 RestartSec=2
-
-[Install]
-WantedBy=multi-user.target

--- a/overlays/configs/systemd/system/multi-user.target.wants/cog-seat1.service
+++ b/overlays/configs/systemd/system/multi-user.target.wants/cog-seat1.service
@@ -1,1 +1,0 @@
-/etc/systemd/system/cog-seat1.service

--- a/overlays/configs/systemd/system/multi-user.target.wants/fake-flipctl-node-server.service
+++ b/overlays/configs/systemd/system/multi-user.target.wants/fake-flipctl-node-server.service
@@ -1,1 +1,0 @@
-/flipperone-testing/fake-flipctl/systemd/fake-flipctl-node-server.service

--- a/overlays/configs/systemd/system/multi-user.target.wants/flipctl.service
+++ b/overlays/configs/systemd/system/multi-user.target.wants/flipctl.service
@@ -1,0 +1,1 @@
+/usr/lib/systemd/system/flipctl.service

--- a/overlays/configs/systemd/system/multi-user.target.wants/flipper-bless-boot.service
+++ b/overlays/configs/systemd/system/multi-user.target.wants/flipper-bless-boot.service
@@ -1,0 +1,1 @@
+/usr/lib/systemd/system/flipper-bless-boot.service

--- a/overlays/configs/systemd/system/umtp-responder.service
+++ b/overlays/configs/systemd/system/umtp-responder.service
@@ -1,0 +1,1 @@
+/dev/null

--- a/overlays/configs/umtprd/umtprd.conf
+++ b/overlays/configs/umtprd/umtprd.conf
@@ -6,7 +6,12 @@
 loop_on_disconnect 1
 
 # storage "PATH" "NAME" "options"
-storage "/home" "Home" "rw"
+#
+# The home of the user umtprd runs as (MTP_USER in usb-gadget-setup.sh, "user"), so what a
+# host copies in belongs to the session that has to open it afterwards. Serving /home instead
+# put transfers in a directory only root could write, and left them root-owned inside that
+# user's own home. The two have to name the same person.
+storage "/home/user" "Home" "rw"
 
 manufacturer "Flipper FZCO"
 product "Flipper One Composite Device"

--- a/overlays/usr/local/bin/usb-gadget-setup.sh
+++ b/overlays/usr/local/bin/usb-gadget-setup.sh
@@ -11,7 +11,7 @@
 #   --acm                       add a USB serial (CDC-ACM) function (kernel)
 #   --storage                   add a mass_storage LUN (implied by a medium option)
 #   --mtp                       add MTP over FunctionFS (needs the umtprd daemon; serves
-#                               the paths in /etc/umtprd/umtprd.conf, /home by default)
+#                               the paths in /etc/umtprd/umtprd.conf, as $MTP_USER)
 #   --name NAME                 configfs gadget name (default: flipper)
 #   --pid HEX / --product STR   idProduct / iProduct (idVendor fixed 0x37C1, serial auto)
 #   --sda|--sdcard|--iso FILE   storage medium
@@ -27,6 +27,8 @@ MSC_FUNC=mass_storage.0
 MTP_FUNC=ffs.mtp
 FFS_INST=mtp
 FFS_DIR=/dev/ffs-mtp
+# Whose files a host transfer creates. Overridable for an image that has no such user.
+: "${MTP_USER:=user}"
 INQUIRY="Flipper Storage"
 SDA=/dev/sda
 SDCARD="${SDCARD:-/dev/mmcblk0}"
@@ -144,9 +146,26 @@ load_medium()
 # UDC is bound; the endpoints ep1/ep2 appear once it has. Storage paths come from its conf.
 mtp_up()
 {
+    # umtprd runs as the desktop user, not as root, because everything the host copies in is
+    # created by it: as root a transfer left root-owned files in that user's own home, mode 0700,
+    # which their session then could not open. umtprd has no way to drop privilege itself (its
+    # config knows storage, umask and the USB keys, and nothing about a user), so the descriptors
+    # it has to write are handed over instead: FunctionFS takes uid/gid mount options, and without
+    # them the endpoints are root:root 0600.
+    _uid="$(id -u "$MTP_USER" 2>/dev/null)"; _gid="$(id -g "$MTP_USER" 2>/dev/null)"
     mkdir -p "$FFS_DIR"
-    grep -q " $FFS_DIR functionfs " /proc/mounts || mount -t functionfs "$FFS_INST" "$FFS_DIR"
-    if ! pgrep -x umtprd >/dev/null 2>&1; then umtprd & fi
+    if [ -n "$_uid" ] && [ -n "$_gid" ]; then
+        grep -q " $FFS_DIR functionfs " /proc/mounts \
+            || mount -t functionfs -o "uid=$_uid,gid=$_gid" "$FFS_INST" "$FFS_DIR"
+        if ! pgrep -x umtprd >/dev/null 2>&1; then
+            setpriv --reuid "$_uid" --regid "$_gid" --init-groups umtprd &
+        fi
+    else
+        # No such user: serve as root rather than not at all, and say why the files will be root's.
+        echo "usb-gadget-setup: no user '$MTP_USER', umtprd runs as root and its files will be too" >&2
+        grep -q " $FFS_DIR functionfs " /proc/mounts || mount -t functionfs "$FFS_INST" "$FFS_DIR"
+        if ! pgrep -x umtprd >/dev/null 2>&1; then umtprd & fi
+    fi
     i=0
     while [ ! -e "$FFS_DIR/ep1" ] && [ "$i" -lt 50 ]; do sleep 0.1; i=$((i + 1)); done
     [ -e "$FFS_DIR/ep1" ] || { echo "umtprd did not bring up FunctionFS" >&2; return 1; }
@@ -252,7 +271,7 @@ Usage: $0 {start|stop|restart|eject} [options]
   --ncm|--ecm|--eem|--rndis   add a USB Ethernet function
   --acm                       add a USB serial (CDC-ACM) function
   --storage                   add a mass_storage LUN (implied by a medium option)
-  --mtp                       add MTP over FunctionFS (needs umtprd; serves /etc/umtprd/umtprd.conf)
+  --mtp                       add MTP over FunctionFS (umtprd as $MTP_USER; serves /etc/umtprd/umtprd.conf)
   --name NAME                 configfs gadget name (default: flipper)
   --pid HEX                   idProduct (idVendor fixed 0x37C1, serial auto from CPU)
   --product STR               iProduct string


### PR DESCRIPTION
Stacked on #168.

flipctl becomes what the image boots on the panel, in place of the flipctl2 prototype.

`build-flipctl.sh` builds it from `flipctl-slint` for arm64, natively on an arm64 builder and cross anywhere else, and stages the tree the ospack overlays onto `/usr`: `/usr/bin/flipctl`, its apps and remote-view assets under `/usr/share/flipctl`, and the unit the repository itself ships, so the image and a deploy from a checkout restart the same one. Nothing there links a C library (EGL and GBM are dlopened, wayland-client uses its Rust backend, slint renders in software), so a cross build needs only the aarch64 std and a linker.

slint 1.17.1 wants rustc 1.92 where trixie has 1.85, so the container and the documented prerequisites take cargo from `trixie-backports` with the arm64 std beside it, and the build stops with one line when either is missing rather than a hundred lines into the resolver.

`sway` is the only package added on flipctl's behalf, being the compositor it hosts apps in. What an app itself needs is left out: each manifest names its packages and flipctl offers to install them when that app is opened.

The prototype is unenabled rather than removed, so the Testing row can still hand the panel over: the two wants symlinks go, and `cog-seat1` loses its `[Install]`. The other half of that, the node server's own `[Install]`, is in flipperone-testing `02f67fd`, which the ospack already stages from `dev`.

Verified on a Flipper One from a freshly flashed image: flipctl active on the panel and serving its remote view, `cog-seat1` and `fake-flipctl-node-server` both `loaded` but not autostarted, and the Testing row able to hand the panel over.

Note for whoever builds this: the ospack step must actually rebuild, `UPDATE_OSPACK=1` or a clean `out/images/`, or an existing `debian-ospack.tar.zst` is reused and none of this lands in the image.
