### PR TITLE
Ship a Rust toolchain, so apps can be built on the device

### DIFF
--- a/debian-rk3576-ospack.yaml
+++ b/debian-rk3576-ospack.yaml
@@ -213,6 +213,19 @@ actions:
     source: overlays/configs
     destination: /etc
 
+  # The Rust toolchain, so a flipctl framework app can be built on the device. Must follow the
+  # overlay above, which puts trixie-backports in the sources. Each name says its suite because
+  # backports is priority 100: cargo alone fails, since apt then refuses to take rustc from
+  # there. libstd-rust-1.94 and libllvm21 follow on their own, which keeps a version out of
+  # this file. 445MB installed.
+  - action: apt
+    description: Install the Rust toolchain from trixie-backports
+    recommends: false
+    packages:
+      - cargo/trixie-backports
+      - rustc/trixie-backports
+      - libstd-rust-dev/trixie-backports
+
   - action: overlay
     description: Overlay Broadcom WiFi/BT firmware files
     source: overlays/firmware

--- a/overlays/configs/apt/sources.list.d/trixie-backports.list
+++ b/overlays/configs/apt/sources.list.d/trixie-backports.list
@@ -1,0 +1,1 @@
+deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian trixie-backports main


### PR DESCRIPTION
`docs/apps.md` in flipctl says an app is built in its own directory and flipctl runs cargo for it, but no shipped profile had a cargo to run — it was installed by hand on whichever device someone happened to be working on.

### Where it comes from

trixie's cargo is 1.85 and slint 1.17, which every flipctl framework app is built with, needs 1.92. So it comes from **trixie-backports**, added the same way the flipper archive is: a file in `overlays/configs/apt/sources.list.d/`, picked up by the existing "Overlay our config defaults" action.

The source is **left enabled**, so what was installed from there can still be updated from there. Nothing drifts in on its own — backports carries priority 100, so a package comes from that suite only when asked for by name, and no pin file raises it.

### Why three packages and not one

`cargo/trixie-backports` alone is refused. apt selects cargo 1.94 and then will not take `rustc` from a suite at that priority:

```
cargo : Depends: rustc (= 1.94.1+dfsg1-1~bpo13+3) but 1.85.0+dfsg3-1 is to be installed
E: Unable to satisfy dependencies. Reached two conflicting decisions.
```

So every hop that has an alternative in trixie names its suite. The two that have none, `libstd-rust-1.94` and `libllvm21`, follow from `libstd-rust-dev` on their own — which keeps a version out of the manifest. `libllvm21` is also why none of this can come from trixie at all: rustc needs LLVM 21 and trixie main has no such package.

Uses debos's native `apt` action rather than a `run` command, so it is update → install → **clean**. Nothing else clears the apt cache in the ospack, so a hand-rolled version would have left ~88MB of debs in every profile.

### Cost

**445MB installed**, measured on a device: `libstd-rust-dev` 172MB, `libllvm21` 127MB, `libstd-rust-1.94` 83MB, `libz3-4` 26MB, `cargo` 23MB, `rustc` 12MB. Two thirds of that is the standard library a build compiles against and the LLVM backend rustc will not run without, so neither can be trimmed. It goes into every profile, including ones that will never build an app.

For scale, building one app costs more than the toolchain does: ~493MB of crate cache in `~/.cargo` and ~1.7GB for a single app's `target/`, both reclaimable.

### Verified before writing it

On a Flipper One with rustup uninstalled, `~/.cargo` deleted and `target/` removed, so only these packages were present: `apps/sysmon` builds from where it is installed into a working 13MB binary, with `slint-build` and `slint-macros` going through Debian's `+dfsg1` rustc against system LLVM 21 without complaint.

The package resolution above was checked in a clean `debian:trixie` container, not inferred.

Standalone, not stacked on #171.