### PR TITLE
Network LEDs follow their ports

### DIFF
--- a/overlays/configs/udev/rules.d/99-network-leds.rules
+++ b/overlays/configs/udev/rules.d/99-network-leds.rules
@@ -1,0 +1,36 @@
+# The network LEDs follow their ports: each lights with its interface's carrier,
+# through the kernel's netdev trigger. Link only, because the trigger also blinks
+# on traffic and a busy link then spends half its time dark.
+#
+# Driven from the interface, not the LED: the wireless name comes from the
+# adapter's MAC, so %k on its own event is the only place to read it, and
+# [subsystem/sysname] is what writes another device's attribute. move as well as
+# add, since a wireless interface is renamed just after it appears.
+#
+# IMPORT loads the trigger module where it stands; RUN would be deferred past the
+# writes below. Colour before trigger, which otherwise has nothing to light.
+SUBSYSTEM=="net", ACTION=="add|move", IMPORT{builtin}="kmod load ledtrig-netdev"
+
+SUBSYSTEM=="net", ACTION=="add|move", KERNEL=="end0", \
+  ATTR{[leds/flipper-one:rgb:eth0]multi_intensity}="120 255 0", \
+  ATTR{[leds/flipper-one:rgb:eth0]trigger}="netdev", \
+  ATTR{[leds/flipper-one:rgb:eth0]device_name}="end0", \
+  ATTR{[leds/flipper-one:rgb:eth0]link}="1", \
+  ATTR{[leds/flipper-one:rgb:eth0]tx}="0", \
+  ATTR{[leds/flipper-one:rgb:eth0]rx}="0"
+
+SUBSYSTEM=="net", ACTION=="add|move", KERNEL=="end1", \
+  ATTR{[leds/flipper-one:rgb:eth1]multi_intensity}="120 255 0", \
+  ATTR{[leds/flipper-one:rgb:eth1]trigger}="netdev", \
+  ATTR{[leds/flipper-one:rgb:eth1]device_name}="end1", \
+  ATTR{[leds/flipper-one:rgb:eth1]link}="1", \
+  ATTR{[leds/flipper-one:rgb:eth1]tx}="0", \
+  ATTR{[leds/flipper-one:rgb:eth1]rx}="0"
+
+SUBSYSTEM=="net", ACTION=="add|move", ENV{DEVTYPE}=="wlan", \
+  ATTR{[leds/flipper-one:rgb:wifi]multi_intensity}="0 255 255", \
+  ATTR{[leds/flipper-one:rgb:wifi]trigger}="netdev", \
+  ATTR{[leds/flipper-one:rgb:wifi]device_name}="%k", \
+  ATTR{[leds/flipper-one:rgb:wifi]link}="1", \
+  ATTR{[leds/flipper-one:rgb:wifi]tx}="0", \
+  ATTR{[leds/flipper-one:rgb:wifi]rx}="0"

--- a/overlays/profile-kde/etc/xdg/kded5rc
+++ b/overlays/profile-kde/etc/xdg/kded5rc
@@ -1,0 +1,8 @@
+# kameleon walks /sys/class/leds at session start and repaints every RGB LED with
+# the desktop accent colour, which fights the network LEDs that
+# 99-network-leds.rules binds to their ports.
+#
+# The file is kded5rc, not kded6rc: kded6 kept the KF5 name for its own config,
+# so a kded6rc is read by nothing.
+[Module-kameleon]
+autoload=false


### PR DESCRIPTION
The three RGB LEDs along the top of the device did nothing. They now follow the
network ports: eth0 and eth1 with the two ethernet ports, wifi with whatever
wireless interface is present, lit while the port has carrier and dark when it
does not.

## How

`99-network-leds.rules` binds each LED to its interface through the kernel's
netdev trigger, so carrier is followed inside the kernel. Nothing runs in
userspace, nothing polls, and there is no daemon to keep alive.

Link only, no traffic blink: the trigger will blink on tx/rx, but at its default
interval a busy link spends half its time dark and reads as a broken LED rather
than as activity.

Colours are the ones the prototype settled on against the hardware, `120 255 0`
for ethernet and `0 255 255` for wifi. Channel order is R G B end to end.

## Why the rules are shaped that way

- Driven from the interface rather than the LED, because the wireless
  interface's name comes from the adapter's MAC and cannot be written down here.
  `%k` on its own event is the only place to read it, and
  `ATTR{[subsystem/sysname]...}` is what lets one device's event write another
  device's attribute. That removed the helper script this would otherwise need.
- `move` as well as `add`, since a wireless interface is renamed just after it
  appears and the rename carries the name it keeps.
- `IMPORT` and not `RUN` to load `ledtrig-netdev`: the trigger is a module, and
  `RUN` is deferred to the end of the event, arriving after the writes it exists
  to enable.
- Colour before trigger, which otherwise has nothing to light.

## The second commit

KDE ships a kded module called kameleon which walks `/sys/class/leds` at session
start and repaints every RGB LED with the desktop accent colour through a
privileged helper. Both ethernet LEDs turned Breeze blue a few seconds into every
boot because of it. It is now kept from starting.

The file is `kded5rc` and not `kded6rc`: kded6 kept the KF5 name for its own
configuration, so a `kded6rc` is read by nothing. The module's own
`DeviceLedsAccentColored` key in kdeglobals is not a lever on Plasma 6.3 either,
since the only file on the system containing that key is the module binary and
setting it by hand changed nothing. Upstream turns the behaviour off by default
in 6.7.3, well ahead of the 6.3.5 this image installs as a dependency of
kde-standard.

## Verified

On a Flipper One, from a cold boot with nothing run by hand: all three LEDs bound
with the right colours including the wifi adapter's generated name, the trigger
module loaded by the rule itself, and no kameleon activity in the journal at all.
Lighting one pure channel per LED confirmed red, green and blue on the glass.

This needs MCU firmware that acts on the LED colour registers. An older build
accepted the writes, left the correct values in the registers, and lit nothing.
