### PR TITLE
Compress images with zstd

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ sudo apt install git build-essential crossbuild-essential-arm64 bc bison flex \
 For assembling disk images — debos, bmaptool, and zeekstd all need to be installed from source:
 
 ```bash
-sudo apt install golang pipx pigz parted fdisk btrfs-progs mmdebstrap \
+sudo apt install golang pipx pigz zstd parted fdisk btrfs-progs mmdebstrap \
     systemd-resolved systemd-container qemu-user-binfmt \
     libglib2.0-dev libostree-dev fakemachine
 
@@ -233,7 +233,7 @@ Once you have bootloader outputs in `prebuilt/u-boot/` and kernel outputs in `pr
 ./build-images.sh
 ```
 
-This produces compressed images for each board whose bootloader is present. The kernel and root filesystem are shared; only the bootloader partition differs per board. Output files: `out/debian-<sector-size>-<board>-<timestamp>.img.gz` with a matching `.bmap` file, for both 512-byte and 4096-byte sector variants. When run inside the container, images go to `out/images/` instead (the container sets `IMG_OUT=/artifacts/images`).
+This produces compressed images for each board whose bootloader is present. The kernel and root filesystem are shared; only the bootloader partition differs per board. Output files: `out/debian-<sector-size>-<board>-<timestamp>.img.zst` with a matching `.bmap` file, for both 512-byte and 4096-byte sector variants. When run inside the container, images go to `out/images/` instead (the container sets `IMG_OUT=/artifacts/images`). Set `ZSTD_LEVEL` to trade build time against image size; it defaults to 12.
 
 Don't run the mainline and BSP kernel scripts in parallel against the same output directory — both write to the same `prebuilt/linux/` path and the final packaging step will fail. Run one, then the other (or set separate `LINUX_OUT` paths).
 
@@ -262,7 +262,7 @@ If you have a built-in SD card slot, you may use that, and the card will likely 
 If you are using a USB card reader, the card will likely show up as `/dev/sdX` (where `X` is a lowercase letter). In this latter case you need to be triple careful, because any SATA or SCSI storage devices will also share the same naming scheme, and if you have important data on any other `/dev/sdX` device (such as your main system disk being called something like `/dev/sda`) you might end up inadvertently overwriting it if you pick the wrong one in the below commands, losing all your data. Please be careful.
 
 ```bash
-sudo bmaptool copy out/debian-512-<your_board>-*.img.gz /dev/sdX
+sudo bmaptool copy out/debian-512-<your_board>-*.img.zst /dev/sdX
 ```
 
 #### Flashing to eMMC using a USB cable and Maskrom
@@ -286,7 +286,7 @@ Your device is now ready for programming over the Rockusb protocol.
 # Boot the board in USB upload mode
 sudo rockusb download-boot prebuilt/u-boot/<your_board>/rk3576_loader_v*.bin
 
-sudo rockusb write-bmap out/debian-512-<your_board>-*.img.gz
+sudo rockusb write-bmap out/debian-512-<your_board>-*.img.zst
 ```
 
 Container builds place bootloaders in `out/u-boot/<board>/` and disk images in `out/images/` instead.
@@ -300,7 +300,7 @@ Switch Radxa 4D into Maskrom mode, then:
 ```bash
 rockusb list
 rockusb download-boot prebuilt/u-boot/rock-4d/rk3576_loader_v*.bin
-rockusb write-bmap out/debian-512-rock-4d-*.img.gz
+rockusb write-bmap out/debian-512-rock-4d-*.img.zst
 rockusb reset-device
 ```
 

--- a/build-images.sh
+++ b/build-images.sh
@@ -2,6 +2,7 @@
 : "${UBOOT_OUT:=prebuilt/u-boot}"
 : "${IMG_OUT:=out}"
 : "${IMGSIZE:=6GiB}"
+: "${ZSTD_LEVEL:=12}"
 
 set -e
 
@@ -38,7 +39,7 @@ compress_image() {
 	echo "$i: creating a block map"
 	bmaptool create -o "$IMG_OUT"/debian-"$s"-"$i"-"$BUILD_ID".img.bmap "$img" || return 1
 	echo "$i: compressing the final image"
-	pigz -p "$PIGZ_THREADS" -c "$img" > "$IMG_OUT"/debian-"$s"-"$i"-"$BUILD_ID".img.gz || return 1
+	zstd -f -T"$ZSTD_THREADS" -"$ZSTD_LEVEL" -o "$IMG_OUT"/debian-"$s"-"$i"-"$BUILD_ID".img.zst "$img" || return 1
 }
 
 build_board_image() {
@@ -84,19 +85,19 @@ EOF
 	SPACE_JOBS=$(( AVAIL * 9 / 10 / IMG_COST ))
 
 	# Run as many jobs at once as both the free space and the cores allow,
-	# and give each one an even slice of the cores for pigz (rounded up so we
+	# and give each one an even slice of the cores for zstd (rounded up so we
 	# don't leave cores idle).
 	MAX_PAR=$(( NJOBS < NPROC ? NJOBS : NPROC ))
 	[ "$SPACE_JOBS" -lt "$MAX_PAR" ] && MAX_PAR=$SPACE_JOBS
 	[ "$MAX_PAR" -lt 1 ] && MAX_PAR=1
-	PIGZ_THREADS=$(( (NPROC + MAX_PAR - 1) / MAX_PAR ))
+	ZSTD_THREADS=$(( (NPROC + MAX_PAR - 1) / MAX_PAR ))
 
 	echo " - $IMG_COST bytes per image, $AVAIL free: room for $SPACE_JOBS"
-	echo " - Building $NJOBS images, $MAX_PAR at a time, $PIGZ_THREADS pigz threads each"
+	echo " - Building $NJOBS images, $MAX_PAR at a time, $ZSTD_THREADS zstd threads each"
 
 	# The base is only read from here on, so it can compress alongside the
 	# boards -- it just has to outlive them. Dispatch it first, since its
-	# pigz pass is the longest single job, and it needs no extra space.
+	# zstd pass is the longest single job, and it needs no extra space.
 	{ compress_image nobootloader "$base" || echo nobootloader >> "$TMPDIR"/failed-"$s"; } &
 
 	for i in $BOARDS; do


### PR DESCRIPTION
`build-images.sh` now compresses the board and nobootloader images with zstd instead of pigz, so the published artifacts are `.img.zst`.

The compression level is explicit at 12 rather than left at zstd's default of 3, and can be overridden through `ZSTD_LEVEL`. Armbian picks the same level for SBC images once four cores are available; 19 would additionally pull in `--long=27`, which raises the window requirement on the decompressor side.

`bmaptool` reads zstd directly by shelling out to the `zstd` binary, which the Dockerfile already installs, and the `.bmap` is still created from the uncompressed image. A round trip was verified: the compressed image plus the uncompressed image's bmap through `bmaptool copy` gives a byte-identical result.

Parallel jobs still get an even slice of the cores, now through `zstd -T` rather than `pigz -p`.

`build-installer-img.sh` is deliberately untouched and still produces `.img.gz`, so `pigz` stays in the Dockerfile and in the README package list.

One thing to be aware of for the README's Maskrom instructions: `rockusb write-bmap` handles `.zst` only as of collabora/rockchiprs commit e1721f7a, which landed after the `rockusb-v0.4.0` tag, so no published release carries it yet. Flashing these images over Maskrom needs rockusb built from `main` until the next release.
