### PR TITLE
cmdline: drop audit=0

### DIFF
--- a/debian-rk3576-img.yaml
+++ b/debian-rk3576-img.yaml
@@ -3,7 +3,7 @@
 {{ $kerneldir  := or .kerneldir  "prebuilt/linux" }}
 # cmdline: shared facts + policy only. The BLS generator adds the per-entry rootflags=subvol=
 # and the serial consoles (console=ttyS0/ttyS4/fbcon or ttyFIQ0, per kernel config).
-{{ $cmdline    := or .cmdline    "audit=0 console=tty1" }}
+{{ $cmdline    := or .cmdline    "console=tty1" }}
 {{ $fslabel    := or .fslabel    "flipperos" }}
 # btrfsopts: fs-wide mount options. ssd is FORCED (loopback/eMMC isn't reliably
 # detected as non-rotational).
@@ -82,7 +82,7 @@ actions:
 
   # debos writes the standard root line into /etc/fstab and root=UUID into the cmdline.
   # The root subvolume is NOT baked here: /etc/kernel/cmdline carries only shared facts +
-  # policy (root=UUID, audit, console=tty1). The BLS generator supplies rootflags=subvol=
+  # policy (root=UUID, console=tty1). The BLS generator supplies rootflags=subvol=
   # per entry (from flipper-profiles at build, from findmnt at runtime). Deploy into @Minimal_stock.
   - action: filesystem-deploy
     append-kernel-cmdline: {{ $cmdline }}


### PR DESCRIPTION
Removes `audit=0` from the image's kernel command line default.

The BLS generator writes this default into every entry's `options=`, so entries created from here on carry no `audit=0`. Entries already on a device keep it until they are rewritten, which happens on the next kernel install or profile creation.

It was the only `audit=0` in the repo.
